### PR TITLE
Add canonical chemistry evidence watch

### DIFF
--- a/.github/workflows/canonical_chemistry_evidence_watch.yml
+++ b/.github/workflows/canonical_chemistry_evidence_watch.yml
@@ -1,0 +1,65 @@
+name: Canonical Chemistry Evidence Watch
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '47 5 * * *'
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/canonical_chemistry_evidence_watch.yml'
+      - 'scripts/canonical_chemistry_evidence_watch.py'
+      - 'scripts/run_canonical_chemistry_evidence_watch.sh'
+      - 'curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json'
+      - 'curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json'
+      - 'curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json'
+      - 'curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json'
+      - 'curricula/DE/Gymnasium/input/**/source-extraction/*CHEM*.source-extraction.json'
+      - 'curricula/DE/Gymnasium/input/**/source-json/*CHEMIE*.json.snapshot'
+      - 'curricula/DE/Gymnasium/mapping/**/*canonical_chemistry*.json'
+      - 'curricula/DE/Gymnasium/composition-views/chemie/*.view.json'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/canonical_chemistry_evidence_watch.yml'
+      - 'scripts/canonical_chemistry_evidence_watch.py'
+      - 'scripts/run_canonical_chemistry_evidence_watch.sh'
+      - 'curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json'
+      - 'curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json'
+      - 'curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json'
+      - 'curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json'
+      - 'curricula/DE/Gymnasium/input/**/source-extraction/*CHEM*.source-extraction.json'
+      - 'curricula/DE/Gymnasium/input/**/source-json/*CHEMIE*.json.snapshot'
+      - 'curricula/DE/Gymnasium/mapping/**/*canonical_chemistry*.json'
+      - 'curricula/DE/Gymnasium/composition-views/chemie/*.view.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chemistry-evidence-watch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Use Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Run canonical chemistry evidence watch
+        run: ./scripts/run_canonical_chemistry_evidence_watch.sh
+
+      - name: Upload evidence-watch artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: canonical-chemistry-evidence-watch
+          path: |
+            docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md
+            docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md

--- a/curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json
+++ b/curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json
@@ -1,0 +1,832 @@
+{
+  "version": 1,
+  "updatedAt": "2026-05-12T00:49:35Z",
+  "manifestVersion": 1,
+  "manifestUpdatedAt": "2026-05-12T00:00:00Z",
+  "mode": "maintenance_evidence_watch",
+  "watchedFileCount": 137,
+  "watchedFiles": [
+    {
+      "relativePath": "curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json",
+      "exists": true,
+      "sha256": "caf2314e8166665c7c58614526ec2853312906c793ece402748b6e0b82347eff",
+      "lastModifiedUtc": "2026-05-11T23:54:30Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-bb-gk.view.json",
+      "exists": true,
+      "sha256": "41be795c3ab03af8c6eb3efcd14ea12e3580120919de7c15f37bba99b032319b",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-bb-lk.view.json",
+      "exists": true,
+      "sha256": "7b2b8027aa32910758a3f5c9758becaeaaf85e25054cada92c8e0216bb20ee91",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-be-gk.view.json",
+      "exists": true,
+      "sha256": "00de28f46bfc24ae2d30569635e2f5700a4f30b5ee9bc493c55c1e5a481625cb",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-be-lk.view.json",
+      "exists": true,
+      "sha256": "a6f8659c8e2c2173c3a97f2652e2cc066a657576d98e2a952ef163b69a86c7ce",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-bw-gk.view.json",
+      "exists": true,
+      "sha256": "47f10802b3ac80218affe4d46ce080c9bb77d8fba773c78e416a1d74f716d921",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-bw-lk.view.json",
+      "exists": true,
+      "sha256": "885046fffccbe8daf1a26b373c3b61d71629057fd0275517304615495c18222a",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-chemistry-gk.view.json",
+      "exists": true,
+      "sha256": "e0f2a559877fe31244854ee8b295a86491307537497824269398a4546ff3334e",
+      "lastModifiedUtc": "2026-05-11T02:26:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-chemistry-lk.view.json",
+      "exists": true,
+      "sha256": "98138ba639d2926cc9e4fe379a1bd6c1c72eef25b8e23712d1a33ae9102bd9c3",
+      "lastModifiedUtc": "2026-05-11T02:26:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-seki-chemistry.view.json",
+      "exists": true,
+      "sha256": "0c3b1a0d01f7b5aa962df6f29d21d1f341df31e3b7be60544e6053b30ded8e18",
+      "lastModifiedUtc": "2026-05-11T02:26:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-sekii-chemistry-gk.view.json",
+      "exists": true,
+      "sha256": "557120ec43bac903cf3c072bc563401b0f266a5ba407acab8687fb4cdd94648d",
+      "lastModifiedUtc": "2026-05-11T02:26:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-sekii-chemistry-lk.view.json",
+      "exists": true,
+      "sha256": "19ef4ce9f43c4c7130158eafd0f758dc37e32f5dccabf5ee03ab07c21b4669e6",
+      "lastModifiedUtc": "2026-05-11T02:26:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-hb-gk.view.json",
+      "exists": true,
+      "sha256": "f852417ae6cb629632f4584dccff8de46b1b4e8ac9a1bad480791079968254f5",
+      "lastModifiedUtc": "2026-05-11T21:37:33Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-hb-lk.view.json",
+      "exists": true,
+      "sha256": "a409d1898512ca56c6c033bab69de853fa6352585e6dfb9912cacad93c34937f",
+      "lastModifiedUtc": "2026-05-11T21:37:33Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-he-gk.view.json",
+      "exists": true,
+      "sha256": "16e324150bda691df6cbc677099991de9324dba9e7f77b3bcfb4c4ee5272c95f",
+      "lastModifiedUtc": "2026-05-11T02:26:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-he-lk.view.json",
+      "exists": true,
+      "sha256": "56f97a454a762bf9d8aaacb65f108410c2dd782bd915ead1a17f35f0a7e55087",
+      "lastModifiedUtc": "2026-05-11T02:26:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-he-sekii-gk.view.json",
+      "exists": true,
+      "sha256": "db629d8607b747977fd32fedaa394682e54a73261af16007ca091f3e8ef1d18d",
+      "lastModifiedUtc": "2026-05-11T02:26:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-he-sekii-lk.view.json",
+      "exists": true,
+      "sha256": "155cc907ea9b1565e35dc32f19701ccc81e6b28232c13b2db36982bb9a99048c",
+      "lastModifiedUtc": "2026-05-11T02:26:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-hh-gk.view.json",
+      "exists": true,
+      "sha256": "874d29a69f22ac120d96b82ab0fc5dd94350fd12061f0c6741b8bbd06b40a9ca",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-hh-lk.view.json",
+      "exists": true,
+      "sha256": "64ff5cd26a28fa2e148b69e2227adb0fc13640e2e20cf4c7b41fa72e405473ce",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-mv-gk.view.json",
+      "exists": true,
+      "sha256": "5e8bfdfd7352f40c7b6603c185d8779f8337289ba528b12360106b78e8256431",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-mv-lk.view.json",
+      "exists": true,
+      "sha256": "54d36dab1c095aebddf3b9a84be3e80faf5b3b2f162ea79c9c28c493c662194b",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-ni-gk.view.json",
+      "exists": true,
+      "sha256": "748cd07e689caf5e3208bd566b4f00685c155fcdea200895c29ed0b22a862026",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-ni-lk.view.json",
+      "exists": true,
+      "sha256": "3545b804797b11320c9ff32b6bcc019c5d529a77e9c6bf4b3321f622076ff3f5",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-nw-gk.view.json",
+      "exists": true,
+      "sha256": "a30203b5f35864f3a934090e887201aa98a985d0ab617c8c2c1d99f466cd91e2",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-nw-lk.view.json",
+      "exists": true,
+      "sha256": "bc353105f01509eca5a6eca429905d03e4a14d004fd46b7979bac4541c9d101c",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-rp-gk.view.json",
+      "exists": true,
+      "sha256": "65367171f96afc04394949b904eb74a6637b39c05ce9bceb32316a3a78936b8e",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-rp-lk.view.json",
+      "exists": true,
+      "sha256": "13cb9341d58b471e5e8468bed749a61ce46fb2d44b4a52f6b3e20e0cd144d397",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-sh-gk.view.json",
+      "exists": true,
+      "sha256": "43375c07fdd6b447e967f58ac686d33a52cc4eba1e959b9763c650c9b650e073",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-sh-lk.view.json",
+      "exists": true,
+      "sha256": "139989e1b39fe2b5062aaa0655d63e3e60ff5eb12f771b250260d395afd0dfb9",
+      "lastModifiedUtc": "2026-05-11T15:47:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-sl-gk.view.json",
+      "exists": true,
+      "sha256": "5f56d33f12a201d2f946797be2bd853b89976262a38ab23d3244aa17c360c024",
+      "lastModifiedUtc": "2026-05-11T20:17:00Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-sl-lk.view.json",
+      "exists": true,
+      "sha256": "08601112c3f60bf7474a2470338306f5d1fae8ffd74ebabf846e10a86642bb14",
+      "lastModifiedUtc": "2026-05-11T20:17:00Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-sn-gk.view.json",
+      "exists": true,
+      "sha256": "3c93f60756928560f46c8135a5f1b09ede3e4547d2ff586bdb74dff029f00633",
+      "lastModifiedUtc": "2026-05-11T20:17:00Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-sn-lk.view.json",
+      "exists": true,
+      "sha256": "e91e08acf2804a1798667835ae302a6fb667a4f3cde03a7868fbf887c0a2c393",
+      "lastModifiedUtc": "2026-05-11T20:17:00Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-st-gk.view.json",
+      "exists": true,
+      "sha256": "cf066a700e012fd6805a80237b9d8ca28e462edabb33a10a6e15a01fc0d9ae9d",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-st-lk.view.json",
+      "exists": true,
+      "sha256": "e81c9fb0d4981fe905da6b755aa51f1f143f9c620e5b6e659394d5dc9ad06d2a",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-th-gk.view.json",
+      "exists": true,
+      "sha256": "45b193b3ebdc653a53e8e3b458aa005a6b0fe95372df6ec838df86770fce9132",
+      "lastModifiedUtc": "2026-05-11T20:17:00Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-th-lk.view.json",
+      "exists": true,
+      "sha256": "5e68c712aabf27751bb4400d3ee59ec8cbbaa7e1e0f33583a953f7e264075250",
+      "lastModifiedUtc": "2026-05-11T20:17:00Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/BB/lower-secondary/source-extraction/DE_BB_CHEMIE_SEKI_RLP_2015.source-extraction.json",
+      "exists": true,
+      "sha256": "a9dea05e32e5f7a91898902ca2f8b62f0c197994a6d225a5441cb1c4ddda2e15",
+      "lastModifiedUtc": "2026-05-11T21:05:05Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/BB/upper-secondary/source-extraction/DE_BB_CHEMIE_SEKII_RLP_GOST_2022.source-extraction.json",
+      "exists": true,
+      "sha256": "54b5654929ab7bd6b665858e5dd35b17de74b5a5052675681e50b7fa687df44a",
+      "lastModifiedUtc": "2026-05-11T11:44:26Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/BE/lower-secondary/source-extraction/DE_BE_CHEMIE_SEKI_RLP_2015.source-extraction.json",
+      "exists": true,
+      "sha256": "b849370b2284fb7e7c8ee8a288f3fd27b302899b1b142ed40aa8dd653cd25ccb",
+      "lastModifiedUtc": "2026-05-11T21:05:05Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/BE/upper-secondary/source-extraction/DE_BE_CHEMIE_SEKII_RLP_GOST_2022.source-extraction.json",
+      "exists": true,
+      "sha256": "7d8b939ed2bf55c22a7deb51577ce329c8bf9a27fc30d5394db4cf4e79a5ff97",
+      "lastModifiedUtc": "2026-05-11T11:44:26Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/BW/lower-secondary/source-extraction/DE_BW_CHEMIE_SEKI_BP2016_V2.source-extraction.json",
+      "exists": true,
+      "sha256": "cee17e8a8d7f4d39d1464d71b8ae71cf850b14532d4934fa75e6c61fee645028",
+      "lastModifiedUtc": "2026-05-11T10:13:38Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/BW/upper-secondary/source-extraction/DE_BW_CHEMIE_SEKII_BP2016_V2.source-extraction.json",
+      "exists": true,
+      "sha256": "25d68fdafcb73d71a5a22c281e3d1dec329578f55884392f9ae1460fba157daa",
+      "lastModifiedUtc": "2026-05-11T10:13:39Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/BY/gymnasium/source-extraction/DE_BY_BIOLOGISCH_CHEMISCHES_PRAKTIKUM_GYMNASIUM_LEHRPLANPLUS.source-extraction.json",
+      "exists": true,
+      "sha256": "2343c4fd2e45b590c75885b912ceb4bedcd4fc2aaa6718239936f1dd0a7e7e71",
+      "lastModifiedUtc": "2026-05-11T02:37:43Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/BY/gymnasium/source-extraction/DE_BY_CHEMIE_GYMNASIUM_LEHRPLANPLUS.source-extraction.json",
+      "exists": true,
+      "sha256": "d8f6b835b00729a089452e7f2b58f1b5b94a870d3dd8096b558755dc49cd5056",
+      "lastModifiedUtc": "2026-05-11T11:07:28Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/HB/lower-secondary/source-extraction/DE_HB_CHEMIE_SEKI_BILDUNGSPLAN_2006_2022.source-extraction.json",
+      "exists": true,
+      "sha256": "adc4f0446eedd4fd3a4ae2e95a8a61d7200f8078ad3dc1db14fccd6c442ff2fc",
+      "lastModifiedUtc": "2026-05-11T21:31:56Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/HB/upper-secondary/source-extraction/DE_HB_CHEMIE_SEKII_GYO_2022.source-extraction.json",
+      "exists": true,
+      "sha256": "3a928a968081b9dd32f7783656a2ee05ac5980de8bdaa5629e9a642a1d310269",
+      "lastModifiedUtc": "2026-05-11T21:37:33Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/HE/lower-secondary/source-extraction/DE_HE_CHEMIE_SEKI_G9.source-extraction.json",
+      "exists": true,
+      "sha256": "3b2584499c028e889dd65a70baa47a2d0816da8bdf15c8bf7e5fb28706513202",
+      "lastModifiedUtc": "2026-05-11T01:55:09Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/HE/lower-secondary/source-json/DE_HES_S_GYM_1_CHEMIE.de.json.snapshot",
+      "exists": true,
+      "sha256": "a11a261b9166e04fe92bbf1f9b4c311c1c475e08c00b13386701c5277d35130f",
+      "lastModifiedUtc": "2026-03-15T08:08:49Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/HE/upper-secondary/source-extraction/DE_HE_CHEMIE_SEKII_KC2024.source-extraction.json",
+      "exists": true,
+      "sha256": "7ee435bcdf39386733a7ab44c3c02ce2b5ec30745c02d04c98531e182e9b2904",
+      "lastModifiedUtc": "2026-05-11T02:16:59Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/HE/upper-secondary/source-json/DE_HES_S_GYM_2_CHEMIE.de.json.snapshot",
+      "exists": true,
+      "sha256": "425d4d3a0b2da9834b1ae08d305fc70df7cb0eb4f65a46cc4e0ed731bbd31de2",
+      "lastModifiedUtc": "2026-03-15T06:54:57Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/HH/lower-secondary/source-extraction/DE_HH_CHEMIE_SEKI_BILDUNGSPLAN.source-extraction.json",
+      "exists": true,
+      "sha256": "ec073c3aa3ceb7f35e7b2a95d927697e5e1595bde479f06c6ebea3a6c04f029e",
+      "lastModifiedUtc": "2026-05-11T15:05:28Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/HH/upper-secondary/source-extraction/DE_HH_CHEMIE_SEKII_BILDUNGSPLAN_2022.source-extraction.json",
+      "exists": true,
+      "sha256": "c8754796e80255a6ab7b7a205a02724535ed4d6aae53fba2cb1ee898e4784311",
+      "lastModifiedUtc": "2026-05-11T15:05:28Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/MV/lower-secondary/source-extraction/DE_MV_CHEMIE_SEKI_RAHMENPLAN_2021.source-extraction.json",
+      "exists": true,
+      "sha256": "f8fe7064ab5d0b5f35bf6b05dced7d97ddbf7d1e4295719aeb52b4a16dfe78af",
+      "lastModifiedUtc": "2026-05-11T17:42:32Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/MV/upper-secondary/source-extraction/DE_MV_CHEMIE_SEKII_RAHMENPLAN_ERPROBUNGSFASSUNG_2022.source-extraction.json",
+      "exists": true,
+      "sha256": "1781d86d4e930cac1047bb648070794e473253bfdef210d6bdca57ceae5d53a5",
+      "lastModifiedUtc": "2026-05-11T17:42:32Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/NI/lower-secondary/source-extraction/DE_NI_CHEMIE_SEKI_KC2015.source-extraction.json",
+      "exists": true,
+      "sha256": "3c82664df56ae345a768e8f527cb8a2f33bcb514b0ba9dbb37fd7e6d20858faf",
+      "lastModifiedUtc": "2026-05-11T13:06:03Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/NI/upper-secondary/source-extraction/DE_NI_CHEMIE_SEKII_KC2022.source-extraction.json",
+      "exists": true,
+      "sha256": "426a4c65902be8dbfc733e77b6aa2bbd720820ffbede5a7915c2e8593ff6a326",
+      "lastModifiedUtc": "2026-05-11T12:14:36Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/NW/lower-secondary/source-extraction/DE_NW_CHEMIE_SEKI_KLP2019.source-extraction.json",
+      "exists": true,
+      "sha256": "6594569b7ed7e9a65678fe911bc166e52417422cef4f1b9c30835e84902d7466",
+      "lastModifiedUtc": "2026-05-11T13:44:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/NW/upper-secondary/source-extraction/DE_NW_CHEMIE_SEKII_KLP2022.source-extraction.json",
+      "exists": true,
+      "sha256": "63af0e8396ff4787364042f0892bf2e471aeb1fb3c7517c35b834c904de3ee8f",
+      "lastModifiedUtc": "2026-05-11T13:44:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/RP/lower-secondary/source-extraction/DE_RP_CHEMIE_SEKI_RAHMENLEHRPLAN_2014.source-extraction.json",
+      "exists": true,
+      "sha256": "aef5035f5da0970fe5a4465f9633aed8c7b0815ec667a36dfcb77dfa1ae23701",
+      "lastModifiedUtc": "2026-05-11T18:19:20Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/RP/upper-secondary/source-extraction/DE_RP_CHEMIE_SEKII_MSS_2022.source-extraction.json",
+      "exists": true,
+      "sha256": "a9397191898cdc79a359f4aca711dc8696380e8fa7f249d5b45cdf665b8166d4",
+      "lastModifiedUtc": "2026-05-11T18:19:20Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/SH/lower-secondary/source-extraction/DE_SH_CHEMIE_SEKI_FACHANFORDERUNGEN_2022.source-extraction.json",
+      "exists": true,
+      "sha256": "125612af7681d03545e40712d25a8d71bf7bb806e7f8d289eab5c89636a10393",
+      "lastModifiedUtc": "2026-05-11T14:26:04Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/SH/upper-secondary/source-extraction/DE_SH_CHEMIE_SEKII_FACHANFORDERUNGEN_2022.source-extraction.json",
+      "exists": true,
+      "sha256": "27026debce0a6b0366b3d6950fb569b6383c95150abdacaef892eca1cc6dc95e",
+      "lastModifiedUtc": "2026-05-11T14:26:04Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/SL/lower-secondary/source-extraction/DE_SL_CHEMIE_SEKI_GYM9_2024_2025.source-extraction.json",
+      "exists": true,
+      "sha256": "04fd855508778e19305e23e722d4fab0e2b7f618b31f6dcd5e6f7462b47c72dc",
+      "lastModifiedUtc": "2026-05-11T19:49:02Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/SL/upper-secondary/source-extraction/DE_SL_CHEMIE_SEKII_GOS_2023_2025.source-extraction.json",
+      "exists": true,
+      "sha256": "b3cf9781a8981fde1bb06b08bcf4294c543d239f9308325f7791551812b20cb7",
+      "lastModifiedUtc": "2026-05-11T19:49:02Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/SN/lower-secondary/source-extraction/DE_SN_CHEMIE_SEKI_LEHRPLAN_GYMNASIUM_2025.source-extraction.json",
+      "exists": true,
+      "sha256": "1de76385d9d7c76783fa312da71262a9e69a4b36dac71986e838f3150db42e76",
+      "lastModifiedUtc": "2026-05-11T20:03:06Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/SN/upper-secondary/source-extraction/DE_SN_CHEMIE_SEKII_LEHRPLAN_GYMNASIUM_2025.source-extraction.json",
+      "exists": true,
+      "sha256": "7038aebf2dd77f84b0db19e1c8cfd453815fb613ec266f256cbfb3027cf87eed",
+      "lastModifiedUtc": "2026-05-11T20:03:06Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/ST/lower-secondary/source-extraction/DE_ST_CHEMIE_SEKI_FACHLEHRPLAN_GYMNASIUM_2022.source-extraction.json",
+      "exists": true,
+      "sha256": "e5a7180e20ea1ea5387ee73fb489467bad081178d199c97b3e660d2ab804c22a",
+      "lastModifiedUtc": "2026-05-11T17:22:28Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/ST/upper-secondary/source-extraction/DE_ST_CHEMIE_SEKII_FACHLEHRPLAN_GYMNASIUM_2022.source-extraction.json",
+      "exists": true,
+      "sha256": "42bc36093be6e3d064db8e16ec2b0f7a9b8d709a7058f9442c2a9210c4ca033d",
+      "lastModifiedUtc": "2026-05-11T17:22:28Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/TH/lower-secondary/source-extraction/DE_TH_CHEMIE_SEKI_LEHRPLAN_GYMNASIUM_2024.source-extraction.json",
+      "exists": true,
+      "sha256": "86c6ba992412c9173a8d2d91e8d26dc0fbd555d03f9000b32d045cfeaca2dd3e",
+      "lastModifiedUtc": "2026-05-11T20:17:09Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/input/TH/upper-secondary/source-extraction/DE_TH_CHEMIE_SEKII_LEHRPLAN_GYMNASIUM_2024.source-extraction.json",
+      "exists": true,
+      "sha256": "ea18290c2a525c6daa0463da0619c095953f967710cf60814e23fb88821a8a24",
+      "lastModifiedUtc": "2026-05-11T20:17:09Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BB/lower-secondary/bb_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "290d8e449c11758abee976ccf0bf18348a05fe85d7aaf5991be67d136a15c79a",
+      "lastModifiedUtc": "2026-05-11T21:05:05Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BB/lower-secondary/bb_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "8bb399e3b6433bb1e6113c5f189784170c978d2aab1e60fa83a53cda911177b8",
+      "lastModifiedUtc": "2026-05-11T21:59:09Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BB/upper-secondary/bb_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "427c3cbd19684f4898b49edbbdb57ccbe710d5324c10ec863de54a491243e224",
+      "lastModifiedUtc": "2026-05-11T15:35:03Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BB/upper-secondary/bb_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "1eb3bfa92c7d3d989754463fbb0a084b43be0c83be62b094840124bd42bda817",
+      "lastModifiedUtc": "2026-05-11T21:59:09Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BE/lower-secondary/be_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "b0365a6ba67fb44f0bd87354f52d278274ba8eefa7ad94e7b03db89f90ba6beb",
+      "lastModifiedUtc": "2026-05-11T21:05:05Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BE/lower-secondary/be_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "6fa9acf7c7fecdee3c333182dea3a6698a5122866cf3e27128f51311c1e95e83",
+      "lastModifiedUtc": "2026-05-11T21:59:09Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BE/upper-secondary/be_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "69cc519d743369ce82de79d7126930a54a8b4030aab936a438a18670e0338c2c",
+      "lastModifiedUtc": "2026-05-11T15:35:03Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BE/upper-secondary/be_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "9c2b7f995bd6deffd43471b02871b25411d9e7ddd5500d10ff4189d24e502ab2",
+      "lastModifiedUtc": "2026-05-11T21:59:09Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BW/lower-secondary/bw_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "2f72d20e10b5a0c353aa246a6e0bfb3ab1abcf8d0498288ba532b530b6bcd934",
+      "lastModifiedUtc": "2026-05-11T10:33:12Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BW/lower-secondary/bw_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "1bed92eb6290ba8182c8b2a0a0d82aa02247e13464f85dde0d73f768fd163920",
+      "lastModifiedUtc": "2026-05-11T22:06:33Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BW/upper-secondary/bw_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "d9212ea8cc64b446db512f020d5d64dcd0f3ad7029167128a8018114c1cbe8c7",
+      "lastModifiedUtc": "2026-05-11T11:10:06Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BW/upper-secondary/bw_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "193434b0857b425b575452ca591e98f55859240484914a3e7b33dc7e2dc28679",
+      "lastModifiedUtc": "2026-05-11T22:06:33Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_biologisch_chemisches_praktikum_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "7c19e1746499b0fa79543474f43a630c677265e5067d4b0b49bfa9cf510dcb99",
+      "lastModifiedUtc": "2026-05-11T09:53:47Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_biologisch_chemisches_praktikum_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "ccf01f85c6e3ac7c12a7b069369ef74709e1049fb87168d02b7a64582afdd138",
+      "lastModifiedUtc": "2026-05-11T09:53:47Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_chemistry_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "21ca2e0a08ae98064afe4aaf94839078a49610eb2fd094b1cf74ad0e309511f3",
+      "lastModifiedUtc": "2026-05-11T11:07:28Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_chemistry_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "db30635f2d503a4ecbd657ad549c5c1d58f690991e10f35706c6fb7ce469ad5b",
+      "lastModifiedUtc": "2026-03-16T06:00:11Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HB/lower-secondary/hb_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "5de3296f1a0e50cfe7211f5d1c174a5c8dbe45e01848f50222911b2a0af2a7c8",
+      "lastModifiedUtc": "2026-05-11T21:31:56Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HB/lower-secondary/hb_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "9b77ef5eab0a133a52f590ea56170cf8064e0b924bbc78629b3f72df5144ee98",
+      "lastModifiedUtc": "2026-05-11T21:31:56Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HB/upper-secondary/hb_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "49132f31b0358bb5884db60cc44709aff7eb1ce47462262d6346b039a0454cc8",
+      "lastModifiedUtc": "2026-05-11T21:37:33Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HB/upper-secondary/hb_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "b05f9b3067a313b6927787f2bf8fcdf3da347bd52e13e608acbd8a282c3b2c82",
+      "lastModifiedUtc": "2026-05-11T21:37:33Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HE/lower-secondary/hessen_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "c2786b6bb4dd5fa934949b3aed0933350a105030fd56ed93e90c6d21aa8c0912",
+      "lastModifiedUtc": "2026-05-11T01:55:09Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HE/lower-secondary/hessen_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "5bbf502202f4095d839dc2f553cee937b7e20ccc2260142821753cc2bbfc6464",
+      "lastModifiedUtc": "2026-03-15T09:11:44Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HE/upper-secondary/hessen_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "57f713b35ca01251865287b39fc17d324876c89d94cc671b7c09fa2148bcf7fd",
+      "lastModifiedUtc": "2026-05-11T11:10:06Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HE/upper-secondary/hessen_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "1742bfb8230ba7d6d61bc92ff20a3a0961a6743c9eb02964fdea251738d374e0",
+      "lastModifiedUtc": "2026-03-13T16:57:34Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HH/lower-secondary/hh_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "1935005ce2f01c99702e2af987d5ada8fd9198c19ce2d1ed910b22dd3edc0b4d",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HH/lower-secondary/hh_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "f71285ae2ebe13883ea7be5b80082717d14ef9dedbe0aeed175c16f6fb6e6504",
+      "lastModifiedUtc": "2026-05-11T22:17:34Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HH/upper-secondary/hh_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "446b05ed72826cb94a5def801ce9e02ed3e899502b3ad156432baff0a50882c0",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-HH/upper-secondary/hh_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "fc5ec4beb50d05a4586be7e33e91064a4f8065f1f5ced8b3ea798031a6c7e636",
+      "lastModifiedUtc": "2026-05-11T22:17:34Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-MV/lower-secondary/mv_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "9db9a53ac8ef4300dcc7d152b5f34a35490b53382bc10745eab07c985223618a",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-MV/lower-secondary/mv_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "ba106034ae1de5421975b9612cbbbb21b73ae17904a8643dd84d539be9304ba6",
+      "lastModifiedUtc": "2026-05-11T22:44:24Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-MV/upper-secondary/mv_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "f749a9d2870c76803e34d822fce328073b6066988df87865e9f48cc4621d0934",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-MV/upper-secondary/mv_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "2f58812c3d6f8755ba1789641907674d17a765596a15023372668bc988dd4133",
+      "lastModifiedUtc": "2026-05-11T22:44:24Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-NI/lower-secondary/ni_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "5ce7f99327b7585e38bb975ef4fdd4885c3479bf69556e2645e220302ffa3ee8",
+      "lastModifiedUtc": "2026-05-11T13:06:03Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-NI/lower-secondary/ni_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "ca0f78f02e848173e40f1a015d638303db5f463ecca3f4e6cd1afc9a1b509c23",
+      "lastModifiedUtc": "2026-05-11T23:11:44Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-NI/upper-secondary/ni_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "4a1bda407b3078e3bfb3744566f92d7da7d304eb97841bba11c93c3ccd5c96da",
+      "lastModifiedUtc": "2026-05-11T15:35:03Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-NI/upper-secondary/ni_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "1b4dad1d44e7c70a2ea299809fb1299bf6209c97cc22e8b44d509872b848b579",
+      "lastModifiedUtc": "2026-05-11T23:11:44Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-NW/lower-secondary/nrw_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "336afa38ae697b0356211aa2b827f59b37ac2c11dee06cf48fb836e181621175",
+      "lastModifiedUtc": "2026-05-11T13:44:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-NW/lower-secondary/nrw_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "b10962d68890a2a9fdeaee4f1b62f8e16fc848180712e4aabdcd28593ebf8ea2",
+      "lastModifiedUtc": "2026-05-11T22:28:19Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-NW/upper-secondary/nrw_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "98c0d136feaf2414b1ff2fbd4b73ce169577c2114dd354fc0e3e1fb72a9e8ca5",
+      "lastModifiedUtc": "2026-05-11T13:44:52Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-NW/upper-secondary/nrw_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "35a79568f58d801e78920b5c6079c38de58767ededc5f81510a93e93aeb3c02a",
+      "lastModifiedUtc": "2026-05-11T22:28:19Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-RP/lower-secondary/rp_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "ae4f292ec7086876fe13595c81060a53328763a57ec3abc9d9bc79e86b2de850",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-RP/lower-secondary/rp_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "032dbdcca3377214f7a05172cdb42b97b7d61500005134e72f6470a0db0cbc6a",
+      "lastModifiedUtc": "2026-05-11T23:05:24Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-RP/upper-secondary/rp_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "31aadba54416add6093cff0eb9b86c59b7af2cada0966b1f35b95f01cd491f72",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-RP/upper-secondary/rp_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "413445dd9c647a7a83d58aee33619145e6fdcd7d0197d4fb20c5dc2f67426f0e",
+      "lastModifiedUtc": "2026-05-11T23:05:24Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SH/lower-secondary/sh_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "d3dfd43e6af4b195e4911b1012ea0707ac13571b49b60bf5f2a82c52e2300fb0",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SH/lower-secondary/sh_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "601f001495e66b3d7a6981aa731573bb97fe9db0866c7884a08d8a2197d58807",
+      "lastModifiedUtc": "2026-05-11T22:55:48Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SH/upper-secondary/sh_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "545655ef9bc1086885204970af4d34fea281e39d81f3f97a8a19a7cf1fa04270",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SH/upper-secondary/sh_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "97c1d642406c79429b06c4b9fda1c99c735e2fd7b3e4420a11f44395ee03bc1e",
+      "lastModifiedUtc": "2026-05-11T22:55:48Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SL/lower-secondary/sl_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "3c1dff6057d0502eea27b90ccfc66db0d532c2d95d25038b32fadcb279dfde85",
+      "lastModifiedUtc": "2026-05-11T20:16:54Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SL/lower-secondary/sl_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "8343cc40f266f09e0cfd10efa095e7bebde4a1e0a404d22fbcbd9f5897aaa6b3",
+      "lastModifiedUtc": "2026-05-11T23:20:06Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SL/upper-secondary/sl_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "a652155822a6843a5e07f97cb3efb38523666ac086ad3a66bf35769797470338",
+      "lastModifiedUtc": "2026-05-11T20:16:54Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SL/upper-secondary/sl_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "13adeb20ba83ced2905867d2c68459dcce89b3befcb167dbf180733fa227414e",
+      "lastModifiedUtc": "2026-05-11T23:20:06Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SN/lower-secondary/sn_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "dddf50c13902ca2d796611c7e44225b774b5c3e86a668cbc53c6550c8916c5e4",
+      "lastModifiedUtc": "2026-05-11T20:16:54Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SN/lower-secondary/sn_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "4c65c491c7bfcf882cf4dfef5247872113555808c7f279ae9dda2d1cb288256f",
+      "lastModifiedUtc": "2026-05-11T23:26:24Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SN/upper-secondary/sn_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "f322b78ad1aff3d090a76ef03c695a1f62044e7fa469f7c93995984c1b39a007",
+      "lastModifiedUtc": "2026-05-11T20:16:54Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-SN/upper-secondary/sn_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "8ec025fbb75945c1679661237bcb53f14dc020b8ced1238e82e837aee13e6e79",
+      "lastModifiedUtc": "2026-05-11T23:26:24Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-ST/lower-secondary/st_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "b12d6fbf1e23aff99bb97383eb407fe6bef62edecd94f6c64db928dcd20e5ff8",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-ST/lower-secondary/st_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "dae00e1cf5aed31617004882a61a46ea1ed2166a4e534fa20acfbe1cef53171e",
+      "lastModifiedUtc": "2026-05-11T23:32:44Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-ST/upper-secondary/st_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "70f28dddbdfa717dc6099c45c51af7d852cc4d10942cb076e34d1a4110145948",
+      "lastModifiedUtc": "2026-05-11T20:22:42Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-ST/upper-secondary/st_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "58e8e3c88a14f27d53f2d4634eb380ae014b7b04ac1e07c3809ab467a62b8a24",
+      "lastModifiedUtc": "2026-05-11T23:32:44Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-TH/lower-secondary/th_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "de0028d2a247cb130e9369ff25cc11a510ccfee899b6f3b393b3a82e60152562",
+      "lastModifiedUtc": "2026-05-11T20:16:54Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-TH/lower-secondary/th_chemistry_lower_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "9d7e465d5199c3f801120e44b147c8bf9b8da35e0b2af1efcffe710b1132c457",
+      "lastModifiedUtc": "2026-05-11T23:38:28Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-TH/upper-secondary/th_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json",
+      "exists": true,
+      "sha256": "e3310405c9d201b077f18a76ebaf150c44470b95a85d3cb130e53907d9e1f86b",
+      "lastModifiedUtc": "2026-05-11T20:16:54Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/mapping/DE-TH/upper-secondary/th_chemistry_upper_secondary_to_canonical_chemistry.json",
+      "exists": true,
+      "sha256": "96b6c8283587cf79b4b1bcb1223a65a60af62aedc315b07afb550f16f698e500",
+      "lastModifiedUtc": "2026-05-11T23:38:28Z"
+    },
+    {
+      "relativePath": "curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json",
+      "exists": true,
+      "sha256": "4a02266a50b72d73585a13b5cae5b17280e868c7376e27cbb937709e1beab9c9",
+      "lastModifiedUtc": "2026-05-11T23:39:34Z"
+    }
+  ]
+}

--- a/curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json
+++ b/curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json
@@ -1,0 +1,140 @@
+{
+  "version": 1,
+  "updatedAt": "2026-05-12T00:00:00Z",
+  "mode": "maintenance_evidence_watch",
+  "landscapePath": "curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json",
+  "trackerPath": "curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json",
+  "baselinePath": "curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json",
+  "baselineCommand": "python3 scripts/canonical_chemistry_evidence_watch.py capture-baseline",
+  "statusViewPath": "docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md",
+  "statusCommand": "python3 scripts/canonical_chemistry_evidence_watch.py render-status",
+  "deltaViewPath": "docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md",
+  "deltaCommand": "python3 scripts/canonical_chemistry_evidence_watch.py render-delta",
+  "checkCommand": "python3 scripts/canonical_chemistry_evidence_watch.py check-delta",
+  "runCommand": "./scripts/run_canonical_chemistry_evidence_watch.sh",
+  "workflowPath": ".github/workflows/canonical_chemistry_evidence_watch.yml",
+  "watchTargets": [
+    {
+      "id": "chemistry_canonical_and_tracker_watch",
+      "kind": "canonical_runtime_contract",
+      "states": [
+        "DE-BB",
+        "DE-BE",
+        "DE-BW",
+        "DE-BY",
+        "DE-HB",
+        "DE-HE",
+        "DE-HH",
+        "DE-MV",
+        "DE-NI",
+        "DE-NW",
+        "DE-RP",
+        "DE-SH",
+        "DE-SL",
+        "DE-SN",
+        "DE-ST",
+        "DE-TH"
+      ],
+      "candidateRows": [
+        "P6 cutover-ready canonical Chemistry graph",
+        "P6 all-state rollout tracker"
+      ],
+      "paths": [
+        "curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json",
+        "curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json"
+      ],
+      "reopenRule": "Reopen Chemistry P6 maintenance only if a canonical graph or tracker delta changes visible scope, source-backed projection status, runtime mapping coverage, or composition-view eligibility."
+    },
+    {
+      "id": "chemistry_source_evidence_watch",
+      "kind": "all_state_source_evidence",
+      "states": [
+        "DE-BB",
+        "DE-BE",
+        "DE-BW",
+        "DE-BY",
+        "DE-HB",
+        "DE-HE",
+        "DE-HH",
+        "DE-MV",
+        "DE-NI",
+        "DE-NW",
+        "DE-RP",
+        "DE-SH",
+        "DE-SL",
+        "DE-SN",
+        "DE-ST",
+        "DE-TH"
+      ],
+      "candidateRows": [
+        "source-extraction inventories for all Chemistry state lanes",
+        "retained Hessen source-json Chemistry snapshots"
+      ],
+      "pathGlobs": [
+        "curricula/DE/Gymnasium/input/**/source-extraction/*CHEM*.source-extraction.json",
+        "curricula/DE/Gymnasium/input/**/source-json/*CHEMIE*.json.snapshot"
+      ],
+      "reopenRule": "Reopen a state lane only if a watched source evidence delta changes the extracted Chemistry learning-goal set or introduces a source-backed visible scope that is not covered by the existing P6 projection."
+    },
+    {
+      "id": "chemistry_mapping_watch",
+      "kind": "all_state_mapping_contract",
+      "states": [
+        "DE-BB",
+        "DE-BE",
+        "DE-BW",
+        "DE-BY",
+        "DE-HB",
+        "DE-HE",
+        "DE-HH",
+        "DE-MV",
+        "DE-NI",
+        "DE-NW",
+        "DE-RP",
+        "DE-SH",
+        "DE-SL",
+        "DE-SN",
+        "DE-ST",
+        "DE-TH"
+      ],
+      "candidateRows": [
+        "reviewed source-extraction to canonical Chemistry mappings",
+        "runtime legacy-to-canonical Chemistry mappings"
+      ],
+      "pathGlobs": [
+        "curricula/DE/Gymnasium/mapping/**/*canonical_chemistry*.json"
+      ],
+      "reopenRule": "Reopen mapping maintenance only if a watched mapping delta changes source-to-canonical coverage, runtime legacy translation, unsupported assigned-goal handling, or projected learner-facing totals."
+    },
+    {
+      "id": "chemistry_composition_view_watch",
+      "kind": "all_state_composition_view_contract",
+      "states": [
+        "DE-BB",
+        "DE-BE",
+        "DE-BW",
+        "DE-BY",
+        "DE-HB",
+        "DE-HE",
+        "DE-HH",
+        "DE-MV",
+        "DE-NI",
+        "DE-NW",
+        "DE-RP",
+        "DE-SH",
+        "DE-SL",
+        "DE-SN",
+        "DE-ST",
+        "DE-TH"
+      ],
+      "candidateRows": [
+        "country-level Chemistry composition views",
+        "state-level GK/LK Chemistry composition views"
+      ],
+      "pathGlobs": [
+        "curricula/DE/Gymnasium/composition-views/chemie/*.view.json"
+      ],
+      "reopenRule": "Reopen composition-view maintenance only if a view delta changes the single-occurrence learner-facing tree, GK/LK eligibility, or a state-specific visible Chemistry scope."
+    }
+  ]
+}

--- a/docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md
+++ b/docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md
@@ -1,0 +1,53 @@
+# Canonical Gymnasium Chemistry Evidence Watch Delta
+
+Snapshot: `2026-05-12T00:49:38Z`
+
+This file is generated from:
+
+- `curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json`
+- `curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json`
+- `scripts/canonical_chemistry_evidence_watch.py`
+
+## Headline
+
+- Baseline snapshot: `2026-05-12T00:49:35Z`
+- Current watched files: `137`
+- Unchanged watched files: `137`
+- Changed watched files: `0`
+- Added watch paths since baseline: `0`
+- Removed watch paths since baseline: `0`
+
+## Interpretation
+
+- A file-level delta is a maintenance signal, not an automatic rollout reopen.
+- Reopen remains gated by the documented reopen rules in the watch manifest.
+
+## Changed files
+
+- none
+
+## Added watch paths
+
+- none
+
+## Removed watch paths
+
+- none
+
+## Target delta register
+
+| Target | Changed files | Added paths | Removed paths |
+| --- | ---: | ---: | ---: |
+| `chemistry_canonical_and_tracker_watch` | `0` | `0` | `0` |
+| `chemistry_source_evidence_watch` | `0` | `0` | `0` |
+| `chemistry_mapping_watch` | `0` | `0` | `0` |
+| `chemistry_composition_view_watch` | `0` | `0` | `0` |
+
+## Regeneration
+
+```bash
+python3 scripts/canonical_chemistry_evidence_watch.py capture-baseline
+python3 scripts/canonical_chemistry_evidence_watch.py render-delta
+python3 scripts/canonical_chemistry_evidence_watch.py check-delta
+./scripts/run_canonical_chemistry_evidence_watch.sh
+```

--- a/docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md
+++ b/docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md
@@ -1,0 +1,382 @@
+# Canonical Gymnasium Chemistry Evidence Watch Status
+
+Snapshot: `2026-05-12T00:00:00Z`
+
+This file is generated from:
+
+- `curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json`
+- `scripts/canonical_chemistry_evidence_watch.py`
+
+## Headline
+
+- Watch mode: `maintenance_evidence_watch`
+- Watch targets: `4`
+- Watched state set: `16`
+- Declared path references across all targets: `6`
+- Expanded path references across all targets: `137`
+- Unique watched files: `137`
+- Existing watched files: `137/137`
+- Missing watched files: `0`
+
+## Watch kinds
+
+| Kind | Count |
+| --- | ---: |
+| `all_state_composition_view_contract` | `1` |
+| `all_state_mapping_contract` | `1` |
+| `all_state_source_evidence` | `1` |
+| `canonical_runtime_contract` | `1` |
+
+## Watch target register
+
+| Target | Kind | States | Candidate rows | Declared refs | Expanded files | Missing files |
+| --- | --- | --- | --- | ---: | ---: | ---: |
+| `chemistry_canonical_and_tracker_watch` | `canonical_runtime_contract` | `DE-BB`, `DE-BE`, `DE-BW`, `DE-BY`, `DE-HB`, `DE-HE`, `DE-HH`, `DE-MV`, `DE-NI`, `DE-NW`, `DE-RP`, `DE-SH`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH` | P6 cutover-ready canonical Chemistry graph<br>P6 all-state rollout tracker | `2` | `2` | `0` |
+| `chemistry_source_evidence_watch` | `all_state_source_evidence` | `DE-BB`, `DE-BE`, `DE-BW`, `DE-BY`, `DE-HB`, `DE-HE`, `DE-HH`, `DE-MV`, `DE-NI`, `DE-NW`, `DE-RP`, `DE-SH`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH` | source-extraction inventories for all Chemistry state lanes<br>retained Hessen source-json Chemistry snapshots | `2` | `34` | `0` |
+| `chemistry_mapping_watch` | `all_state_mapping_contract` | `DE-BB`, `DE-BE`, `DE-BW`, `DE-BY`, `DE-HB`, `DE-HE`, `DE-HH`, `DE-MV`, `DE-NI`, `DE-NW`, `DE-RP`, `DE-SH`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH` | reviewed source-extraction to canonical Chemistry mappings<br>runtime legacy-to-canonical Chemistry mappings | `1` | `64` | `0` |
+| `chemistry_composition_view_watch` | `all_state_composition_view_contract` | `DE-BB`, `DE-BE`, `DE-BW`, `DE-BY`, `DE-HB`, `DE-HE`, `DE-HH`, `DE-MV`, `DE-NI`, `DE-NW`, `DE-RP`, `DE-SH`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH` | country-level Chemistry composition views<br>state-level GK/LK Chemistry composition views | `1` | `37` | `0` |
+
+## Unique file register
+
+| File | Exists | SHA256-12 | Last modified (UTC) |
+| --- | --- | --- | --- |
+| `curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json` | `yes` | `caf2314e8166` | `2026-05-11T23:54:30Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-bb-gk.view.json` | `yes` | `41be795c3ab0` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-bb-lk.view.json` | `yes` | `7b2b8027aa32` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-be-gk.view.json` | `yes` | `00de28f46bfc` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-be-lk.view.json` | `yes` | `a6f8659c8e2c` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-bw-gk.view.json` | `yes` | `47f10802b3ac` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-bw-lk.view.json` | `yes` | `885046fffccb` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-chemistry-gk.view.json` | `yes` | `e0f2a559877f` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-chemistry-lk.view.json` | `yes` | `98138ba639d2` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-seki-chemistry.view.json` | `yes` | `0c3b1a0d01f7` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-sekii-chemistry-gk.view.json` | `yes` | `557120ec43ba` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-sekii-chemistry-lk.view.json` | `yes` | `19ef4ce9f43c` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-hb-gk.view.json` | `yes` | `f852417ae6cb` | `2026-05-11T21:37:33Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-hb-lk.view.json` | `yes` | `a409d1898512` | `2026-05-11T21:37:33Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-he-gk.view.json` | `yes` | `16e324150bda` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-he-lk.view.json` | `yes` | `56f97a454a76` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-he-sekii-gk.view.json` | `yes` | `db629d8607b7` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-he-sekii-lk.view.json` | `yes` | `155cc907ea9b` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-hh-gk.view.json` | `yes` | `874d29a69f22` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-hh-lk.view.json` | `yes` | `64ff5cd26a28` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-mv-gk.view.json` | `yes` | `5e8bfdfd7352` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-mv-lk.view.json` | `yes` | `54d36dab1c09` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-ni-gk.view.json` | `yes` | `748cd07e689c` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-ni-lk.view.json` | `yes` | `3545b804797b` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-nw-gk.view.json` | `yes` | `a30203b5f358` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-nw-lk.view.json` | `yes` | `bc353105f015` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-rp-gk.view.json` | `yes` | `65367171f96a` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-rp-lk.view.json` | `yes` | `13cb9341d58b` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sh-gk.view.json` | `yes` | `43375c07fdd6` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sh-lk.view.json` | `yes` | `139989e1b39f` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sl-gk.view.json` | `yes` | `5f56d33f12a2` | `2026-05-11T20:17:00Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sl-lk.view.json` | `yes` | `08601112c3f6` | `2026-05-11T20:17:00Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sn-gk.view.json` | `yes` | `3c93f6075692` | `2026-05-11T20:17:00Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sn-lk.view.json` | `yes` | `e91e08acf280` | `2026-05-11T20:17:00Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-st-gk.view.json` | `yes` | `cf066a700e01` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-st-lk.view.json` | `yes` | `e81c9fb0d498` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-th-gk.view.json` | `yes` | `45b193b3ebdc` | `2026-05-11T20:17:00Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-th-lk.view.json` | `yes` | `5e68c712aabf` | `2026-05-11T20:17:00Z` |
+| `curricula/DE/Gymnasium/input/BB/lower-secondary/source-extraction/DE_BB_CHEMIE_SEKI_RLP_2015.source-extraction.json` | `yes` | `a9dea05e32e5` | `2026-05-11T21:05:05Z` |
+| `curricula/DE/Gymnasium/input/BB/upper-secondary/source-extraction/DE_BB_CHEMIE_SEKII_RLP_GOST_2022.source-extraction.json` | `yes` | `54b5654929ab` | `2026-05-11T11:44:26Z` |
+| `curricula/DE/Gymnasium/input/BE/lower-secondary/source-extraction/DE_BE_CHEMIE_SEKI_RLP_2015.source-extraction.json` | `yes` | `b849370b2284` | `2026-05-11T21:05:05Z` |
+| `curricula/DE/Gymnasium/input/BE/upper-secondary/source-extraction/DE_BE_CHEMIE_SEKII_RLP_GOST_2022.source-extraction.json` | `yes` | `7d8b939ed2bf` | `2026-05-11T11:44:26Z` |
+| `curricula/DE/Gymnasium/input/BW/lower-secondary/source-extraction/DE_BW_CHEMIE_SEKI_BP2016_V2.source-extraction.json` | `yes` | `cee17e8a8d7f` | `2026-05-11T10:13:38Z` |
+| `curricula/DE/Gymnasium/input/BW/upper-secondary/source-extraction/DE_BW_CHEMIE_SEKII_BP2016_V2.source-extraction.json` | `yes` | `25d68fdafcb7` | `2026-05-11T10:13:39Z` |
+| `curricula/DE/Gymnasium/input/BY/gymnasium/source-extraction/DE_BY_BIOLOGISCH_CHEMISCHES_PRAKTIKUM_GYMNASIUM_LEHRPLANPLUS.source-extraction.json` | `yes` | `2343c4fd2e45` | `2026-05-11T02:37:43Z` |
+| `curricula/DE/Gymnasium/input/BY/gymnasium/source-extraction/DE_BY_CHEMIE_GYMNASIUM_LEHRPLANPLUS.source-extraction.json` | `yes` | `d8f6b835b007` | `2026-05-11T11:07:28Z` |
+| `curricula/DE/Gymnasium/input/HB/lower-secondary/source-extraction/DE_HB_CHEMIE_SEKI_BILDUNGSPLAN_2006_2022.source-extraction.json` | `yes` | `adc4f0446eed` | `2026-05-11T21:31:56Z` |
+| `curricula/DE/Gymnasium/input/HB/upper-secondary/source-extraction/DE_HB_CHEMIE_SEKII_GYO_2022.source-extraction.json` | `yes` | `3a928a968081` | `2026-05-11T21:37:33Z` |
+| `curricula/DE/Gymnasium/input/HE/lower-secondary/source-extraction/DE_HE_CHEMIE_SEKI_G9.source-extraction.json` | `yes` | `3b2584499c02` | `2026-05-11T01:55:09Z` |
+| `curricula/DE/Gymnasium/input/HE/lower-secondary/source-json/DE_HES_S_GYM_1_CHEMIE.de.json.snapshot` | `yes` | `a11a261b9166` | `2026-03-15T08:08:49Z` |
+| `curricula/DE/Gymnasium/input/HE/upper-secondary/source-extraction/DE_HE_CHEMIE_SEKII_KC2024.source-extraction.json` | `yes` | `7ee435bcdf39` | `2026-05-11T02:16:59Z` |
+| `curricula/DE/Gymnasium/input/HE/upper-secondary/source-json/DE_HES_S_GYM_2_CHEMIE.de.json.snapshot` | `yes` | `425d4d3a0b2d` | `2026-03-15T06:54:57Z` |
+| `curricula/DE/Gymnasium/input/HH/lower-secondary/source-extraction/DE_HH_CHEMIE_SEKI_BILDUNGSPLAN.source-extraction.json` | `yes` | `ec073c3aa3ce` | `2026-05-11T15:05:28Z` |
+| `curricula/DE/Gymnasium/input/HH/upper-secondary/source-extraction/DE_HH_CHEMIE_SEKII_BILDUNGSPLAN_2022.source-extraction.json` | `yes` | `c8754796e802` | `2026-05-11T15:05:28Z` |
+| `curricula/DE/Gymnasium/input/MV/lower-secondary/source-extraction/DE_MV_CHEMIE_SEKI_RAHMENPLAN_2021.source-extraction.json` | `yes` | `f8fe7064ab5d` | `2026-05-11T17:42:32Z` |
+| `curricula/DE/Gymnasium/input/MV/upper-secondary/source-extraction/DE_MV_CHEMIE_SEKII_RAHMENPLAN_ERPROBUNGSFASSUNG_2022.source-extraction.json` | `yes` | `1781d86d4e93` | `2026-05-11T17:42:32Z` |
+| `curricula/DE/Gymnasium/input/NI/lower-secondary/source-extraction/DE_NI_CHEMIE_SEKI_KC2015.source-extraction.json` | `yes` | `3c82664df56a` | `2026-05-11T13:06:03Z` |
+| `curricula/DE/Gymnasium/input/NI/upper-secondary/source-extraction/DE_NI_CHEMIE_SEKII_KC2022.source-extraction.json` | `yes` | `426a4c65902b` | `2026-05-11T12:14:36Z` |
+| `curricula/DE/Gymnasium/input/NW/lower-secondary/source-extraction/DE_NW_CHEMIE_SEKI_KLP2019.source-extraction.json` | `yes` | `6594569b7ed7` | `2026-05-11T13:44:52Z` |
+| `curricula/DE/Gymnasium/input/NW/upper-secondary/source-extraction/DE_NW_CHEMIE_SEKII_KLP2022.source-extraction.json` | `yes` | `63af0e8396ff` | `2026-05-11T13:44:52Z` |
+| `curricula/DE/Gymnasium/input/RP/lower-secondary/source-extraction/DE_RP_CHEMIE_SEKI_RAHMENLEHRPLAN_2014.source-extraction.json` | `yes` | `aef5035f5da0` | `2026-05-11T18:19:20Z` |
+| `curricula/DE/Gymnasium/input/RP/upper-secondary/source-extraction/DE_RP_CHEMIE_SEKII_MSS_2022.source-extraction.json` | `yes` | `a9397191898c` | `2026-05-11T18:19:20Z` |
+| `curricula/DE/Gymnasium/input/SH/lower-secondary/source-extraction/DE_SH_CHEMIE_SEKI_FACHANFORDERUNGEN_2022.source-extraction.json` | `yes` | `125612af7681` | `2026-05-11T14:26:04Z` |
+| `curricula/DE/Gymnasium/input/SH/upper-secondary/source-extraction/DE_SH_CHEMIE_SEKII_FACHANFORDERUNGEN_2022.source-extraction.json` | `yes` | `27026debce0a` | `2026-05-11T14:26:04Z` |
+| `curricula/DE/Gymnasium/input/SL/lower-secondary/source-extraction/DE_SL_CHEMIE_SEKI_GYM9_2024_2025.source-extraction.json` | `yes` | `04fd85550877` | `2026-05-11T19:49:02Z` |
+| `curricula/DE/Gymnasium/input/SL/upper-secondary/source-extraction/DE_SL_CHEMIE_SEKII_GOS_2023_2025.source-extraction.json` | `yes` | `b3cf9781a898` | `2026-05-11T19:49:02Z` |
+| `curricula/DE/Gymnasium/input/SN/lower-secondary/source-extraction/DE_SN_CHEMIE_SEKI_LEHRPLAN_GYMNASIUM_2025.source-extraction.json` | `yes` | `1de76385d9d7` | `2026-05-11T20:03:06Z` |
+| `curricula/DE/Gymnasium/input/SN/upper-secondary/source-extraction/DE_SN_CHEMIE_SEKII_LEHRPLAN_GYMNASIUM_2025.source-extraction.json` | `yes` | `7038aebf2dd7` | `2026-05-11T20:03:06Z` |
+| `curricula/DE/Gymnasium/input/ST/lower-secondary/source-extraction/DE_ST_CHEMIE_SEKI_FACHLEHRPLAN_GYMNASIUM_2022.source-extraction.json` | `yes` | `e5a7180e20ea` | `2026-05-11T17:22:28Z` |
+| `curricula/DE/Gymnasium/input/ST/upper-secondary/source-extraction/DE_ST_CHEMIE_SEKII_FACHLEHRPLAN_GYMNASIUM_2022.source-extraction.json` | `yes` | `42bc36093be6` | `2026-05-11T17:22:28Z` |
+| `curricula/DE/Gymnasium/input/TH/lower-secondary/source-extraction/DE_TH_CHEMIE_SEKI_LEHRPLAN_GYMNASIUM_2024.source-extraction.json` | `yes` | `86c6ba992412` | `2026-05-11T20:17:09Z` |
+| `curricula/DE/Gymnasium/input/TH/upper-secondary/source-extraction/DE_TH_CHEMIE_SEKII_LEHRPLAN_GYMNASIUM_2024.source-extraction.json` | `yes` | `ea18290c2a52` | `2026-05-11T20:17:09Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BB/lower-secondary/bb_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `290d8e449c11` | `2026-05-11T21:05:05Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BB/lower-secondary/bb_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `8bb399e3b643` | `2026-05-11T21:59:09Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BB/upper-secondary/bb_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `427c3cbd1968` | `2026-05-11T15:35:03Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BB/upper-secondary/bb_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `1eb3bfa92c7d` | `2026-05-11T21:59:09Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BE/lower-secondary/be_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `b0365a6ba67f` | `2026-05-11T21:05:05Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BE/lower-secondary/be_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `6fa9acf7c7fe` | `2026-05-11T21:59:09Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BE/upper-secondary/be_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `69cc519d7433` | `2026-05-11T15:35:03Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BE/upper-secondary/be_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `9c2b7f995bd6` | `2026-05-11T21:59:09Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BW/lower-secondary/bw_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `2f72d20e10b5` | `2026-05-11T10:33:12Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BW/lower-secondary/bw_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `1bed92eb6290` | `2026-05-11T22:06:33Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BW/upper-secondary/bw_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `d9212ea8cc64` | `2026-05-11T11:10:06Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BW/upper-secondary/bw_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `193434b0857b` | `2026-05-11T22:06:33Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_biologisch_chemisches_praktikum_source_extraction_to_canonical_chemistry.review.json` | `yes` | `7c19e1746499` | `2026-05-11T09:53:47Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_biologisch_chemisches_praktikum_to_canonical_chemistry.json` | `yes` | `ccf01f85c6e3` | `2026-05-11T09:53:47Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_chemistry_source_extraction_to_canonical_chemistry.review.json` | `yes` | `21ca2e0a08ae` | `2026-05-11T11:07:28Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_chemistry_to_canonical_chemistry.json` | `yes` | `db30635f2d50` | `2026-03-16T06:00:11Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HB/lower-secondary/hb_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `5de3296f1a0e` | `2026-05-11T21:31:56Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HB/lower-secondary/hb_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `9b77ef5eab0a` | `2026-05-11T21:31:56Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HB/upper-secondary/hb_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `49132f31b035` | `2026-05-11T21:37:33Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HB/upper-secondary/hb_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `b05f9b3067a3` | `2026-05-11T21:37:33Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HE/lower-secondary/hessen_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `c2786b6bb4dd` | `2026-05-11T01:55:09Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HE/lower-secondary/hessen_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `5bbf502202f4` | `2026-03-15T09:11:44Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HE/upper-secondary/hessen_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `57f713b35ca0` | `2026-05-11T11:10:06Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HE/upper-secondary/hessen_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `1742bfb8230b` | `2026-03-13T16:57:34Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HH/lower-secondary/hh_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `1935005ce2f0` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HH/lower-secondary/hh_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `f71285ae2ebe` | `2026-05-11T22:17:34Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HH/upper-secondary/hh_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `446b05ed7282` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HH/upper-secondary/hh_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `fc5ec4beb50d` | `2026-05-11T22:17:34Z` |
+| `curricula/DE/Gymnasium/mapping/DE-MV/lower-secondary/mv_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `9db9a53ac8ef` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-MV/lower-secondary/mv_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `ba106034ae1d` | `2026-05-11T22:44:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-MV/upper-secondary/mv_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `f749a9d2870c` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-MV/upper-secondary/mv_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `2f58812c3d6f` | `2026-05-11T22:44:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NI/lower-secondary/ni_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `5ce7f99327b7` | `2026-05-11T13:06:03Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NI/lower-secondary/ni_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `ca0f78f02e84` | `2026-05-11T23:11:44Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NI/upper-secondary/ni_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `4a1bda407b30` | `2026-05-11T15:35:03Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NI/upper-secondary/ni_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `1b4dad1d44e7` | `2026-05-11T23:11:44Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NW/lower-secondary/nrw_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `336afa38ae69` | `2026-05-11T13:44:52Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NW/lower-secondary/nrw_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `b10962d68890` | `2026-05-11T22:28:19Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NW/upper-secondary/nrw_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `98c0d136feaf` | `2026-05-11T13:44:52Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NW/upper-secondary/nrw_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `35a79568f58d` | `2026-05-11T22:28:19Z` |
+| `curricula/DE/Gymnasium/mapping/DE-RP/lower-secondary/rp_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `ae4f292ec708` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-RP/lower-secondary/rp_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `032dbdcca337` | `2026-05-11T23:05:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-RP/upper-secondary/rp_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `31aadba54416` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-RP/upper-secondary/rp_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `413445dd9c64` | `2026-05-11T23:05:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SH/lower-secondary/sh_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `d3dfd43e6af4` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SH/lower-secondary/sh_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `601f001495e6` | `2026-05-11T22:55:48Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SH/upper-secondary/sh_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `545655ef9bc1` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SH/upper-secondary/sh_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `97c1d642406c` | `2026-05-11T22:55:48Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SL/lower-secondary/sl_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `3c1dff6057d0` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SL/lower-secondary/sl_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `8343cc40f266` | `2026-05-11T23:20:06Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SL/upper-secondary/sl_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `a652155822a6` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SL/upper-secondary/sl_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `13adeb20ba83` | `2026-05-11T23:20:06Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SN/lower-secondary/sn_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `dddf50c13902` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SN/lower-secondary/sn_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `4c65c491c7bf` | `2026-05-11T23:26:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SN/upper-secondary/sn_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `f322b78ad1af` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SN/upper-secondary/sn_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `8ec025fbb759` | `2026-05-11T23:26:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-ST/lower-secondary/st_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `b12d6fbf1e23` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-ST/lower-secondary/st_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `dae00e1cf5ae` | `2026-05-11T23:32:44Z` |
+| `curricula/DE/Gymnasium/mapping/DE-ST/upper-secondary/st_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `70f28dddbdfa` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-ST/upper-secondary/st_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `58e8e3c88a14` | `2026-05-11T23:32:44Z` |
+| `curricula/DE/Gymnasium/mapping/DE-TH/lower-secondary/th_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `de0028d2a247` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-TH/lower-secondary/th_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `9d7e465d5199` | `2026-05-11T23:38:28Z` |
+| `curricula/DE/Gymnasium/mapping/DE-TH/upper-secondary/th_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `e3310405c9d2` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-TH/upper-secondary/th_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `96b6c8283587` | `2026-05-11T23:38:28Z` |
+| `curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json` | `yes` | `4a02266a50b7` | `2026-05-11T23:39:34Z` |
+
+## `chemistry_canonical_and_tracker_watch`
+
+- Kind: `canonical_runtime_contract`
+- States: `DE-BB`, `DE-BE`, `DE-BW`, `DE-BY`, `DE-HB`, `DE-HE`, `DE-HH`, `DE-MV`, `DE-NI`, `DE-NW`, `DE-RP`, `DE-SH`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH`
+- Candidate rows:
+  - `P6 cutover-ready canonical Chemistry graph`
+  - `P6 all-state rollout tracker`
+- Reopen rule: Reopen Chemistry P6 maintenance only if a canonical graph or tracker delta changes visible scope, source-backed projection status, runtime mapping coverage, or composition-view eligibility.
+- Watched files:
+
+| File | Exists | SHA256-12 | Last modified (UTC) |
+| --- | --- | --- | --- |
+| `curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json` | `yes` | `caf2314e8166` | `2026-05-11T23:54:30Z` |
+| `curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json` | `yes` | `4a02266a50b7` | `2026-05-11T23:39:34Z` |
+
+## `chemistry_source_evidence_watch`
+
+- Kind: `all_state_source_evidence`
+- States: `DE-BB`, `DE-BE`, `DE-BW`, `DE-BY`, `DE-HB`, `DE-HE`, `DE-HH`, `DE-MV`, `DE-NI`, `DE-NW`, `DE-RP`, `DE-SH`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH`
+- Candidate rows:
+  - `source-extraction inventories for all Chemistry state lanes`
+  - `retained Hessen source-json Chemistry snapshots`
+- Reopen rule: Reopen a state lane only if a watched source evidence delta changes the extracted Chemistry learning-goal set or introduces a source-backed visible scope that is not covered by the existing P6 projection.
+- Path globs:
+  - `curricula/DE/Gymnasium/input/**/source-extraction/*CHEM*.source-extraction.json`
+  - `curricula/DE/Gymnasium/input/**/source-json/*CHEMIE*.json.snapshot`
+- Watched files:
+
+| File | Exists | SHA256-12 | Last modified (UTC) |
+| --- | --- | --- | --- |
+| `curricula/DE/Gymnasium/input/BB/lower-secondary/source-extraction/DE_BB_CHEMIE_SEKI_RLP_2015.source-extraction.json` | `yes` | `a9dea05e32e5` | `2026-05-11T21:05:05Z` |
+| `curricula/DE/Gymnasium/input/BB/upper-secondary/source-extraction/DE_BB_CHEMIE_SEKII_RLP_GOST_2022.source-extraction.json` | `yes` | `54b5654929ab` | `2026-05-11T11:44:26Z` |
+| `curricula/DE/Gymnasium/input/BE/lower-secondary/source-extraction/DE_BE_CHEMIE_SEKI_RLP_2015.source-extraction.json` | `yes` | `b849370b2284` | `2026-05-11T21:05:05Z` |
+| `curricula/DE/Gymnasium/input/BE/upper-secondary/source-extraction/DE_BE_CHEMIE_SEKII_RLP_GOST_2022.source-extraction.json` | `yes` | `7d8b939ed2bf` | `2026-05-11T11:44:26Z` |
+| `curricula/DE/Gymnasium/input/BW/lower-secondary/source-extraction/DE_BW_CHEMIE_SEKI_BP2016_V2.source-extraction.json` | `yes` | `cee17e8a8d7f` | `2026-05-11T10:13:38Z` |
+| `curricula/DE/Gymnasium/input/BW/upper-secondary/source-extraction/DE_BW_CHEMIE_SEKII_BP2016_V2.source-extraction.json` | `yes` | `25d68fdafcb7` | `2026-05-11T10:13:39Z` |
+| `curricula/DE/Gymnasium/input/BY/gymnasium/source-extraction/DE_BY_BIOLOGISCH_CHEMISCHES_PRAKTIKUM_GYMNASIUM_LEHRPLANPLUS.source-extraction.json` | `yes` | `2343c4fd2e45` | `2026-05-11T02:37:43Z` |
+| `curricula/DE/Gymnasium/input/BY/gymnasium/source-extraction/DE_BY_CHEMIE_GYMNASIUM_LEHRPLANPLUS.source-extraction.json` | `yes` | `d8f6b835b007` | `2026-05-11T11:07:28Z` |
+| `curricula/DE/Gymnasium/input/HB/lower-secondary/source-extraction/DE_HB_CHEMIE_SEKI_BILDUNGSPLAN_2006_2022.source-extraction.json` | `yes` | `adc4f0446eed` | `2026-05-11T21:31:56Z` |
+| `curricula/DE/Gymnasium/input/HB/upper-secondary/source-extraction/DE_HB_CHEMIE_SEKII_GYO_2022.source-extraction.json` | `yes` | `3a928a968081` | `2026-05-11T21:37:33Z` |
+| `curricula/DE/Gymnasium/input/HE/lower-secondary/source-extraction/DE_HE_CHEMIE_SEKI_G9.source-extraction.json` | `yes` | `3b2584499c02` | `2026-05-11T01:55:09Z` |
+| `curricula/DE/Gymnasium/input/HE/lower-secondary/source-json/DE_HES_S_GYM_1_CHEMIE.de.json.snapshot` | `yes` | `a11a261b9166` | `2026-03-15T08:08:49Z` |
+| `curricula/DE/Gymnasium/input/HE/upper-secondary/source-extraction/DE_HE_CHEMIE_SEKII_KC2024.source-extraction.json` | `yes` | `7ee435bcdf39` | `2026-05-11T02:16:59Z` |
+| `curricula/DE/Gymnasium/input/HE/upper-secondary/source-json/DE_HES_S_GYM_2_CHEMIE.de.json.snapshot` | `yes` | `425d4d3a0b2d` | `2026-03-15T06:54:57Z` |
+| `curricula/DE/Gymnasium/input/HH/lower-secondary/source-extraction/DE_HH_CHEMIE_SEKI_BILDUNGSPLAN.source-extraction.json` | `yes` | `ec073c3aa3ce` | `2026-05-11T15:05:28Z` |
+| `curricula/DE/Gymnasium/input/HH/upper-secondary/source-extraction/DE_HH_CHEMIE_SEKII_BILDUNGSPLAN_2022.source-extraction.json` | `yes` | `c8754796e802` | `2026-05-11T15:05:28Z` |
+| `curricula/DE/Gymnasium/input/MV/lower-secondary/source-extraction/DE_MV_CHEMIE_SEKI_RAHMENPLAN_2021.source-extraction.json` | `yes` | `f8fe7064ab5d` | `2026-05-11T17:42:32Z` |
+| `curricula/DE/Gymnasium/input/MV/upper-secondary/source-extraction/DE_MV_CHEMIE_SEKII_RAHMENPLAN_ERPROBUNGSFASSUNG_2022.source-extraction.json` | `yes` | `1781d86d4e93` | `2026-05-11T17:42:32Z` |
+| `curricula/DE/Gymnasium/input/NI/lower-secondary/source-extraction/DE_NI_CHEMIE_SEKI_KC2015.source-extraction.json` | `yes` | `3c82664df56a` | `2026-05-11T13:06:03Z` |
+| `curricula/DE/Gymnasium/input/NI/upper-secondary/source-extraction/DE_NI_CHEMIE_SEKII_KC2022.source-extraction.json` | `yes` | `426a4c65902b` | `2026-05-11T12:14:36Z` |
+| `curricula/DE/Gymnasium/input/NW/lower-secondary/source-extraction/DE_NW_CHEMIE_SEKI_KLP2019.source-extraction.json` | `yes` | `6594569b7ed7` | `2026-05-11T13:44:52Z` |
+| `curricula/DE/Gymnasium/input/NW/upper-secondary/source-extraction/DE_NW_CHEMIE_SEKII_KLP2022.source-extraction.json` | `yes` | `63af0e8396ff` | `2026-05-11T13:44:52Z` |
+| `curricula/DE/Gymnasium/input/RP/lower-secondary/source-extraction/DE_RP_CHEMIE_SEKI_RAHMENLEHRPLAN_2014.source-extraction.json` | `yes` | `aef5035f5da0` | `2026-05-11T18:19:20Z` |
+| `curricula/DE/Gymnasium/input/RP/upper-secondary/source-extraction/DE_RP_CHEMIE_SEKII_MSS_2022.source-extraction.json` | `yes` | `a9397191898c` | `2026-05-11T18:19:20Z` |
+| `curricula/DE/Gymnasium/input/SH/lower-secondary/source-extraction/DE_SH_CHEMIE_SEKI_FACHANFORDERUNGEN_2022.source-extraction.json` | `yes` | `125612af7681` | `2026-05-11T14:26:04Z` |
+| `curricula/DE/Gymnasium/input/SH/upper-secondary/source-extraction/DE_SH_CHEMIE_SEKII_FACHANFORDERUNGEN_2022.source-extraction.json` | `yes` | `27026debce0a` | `2026-05-11T14:26:04Z` |
+| `curricula/DE/Gymnasium/input/SL/lower-secondary/source-extraction/DE_SL_CHEMIE_SEKI_GYM9_2024_2025.source-extraction.json` | `yes` | `04fd85550877` | `2026-05-11T19:49:02Z` |
+| `curricula/DE/Gymnasium/input/SL/upper-secondary/source-extraction/DE_SL_CHEMIE_SEKII_GOS_2023_2025.source-extraction.json` | `yes` | `b3cf9781a898` | `2026-05-11T19:49:02Z` |
+| `curricula/DE/Gymnasium/input/SN/lower-secondary/source-extraction/DE_SN_CHEMIE_SEKI_LEHRPLAN_GYMNASIUM_2025.source-extraction.json` | `yes` | `1de76385d9d7` | `2026-05-11T20:03:06Z` |
+| `curricula/DE/Gymnasium/input/SN/upper-secondary/source-extraction/DE_SN_CHEMIE_SEKII_LEHRPLAN_GYMNASIUM_2025.source-extraction.json` | `yes` | `7038aebf2dd7` | `2026-05-11T20:03:06Z` |
+| `curricula/DE/Gymnasium/input/ST/lower-secondary/source-extraction/DE_ST_CHEMIE_SEKI_FACHLEHRPLAN_GYMNASIUM_2022.source-extraction.json` | `yes` | `e5a7180e20ea` | `2026-05-11T17:22:28Z` |
+| `curricula/DE/Gymnasium/input/ST/upper-secondary/source-extraction/DE_ST_CHEMIE_SEKII_FACHLEHRPLAN_GYMNASIUM_2022.source-extraction.json` | `yes` | `42bc36093be6` | `2026-05-11T17:22:28Z` |
+| `curricula/DE/Gymnasium/input/TH/lower-secondary/source-extraction/DE_TH_CHEMIE_SEKI_LEHRPLAN_GYMNASIUM_2024.source-extraction.json` | `yes` | `86c6ba992412` | `2026-05-11T20:17:09Z` |
+| `curricula/DE/Gymnasium/input/TH/upper-secondary/source-extraction/DE_TH_CHEMIE_SEKII_LEHRPLAN_GYMNASIUM_2024.source-extraction.json` | `yes` | `ea18290c2a52` | `2026-05-11T20:17:09Z` |
+
+## `chemistry_mapping_watch`
+
+- Kind: `all_state_mapping_contract`
+- States: `DE-BB`, `DE-BE`, `DE-BW`, `DE-BY`, `DE-HB`, `DE-HE`, `DE-HH`, `DE-MV`, `DE-NI`, `DE-NW`, `DE-RP`, `DE-SH`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH`
+- Candidate rows:
+  - `reviewed source-extraction to canonical Chemistry mappings`
+  - `runtime legacy-to-canonical Chemistry mappings`
+- Reopen rule: Reopen mapping maintenance only if a watched mapping delta changes source-to-canonical coverage, runtime legacy translation, unsupported assigned-goal handling, or projected learner-facing totals.
+- Path globs:
+  - `curricula/DE/Gymnasium/mapping/**/*canonical_chemistry*.json`
+- Watched files:
+
+| File | Exists | SHA256-12 | Last modified (UTC) |
+| --- | --- | --- | --- |
+| `curricula/DE/Gymnasium/mapping/DE-BB/lower-secondary/bb_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `290d8e449c11` | `2026-05-11T21:05:05Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BB/lower-secondary/bb_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `8bb399e3b643` | `2026-05-11T21:59:09Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BB/upper-secondary/bb_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `427c3cbd1968` | `2026-05-11T15:35:03Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BB/upper-secondary/bb_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `1eb3bfa92c7d` | `2026-05-11T21:59:09Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BE/lower-secondary/be_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `b0365a6ba67f` | `2026-05-11T21:05:05Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BE/lower-secondary/be_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `6fa9acf7c7fe` | `2026-05-11T21:59:09Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BE/upper-secondary/be_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `69cc519d7433` | `2026-05-11T15:35:03Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BE/upper-secondary/be_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `9c2b7f995bd6` | `2026-05-11T21:59:09Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BW/lower-secondary/bw_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `2f72d20e10b5` | `2026-05-11T10:33:12Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BW/lower-secondary/bw_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `1bed92eb6290` | `2026-05-11T22:06:33Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BW/upper-secondary/bw_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `d9212ea8cc64` | `2026-05-11T11:10:06Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BW/upper-secondary/bw_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `193434b0857b` | `2026-05-11T22:06:33Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_biologisch_chemisches_praktikum_source_extraction_to_canonical_chemistry.review.json` | `yes` | `7c19e1746499` | `2026-05-11T09:53:47Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_biologisch_chemisches_praktikum_to_canonical_chemistry.json` | `yes` | `ccf01f85c6e3` | `2026-05-11T09:53:47Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_chemistry_source_extraction_to_canonical_chemistry.review.json` | `yes` | `21ca2e0a08ae` | `2026-05-11T11:07:28Z` |
+| `curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_chemistry_to_canonical_chemistry.json` | `yes` | `db30635f2d50` | `2026-03-16T06:00:11Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HB/lower-secondary/hb_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `5de3296f1a0e` | `2026-05-11T21:31:56Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HB/lower-secondary/hb_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `9b77ef5eab0a` | `2026-05-11T21:31:56Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HB/upper-secondary/hb_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `49132f31b035` | `2026-05-11T21:37:33Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HB/upper-secondary/hb_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `b05f9b3067a3` | `2026-05-11T21:37:33Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HE/lower-secondary/hessen_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `c2786b6bb4dd` | `2026-05-11T01:55:09Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HE/lower-secondary/hessen_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `5bbf502202f4` | `2026-03-15T09:11:44Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HE/upper-secondary/hessen_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `57f713b35ca0` | `2026-05-11T11:10:06Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HE/upper-secondary/hessen_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `1742bfb8230b` | `2026-03-13T16:57:34Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HH/lower-secondary/hh_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `1935005ce2f0` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HH/lower-secondary/hh_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `f71285ae2ebe` | `2026-05-11T22:17:34Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HH/upper-secondary/hh_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `446b05ed7282` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-HH/upper-secondary/hh_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `fc5ec4beb50d` | `2026-05-11T22:17:34Z` |
+| `curricula/DE/Gymnasium/mapping/DE-MV/lower-secondary/mv_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `9db9a53ac8ef` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-MV/lower-secondary/mv_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `ba106034ae1d` | `2026-05-11T22:44:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-MV/upper-secondary/mv_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `f749a9d2870c` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-MV/upper-secondary/mv_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `2f58812c3d6f` | `2026-05-11T22:44:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NI/lower-secondary/ni_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `5ce7f99327b7` | `2026-05-11T13:06:03Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NI/lower-secondary/ni_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `ca0f78f02e84` | `2026-05-11T23:11:44Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NI/upper-secondary/ni_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `4a1bda407b30` | `2026-05-11T15:35:03Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NI/upper-secondary/ni_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `1b4dad1d44e7` | `2026-05-11T23:11:44Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NW/lower-secondary/nrw_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `336afa38ae69` | `2026-05-11T13:44:52Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NW/lower-secondary/nrw_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `b10962d68890` | `2026-05-11T22:28:19Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NW/upper-secondary/nrw_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `98c0d136feaf` | `2026-05-11T13:44:52Z` |
+| `curricula/DE/Gymnasium/mapping/DE-NW/upper-secondary/nrw_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `35a79568f58d` | `2026-05-11T22:28:19Z` |
+| `curricula/DE/Gymnasium/mapping/DE-RP/lower-secondary/rp_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `ae4f292ec708` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-RP/lower-secondary/rp_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `032dbdcca337` | `2026-05-11T23:05:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-RP/upper-secondary/rp_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `31aadba54416` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-RP/upper-secondary/rp_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `413445dd9c64` | `2026-05-11T23:05:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SH/lower-secondary/sh_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `d3dfd43e6af4` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SH/lower-secondary/sh_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `601f001495e6` | `2026-05-11T22:55:48Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SH/upper-secondary/sh_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `545655ef9bc1` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SH/upper-secondary/sh_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `97c1d642406c` | `2026-05-11T22:55:48Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SL/lower-secondary/sl_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `3c1dff6057d0` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SL/lower-secondary/sl_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `8343cc40f266` | `2026-05-11T23:20:06Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SL/upper-secondary/sl_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `a652155822a6` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SL/upper-secondary/sl_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `13adeb20ba83` | `2026-05-11T23:20:06Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SN/lower-secondary/sn_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `dddf50c13902` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SN/lower-secondary/sn_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `4c65c491c7bf` | `2026-05-11T23:26:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SN/upper-secondary/sn_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `f322b78ad1af` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-SN/upper-secondary/sn_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `8ec025fbb759` | `2026-05-11T23:26:24Z` |
+| `curricula/DE/Gymnasium/mapping/DE-ST/lower-secondary/st_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `b12d6fbf1e23` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-ST/lower-secondary/st_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `dae00e1cf5ae` | `2026-05-11T23:32:44Z` |
+| `curricula/DE/Gymnasium/mapping/DE-ST/upper-secondary/st_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `70f28dddbdfa` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/mapping/DE-ST/upper-secondary/st_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `58e8e3c88a14` | `2026-05-11T23:32:44Z` |
+| `curricula/DE/Gymnasium/mapping/DE-TH/lower-secondary/th_chemistry_lower_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `de0028d2a247` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-TH/lower-secondary/th_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `9d7e465d5199` | `2026-05-11T23:38:28Z` |
+| `curricula/DE/Gymnasium/mapping/DE-TH/upper-secondary/th_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `e3310405c9d2` | `2026-05-11T20:16:54Z` |
+| `curricula/DE/Gymnasium/mapping/DE-TH/upper-secondary/th_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `96b6c8283587` | `2026-05-11T23:38:28Z` |
+
+## `chemistry_composition_view_watch`
+
+- Kind: `all_state_composition_view_contract`
+- States: `DE-BB`, `DE-BE`, `DE-BW`, `DE-BY`, `DE-HB`, `DE-HE`, `DE-HH`, `DE-MV`, `DE-NI`, `DE-NW`, `DE-RP`, `DE-SH`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH`
+- Candidate rows:
+  - `country-level Chemistry composition views`
+  - `state-level GK/LK Chemistry composition views`
+- Reopen rule: Reopen composition-view maintenance only if a view delta changes the single-occurrence learner-facing tree, GK/LK eligibility, or a state-specific visible Chemistry scope.
+- Path globs:
+  - `curricula/DE/Gymnasium/composition-views/chemie/*.view.json`
+- Watched files:
+
+| File | Exists | SHA256-12 | Last modified (UTC) |
+| --- | --- | --- | --- |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-bb-gk.view.json` | `yes` | `41be795c3ab0` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-bb-lk.view.json` | `yes` | `7b2b8027aa32` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-be-gk.view.json` | `yes` | `00de28f46bfc` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-be-lk.view.json` | `yes` | `a6f8659c8e2c` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-bw-gk.view.json` | `yes` | `47f10802b3ac` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-bw-lk.view.json` | `yes` | `885046fffccb` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-chemistry-gk.view.json` | `yes` | `e0f2a559877f` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-chemistry-lk.view.json` | `yes` | `98138ba639d2` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-seki-chemistry.view.json` | `yes` | `0c3b1a0d01f7` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-sekii-chemistry-gk.view.json` | `yes` | `557120ec43ba` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-de-gym-sekii-chemistry-lk.view.json` | `yes` | `19ef4ce9f43c` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-hb-gk.view.json` | `yes` | `f852417ae6cb` | `2026-05-11T21:37:33Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-hb-lk.view.json` | `yes` | `a409d1898512` | `2026-05-11T21:37:33Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-he-gk.view.json` | `yes` | `16e324150bda` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-he-lk.view.json` | `yes` | `56f97a454a76` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-he-sekii-gk.view.json` | `yes` | `db629d8607b7` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-he-sekii-lk.view.json` | `yes` | `155cc907ea9b` | `2026-05-11T02:26:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-hh-gk.view.json` | `yes` | `874d29a69f22` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-hh-lk.view.json` | `yes` | `64ff5cd26a28` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-mv-gk.view.json` | `yes` | `5e8bfdfd7352` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-mv-lk.view.json` | `yes` | `54d36dab1c09` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-ni-gk.view.json` | `yes` | `748cd07e689c` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-ni-lk.view.json` | `yes` | `3545b804797b` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-nw-gk.view.json` | `yes` | `a30203b5f358` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-nw-lk.view.json` | `yes` | `bc353105f015` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-rp-gk.view.json` | `yes` | `65367171f96a` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-rp-lk.view.json` | `yes` | `13cb9341d58b` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sh-gk.view.json` | `yes` | `43375c07fdd6` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sh-lk.view.json` | `yes` | `139989e1b39f` | `2026-05-11T15:47:52Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sl-gk.view.json` | `yes` | `5f56d33f12a2` | `2026-05-11T20:17:00Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sl-lk.view.json` | `yes` | `08601112c3f6` | `2026-05-11T20:17:00Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sn-gk.view.json` | `yes` | `3c93f6075692` | `2026-05-11T20:17:00Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-sn-lk.view.json` | `yes` | `e91e08acf280` | `2026-05-11T20:17:00Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-st-gk.view.json` | `yes` | `cf066a700e01` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-st-lk.view.json` | `yes` | `e81c9fb0d498` | `2026-05-11T20:22:42Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-th-gk.view.json` | `yes` | `45b193b3ebdc` | `2026-05-11T20:17:00Z` |
+| `curricula/DE/Gymnasium/composition-views/chemie/de-th-lk.view.json` | `yes` | `5e68c712aabf` | `2026-05-11T20:17:00Z` |
+
+## Regeneration
+
+```bash
+python3 scripts/canonical_chemistry_evidence_watch.py render-status
+./scripts/run_canonical_chemistry_evidence_watch.sh
+```

--- a/scripts/canonical_chemistry_evidence_watch.py
+++ b/scripts/canonical_chemistry_evidence_watch.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json"
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def short_hash(value: str | None) -> str:
+    if not value:
+        return "-"
+    return value[:12]
+
+
+def format_mtime_utc(path: Path) -> str:
+    timestamp = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    return timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def expand_glob(pattern: str) -> list[str]:
+    return sorted(
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in REPO_ROOT.glob(pattern)
+        if path.is_file()
+    )
+
+
+def target_paths(target: dict) -> list[str]:
+    paths = {
+        rel_path
+        for rel_path in target.get("paths", [])
+        if isinstance(rel_path, str)
+    }
+    for pattern in target.get("pathGlobs", []):
+        if isinstance(pattern, str):
+            paths.update(expand_glob(pattern))
+    return sorted(paths)
+
+
+def unique_watch_paths(manifest: dict) -> list[str]:
+    return sorted(
+        {
+            rel_path
+            for target in manifest.get("watchTargets", [])
+            for rel_path in target_paths(target)
+        }
+    )
+
+
+def declared_ref_count(target: dict) -> int:
+    return len(target.get("paths", [])) + len(target.get("pathGlobs", []))
+
+
+def current_record(rel_path: str) -> dict[str, str | bool | None]:
+    path = REPO_ROOT / rel_path
+    exists = path.exists()
+    return {
+        "relativePath": rel_path,
+        "exists": exists,
+        "sha256": sha256(path) if exists else None,
+        "lastModifiedUtc": format_mtime_utc(path) if exists else None,
+    }
+
+
+def display_record(rel_path: str) -> dict[str, str | bool]:
+    record = current_record(rel_path)
+    return {
+        "relativePath": rel_path,
+        "exists": record["exists"],
+        "sha256Prefix": short_hash(record["sha256"]),
+        "lastModifiedUtc": record["lastModifiedUtc"] or "-",
+    }
+
+
+def diff_records(manifest: dict, baseline: dict) -> tuple[dict, list[str], list[str], list[str], list[str]]:
+    current_paths = unique_watch_paths(manifest)
+    baseline_records = {
+        record["relativePath"]: record
+        for record in baseline.get("watchedFiles", [])
+        if isinstance(record, dict) and isinstance(record.get("relativePath"), str)
+    }
+    current_records = {rel_path: current_record(rel_path) for rel_path in current_paths}
+
+    added_paths = sorted(set(current_records) - set(baseline_records))
+    removed_paths = sorted(set(baseline_records) - set(current_records))
+    changed_paths = []
+    unchanged_paths = []
+    for rel_path in sorted(set(current_records) & set(baseline_records)):
+        baseline_record = baseline_records[rel_path]
+        current = current_records[rel_path]
+        if (
+            baseline_record.get("exists") != current.get("exists")
+            or baseline_record.get("sha256") != current.get("sha256")
+        ):
+            changed_paths.append(rel_path)
+        else:
+            unchanged_paths.append(rel_path)
+
+    delta = {
+        "baselineRecords": baseline_records,
+        "currentRecords": current_records,
+    }
+    return delta, changed_paths, added_paths, removed_paths, unchanged_paths
+
+
+def capture_baseline() -> None:
+    manifest = load_json(MANIFEST_PATH)
+    watched_files = [current_record(rel_path) for rel_path in unique_watch_paths(manifest)]
+
+    baseline = {
+        "version": 1,
+        "updatedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "manifestVersion": manifest.get("version"),
+        "manifestUpdatedAt": manifest.get("updatedAt"),
+        "mode": manifest.get("mode"),
+        "watchedFileCount": len(watched_files),
+        "watchedFiles": watched_files,
+    }
+
+    output_path = REPO_ROOT / manifest["baselinePath"]
+    output_path.write_text(json.dumps(baseline, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def render_status() -> str:
+    manifest = load_json(MANIFEST_PATH)
+    targets = manifest.get("watchTargets", [])
+
+    unique_paths = unique_watch_paths(manifest)
+    unique_records = [display_record(rel_path) for rel_path in unique_paths]
+    existing_unique_records = [record for record in unique_records if record["exists"]]
+    missing_unique_records = [record for record in unique_records if not record["exists"]]
+    kind_counts = Counter(
+        target["kind"] for target in targets if isinstance(target, dict) and isinstance(target.get("kind"), str)
+    )
+    watched_states = sorted(
+        {
+            state
+            for target in targets
+            for state in target.get("states", [])
+            if isinstance(state, str)
+        }
+    )
+    expanded_path_count = sum(len(target_paths(target)) for target in targets)
+
+    lines: list[str] = []
+    lines.append("# Canonical Gymnasium Chemistry Evidence Watch Status")
+    lines.append("")
+    lines.append(f"Snapshot: `{manifest['updatedAt']}`")
+    lines.append("")
+    lines.append("This file is generated from:")
+    lines.append("")
+    lines.append(f"- `{MANIFEST_PATH.relative_to(REPO_ROOT)}`")
+    lines.append(f"- `{Path(__file__).relative_to(REPO_ROOT)}`")
+    lines.append("")
+    lines.append("## Headline")
+    lines.append("")
+    lines.append(f"- Watch mode: `{manifest.get('mode', 'maintenance_evidence_watch')}`")
+    lines.append(f"- Watch targets: `{len(targets)}`")
+    lines.append(f"- Watched state set: `{len(watched_states)}`")
+    lines.append(f"- Declared path references across all targets: `{sum(declared_ref_count(target) for target in targets)}`")
+    lines.append(f"- Expanded path references across all targets: `{expanded_path_count}`")
+    lines.append(f"- Unique watched files: `{len(unique_records)}`")
+    lines.append(f"- Existing watched files: `{len(existing_unique_records)}/{len(unique_records)}`")
+    lines.append(f"- Missing watched files: `{len(missing_unique_records)}`")
+    lines.append("")
+    lines.append("## Watch kinds")
+    lines.append("")
+    lines.append("| Kind | Count |")
+    lines.append("| --- | ---: |")
+    for kind, count in sorted(kind_counts.items()):
+        lines.append(f"| `{kind}` | `{count}` |")
+    lines.append("")
+    lines.append("## Watch target register")
+    lines.append("")
+    lines.append("| Target | Kind | States | Candidate rows | Declared refs | Expanded files | Missing files |")
+    lines.append("| --- | --- | --- | --- | ---: | ---: | ---: |")
+    for target in targets:
+        paths = target_paths(target)
+        states = ", ".join(f"`{state}`" for state in target.get("states", []))
+        candidate_rows = "<br>".join(target.get("candidateRows", []))
+        missing_count = sum(1 for rel_path in paths if not (REPO_ROOT / rel_path).exists())
+        lines.append(
+            f"| `{target['id']}` | `{target['kind']}` | {states} | {candidate_rows} | "
+            f"`{declared_ref_count(target)}` | `{len(paths)}` | `{missing_count}` |"
+        )
+
+    lines.append("")
+    lines.append("## Unique file register")
+    lines.append("")
+    lines.append("| File | Exists | SHA256-12 | Last modified (UTC) |")
+    lines.append("| --- | --- | --- | --- |")
+    for record in unique_records:
+        exists = "yes" if record["exists"] else "no"
+        lines.append(
+            f"| `{record['relativePath']}` | `{exists}` | `{record['sha256Prefix']}` | `{record['lastModifiedUtc']}` |"
+        )
+
+    for target in targets:
+        lines.append("")
+        lines.append(f"## `{target['id']}`")
+        lines.append("")
+        lines.append(f"- Kind: `{target['kind']}`")
+        lines.append(f"- States: {', '.join(f'`{state}`' for state in target.get('states', []))}")
+        lines.append("- Candidate rows:")
+        for row in target.get("candidateRows", []):
+            lines.append(f"  - `{row}`")
+        lines.append(f"- Reopen rule: {target['reopenRule']}")
+        if target.get("pathGlobs"):
+            lines.append("- Path globs:")
+            for pattern in target.get("pathGlobs", []):
+                lines.append(f"  - `{pattern}`")
+        lines.append("- Watched files:")
+        lines.append("")
+        lines.append("| File | Exists | SHA256-12 | Last modified (UTC) |")
+        lines.append("| --- | --- | --- | --- |")
+        for rel_path in target_paths(target):
+            record = display_record(rel_path)
+            exists = "yes" if record["exists"] else "no"
+            lines.append(
+                f"| `{record['relativePath']}` | `{exists}` | `{record['sha256Prefix']}` | `{record['lastModifiedUtc']}` |"
+            )
+
+    lines.append("")
+    lines.append("## Regeneration")
+    lines.append("")
+    lines.append("```bash")
+    lines.append(manifest["statusCommand"])
+    if "runCommand" in manifest:
+        lines.append(manifest["runCommand"])
+    lines.append("```")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_status() -> None:
+    manifest = load_json(MANIFEST_PATH)
+    output_path = REPO_ROOT / manifest["statusViewPath"]
+    output_path.write_text(render_status(), encoding="utf-8")
+
+
+def render_delta() -> str:
+    manifest = load_json(MANIFEST_PATH)
+    baseline = load_json(REPO_ROOT / manifest["baselinePath"])
+    targets = manifest.get("watchTargets", [])
+    delta, changed_paths, added_paths, removed_paths, unchanged_paths = diff_records(manifest, baseline)
+    baseline_records = delta["baselineRecords"]
+    current_records = delta["currentRecords"]
+
+    lines: list[str] = []
+    lines.append("# Canonical Gymnasium Chemistry Evidence Watch Delta")
+    lines.append("")
+    lines.append(f"Snapshot: `{datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}`")
+    lines.append("")
+    lines.append("This file is generated from:")
+    lines.append("")
+    lines.append(f"- `{MANIFEST_PATH.relative_to(REPO_ROOT)}`")
+    lines.append(f"- `{Path(manifest['baselinePath'])}`")
+    lines.append(f"- `{Path(__file__).relative_to(REPO_ROOT)}`")
+    lines.append("")
+    lines.append("## Headline")
+    lines.append("")
+    lines.append(f"- Baseline snapshot: `{baseline.get('updatedAt', '-')}`")
+    lines.append(f"- Current watched files: `{len(current_records)}`")
+    lines.append(f"- Unchanged watched files: `{len(unchanged_paths)}`")
+    lines.append(f"- Changed watched files: `{len(changed_paths)}`")
+    lines.append(f"- Added watch paths since baseline: `{len(added_paths)}`")
+    lines.append(f"- Removed watch paths since baseline: `{len(removed_paths)}`")
+    lines.append("")
+    lines.append("## Interpretation")
+    lines.append("")
+    lines.append("- A file-level delta is a maintenance signal, not an automatic rollout reopen.")
+    lines.append("- Reopen remains gated by the documented reopen rules in the watch manifest.")
+    lines.append("")
+    lines.append("## Changed files")
+    lines.append("")
+    if not changed_paths:
+        lines.append("- none")
+    else:
+        lines.append("| File | Exists (baseline -> current) | SHA256-12 (baseline -> current) | Last modified UTC (baseline -> current) |")
+        lines.append("| --- | --- | --- | --- |")
+        for rel_path in changed_paths:
+            baseline_record = baseline_records[rel_path]
+            current = current_records[rel_path]
+            lines.append(
+                f"| `{rel_path}` | `{baseline_record.get('exists')} -> {current.get('exists')}` | "
+                f"`{short_hash(baseline_record.get('sha256'))} -> {short_hash(current.get('sha256'))}` | "
+                f"`{baseline_record.get('lastModifiedUtc') or '-'} -> {current.get('lastModifiedUtc') or '-'}` |"
+            )
+
+    lines.append("")
+    lines.append("## Added watch paths")
+    lines.append("")
+    if not added_paths:
+        lines.append("- none")
+    else:
+        for rel_path in added_paths:
+            lines.append(f"- `{rel_path}`")
+
+    lines.append("")
+    lines.append("## Removed watch paths")
+    lines.append("")
+    if not removed_paths:
+        lines.append("- none")
+    else:
+        for rel_path in removed_paths:
+            lines.append(f"- `{rel_path}`")
+
+    lines.append("")
+    lines.append("## Target delta register")
+    lines.append("")
+    lines.append("| Target | Changed files | Added paths | Removed paths |")
+    lines.append("| --- | ---: | ---: | ---: |")
+    for target in targets:
+        paths = target_paths(target)
+        target_changed = sum(1 for rel_path in paths if rel_path in changed_paths)
+        target_added = sum(1 for rel_path in paths if rel_path in added_paths)
+        target_removed = sum(1 for rel_path in removed_paths if rel_path in paths)
+        lines.append(f"| `{target['id']}` | `{target_changed}` | `{target_added}` | `{target_removed}` |")
+
+    lines.append("")
+    lines.append("## Regeneration")
+    lines.append("")
+    lines.append("```bash")
+    lines.append(manifest["baselineCommand"])
+    lines.append(manifest["deltaCommand"])
+    if "checkCommand" in manifest:
+        lines.append(manifest["checkCommand"])
+    if "runCommand" in manifest:
+        lines.append(manifest["runCommand"])
+    lines.append("```")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_delta() -> None:
+    manifest = load_json(MANIFEST_PATH)
+    output_path = REPO_ROOT / manifest["deltaViewPath"]
+    output_path.write_text(render_delta(), encoding="utf-8")
+
+
+def check_delta() -> None:
+    manifest = load_json(MANIFEST_PATH)
+    baseline = load_json(REPO_ROOT / manifest["baselinePath"])
+    _, changed_paths, added_paths, removed_paths, _ = diff_records(manifest, baseline)
+
+    print(
+        f"chemistry-evidence-watch: changed={len(changed_paths)} added={len(added_paths)} removed={len(removed_paths)}"
+    )
+    for rel_path in changed_paths:
+        print(f"CHANGED {rel_path}")
+    for rel_path in added_paths:
+        print(f"ADDED {rel_path}")
+    for rel_path in removed_paths:
+        print(f"REMOVED {rel_path}")
+
+    if changed_paths or added_paths or removed_paths:
+        sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render and check the canonical Chemistry evidence watch.")
+    parser.add_argument(
+        "command",
+        choices=("capture-baseline", "render-status", "render-delta", "check-delta"),
+    )
+    args = parser.parse_args()
+
+    if args.command == "capture-baseline":
+        capture_baseline()
+    elif args.command == "render-status":
+        write_status()
+    elif args.command == "render-delta":
+        write_delta()
+    elif args.command == "check-delta":
+        check_delta()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_canonical_chemistry_evidence_watch.sh
+++ b/scripts/run_canonical_chemistry_evidence_watch.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASELINE_PATH="$ROOT_DIR/curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json"
+
+cd "$ROOT_DIR"
+
+if [[ ! -f "$BASELINE_PATH" ]]; then
+  echo "chemistry-evidence-watch: baseline missing at $BASELINE_PATH" >&2
+  echo "Run: python3 scripts/canonical_chemistry_evidence_watch.py capture-baseline" >&2
+  exit 2
+fi
+
+python3 scripts/canonical_chemistry_evidence_watch.py render-status
+python3 scripts/canonical_chemistry_evidence_watch.py render-delta
+python3 scripts/canonical_chemistry_evidence_watch.py check-delta
+
+echo "CHEMISTRY_EVIDENCE_WATCH=OK"


### PR DESCRIPTION
## Summary
- add a canonical Chemistry evidence-watch workflow for source, mapping, composition-view, canonical graph, and tracker drift
- add manifest, baseline, generated status, and generated delta docs for the P6 maintenance lane
- add a local runner and Python subcommands for baseline capture, status/delta rendering, and delta checks

## Validation
- ./scripts/run_canonical_chemistry_evidence_watch.sh
- python3 -m py_compile scripts/canonical_chemistry_evidence_watch.py
- python3 -m json.tool curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json
- python3 -m json.tool curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/canonical_chemistry_evidence_watch.yml")'
- git diff --cached --check
- ./run_ci.sh