### PR TITLE
[codex] Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/canonical_physics_evidence_watch.yml
+++ b/.github/workflows/canonical_physics_evidence_watch.yml
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload evidence-watch artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: canonical-physics-evidence-watch
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
         working-directory: app
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -54,9 +54,9 @@ jobs:
         working-directory: app
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -70,7 +70,7 @@ jobs:
       - name: Validate Composition Views
         run: npm run validate:composition-views
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install Python dependencies
@@ -99,9 +99,9 @@ jobs:
         working-directory: backend
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 25

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -9,8 +9,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: pip install -r requirements-docs.txt


### PR DESCRIPTION
## Summary

- update GitHub workflow actions to Node 24 compatible major versions
- move `actions/checkout`, `actions/setup-node`, `actions/setup-python`, and `actions/upload-artifact` references to v6
- move `actions/setup-java` to v5, its Node 24 compatible major
- keep existing runtime versions, cache settings, artifact paths, and job structure unchanged

## Why

GitHub Actions reported Node.js 20 deprecation annotations on the main CI run and on follow-up PR checks. The updated action majors remove those warnings before GitHub forces JavaScript actions to Node 24.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/docs_deploy.yml .github/workflows/canonical_physics_evidence_watch.yml`