### PR TITLE
Wire chemistry tracker to evidence watch

### DIFF
--- a/curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json
+++ b/curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json
@@ -1,10 +1,17 @@
 {
   "version": 1,
-  "updatedAt": "2026-05-11T23:39:34Z",
+  "updatedAt": "2026-05-12T01:05:00Z",
   "landscapePath": "curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json",
   "quickViewPath": "docs/dev/canonical-gymnasium-chemistry-bundeslaender-status.md",
   "qualityStatusPath": "docs/qa-ci/status/curriculum-quality-status.json",
   "renderCommand": "python3 scripts/render_canonical_chemistry_bundesland_status.py",
+  "evidenceWatch": {
+    "manifestPath": "curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json",
+    "statusViewPath": "docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md",
+    "deltaViewPath": "docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md",
+    "runCommand": "./scripts/run_canonical_chemistry_evidence_watch.sh",
+    "workflowPath": ".github/workflows/canonical_chemistry_evidence_watch.yml"
+  },
   "phaseScale": [
     {
       "id": "P0",
@@ -77,7 +84,7 @@
     },
     {
       "id": "F5",
-      "title": "Cutover and maintenance",
+      "title": "Cutover, maintenance, and evidence watch",
       "status": "active"
     }
   ],
@@ -194,7 +201,7 @@
         "DE-ST",
         "DE-TH"
       ],
-      "nextStep": "Keep cutover-ready Chemistry states on maintenance only: refresh retained source evidence, runtime mappings, archive-only fences, composition views, and learner migration checks together when a source revision changes visible scope."
+      "nextStep": "Chemistry is now in P6 maintenance / evidence-watch mode with no open canonical residue lane. Use the machine-readable watch manifest `curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json`, the rendered watch status `docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md`, the baseline-driven delta view `docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md`, the fixed run path `./scripts/run_canonical_chemistry_evidence_watch.sh`, and the scheduled workflow `.github/workflows/canonical_chemistry_evidence_watch.yml` as the operational watch surface. Keep cutover-ready Chemistry states on maintenance only: refresh retained source evidence, runtime mappings, archive-only fences, composition views, and learner migration checks together only when a source revision or watched file delta changes visible scope."
     }
   ],
   "states": [

--- a/curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json
+++ b/curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-05-12T00:49:35Z",
+  "updatedAt": "2026-05-12T01:06:50Z",
   "manifestVersion": 1,
   "manifestUpdatedAt": "2026-05-12T00:00:00Z",
   "mode": "maintenance_evidence_watch",
@@ -825,8 +825,8 @@
     {
       "relativePath": "curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json",
       "exists": true,
-      "sha256": "4a02266a50b72d73585a13b5cae5b17280e868c7376e27cbb937709e1beab9c9",
-      "lastModifiedUtc": "2026-05-11T23:39:34Z"
+      "sha256": "8d5b1a12a19aea7ddc88b97142814f567634cf1e56f9a0c840efb83b0680b01e",
+      "lastModifiedUtc": "2026-05-12T01:06:36Z"
     }
   ]
 }

--- a/docs/dev/canonical-gymnasium-chemistry-all-states-cutover-completion-audit.md
+++ b/docs/dev/canonical-gymnasium-chemistry-all-states-cutover-completion-audit.md
@@ -32,6 +32,11 @@ All 16 tracked states are source-backed, projection-clean, and operationally cut
   - `curricula/DE/Gymnasium/provenance/source-landscape-registry.json`
 - Learner-facing composition views:
   - `curricula/DE/Gymnasium/composition-views/chemie/*.view.json`
+- Evidence watch:
+  - `curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json`
+  - `docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md`
+  - `docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md`
+  - `.github/workflows/canonical_chemistry_evidence_watch.yml`
 
 ## Runtime Notes
 
@@ -47,6 +52,8 @@ Retained state source-extraction landscapes are archive-only compatibility surfa
 
 Keep all states on P6 maintenance. When an official source revision changes a visible scope, refresh the source extraction, reviewed mapping, runtime mapping, source-only archive fence, and relevant composition views together.
 
+Use `./scripts/run_canonical_chemistry_evidence_watch.sh` as the fixed local maintenance gate. A file-level watch delta is a signal for review, not an automatic rollout reopen; reopen active Chemistry rollout only when the manifest's documented reopen rule for the affected target is satisfied.
+
 ## Verification
 
 Current focused verification path:
@@ -56,6 +63,7 @@ Current focused verification path:
   --tests com.skillpilot.backend.landscape.LandscapeServiceTest \
   --tests com.skillpilot.backend.landscape.GoalMappingRepositoryFixtureTest
 python3 scripts/render_canonical_chemistry_bundesland_status.py
+./scripts/run_canonical_chemistry_evidence_watch.sh
 python3 scripts/validate_schemas.py
 (cd app && npm run validate:graph)
 (cd app && npm run validate:composition-views)

--- a/docs/dev/canonical-gymnasium-chemistry-bundeslaender-status.md
+++ b/docs/dev/canonical-gymnasium-chemistry-bundeslaender-status.md
@@ -1,6 +1,6 @@
 # Canonical Gymnasium Chemistry Bundeslaender Status
 
-Snapshot: `2026-05-11T23:39:34Z`
+Snapshot: `2026-05-12T01:05:00Z`
 
 This file is generated from:
 
@@ -8,6 +8,7 @@ This file is generated from:
 - `curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json`
 - `docs/qa-ci/status/curriculum-quality-status.json`
 - Chemistry `*.source-extraction.json` files under `curricula/DE/Gymnasium/input`
+- `curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json`
 - `scripts/render_canonical_chemistry_bundesland_status.py`
 
 ## Headline
@@ -26,6 +27,15 @@ This file is generated from:
 - States operationally cutover-ready (`P6`): `16/16`
 - Active canonical corridors: `1/6`
 - Priority `backlog`: `16`
+
+## Evidence watch
+
+- Manifest: `curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json`
+- Status view: `docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md`
+- Delta view: `docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md`
+- Local run: `./scripts/run_canonical_chemistry_evidence_watch.sh`
+- Scheduled workflow: `.github/workflows/canonical_chemistry_evidence_watch.yml`
+- Interpretation: file-level deltas are maintenance signals; active rollout reopens only when the watch manifest's documented reopen rules are satisfied.
 
 ## Steering model
 
@@ -52,7 +62,7 @@ This file is generated from:
 | `CHEM.REMAINING_SOURCE_ONBOARDING` Remaining Chemistry source onboarding tranche | `completed` | `DE-MV`, `DE-RP`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH` | All tracked Chemistry Bundesland source lanes are source-backed and clean on P4; keep the source onboarding tranche closed unless an official source revision changes evidence. |
 | `CHEM.HORIZONTAL_TOPIC_GAP_REVIEW` Horizontal all-state Chemistry topic-gap review | `completed` | `DE-BB`, `DE-BE`, `DE-BW`, `DE-BY`, `DE-HB`, `DE-HE`, `DE-HH`, `DE-MV`, `DE-NI`, `DE-NW`, `DE-RP`, `DE-SH`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH` | F4 is closed: 710 broad cluster-target mappings were reviewed or accepted as package evidence, with no shared canonical atom gap proven. |
 | `CHEM.P5_BROADENING_AND_CUTOVER_MAINTENANCE` P5 broad coverage and cutover maintenance | `completed` | - | All tracked Chemistry Bundesland lanes are cutover-ready on P6; reopen this corridor only if a source revision or runtime regression creates a non-cutover maintenance lane. |
-| `CHEM.P6_CUTOVER_READY_MAINTENANCE` P6 cutover-ready Chemistry maintenance | `active` | `DE-BB`, `DE-BE`, `DE-BW`, `DE-BY`, `DE-HB`, `DE-HE`, `DE-HH`, `DE-MV`, `DE-NI`, `DE-NW`, `DE-RP`, `DE-SH`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH` | Keep cutover-ready Chemistry states on maintenance only: refresh retained source evidence, runtime mappings, archive-only fences, composition views, and learner migration checks together when a source revision changes visible scope. |
+| `CHEM.P6_CUTOVER_READY_MAINTENANCE` P6 cutover-ready Chemistry maintenance | `active` | `DE-BB`, `DE-BE`, `DE-BW`, `DE-BY`, `DE-HB`, `DE-HE`, `DE-HH`, `DE-MV`, `DE-NI`, `DE-NW`, `DE-RP`, `DE-SH`, `DE-SL`, `DE-SN`, `DE-ST`, `DE-TH` | Chemistry is now in P6 maintenance / evidence-watch mode with no open canonical residue lane. Use the machine-readable watch manifest `curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-manifest.json`, the rendered watch status `docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md`, the baseline-driven delta view `docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md`, the fixed run path `./scripts/run_canonical_chemistry_evidence_watch.sh`, and the scheduled workflow `.github/workflows/canonical_chemistry_evidence_watch.yml` as the operational watch surface. Keep cutover-ready Chemistry states on maintenance only: refresh retained source evidence, runtime mappings, archive-only fences, composition views, and learner migration checks together only when a source revision or watched file delta changes visible scope. |
 
 ## Program phases
 
@@ -63,7 +73,7 @@ This file is generated from:
 | `F2` Ten-state source-backed projection pass | `completed` |
 | `F3` Remaining state source onboarding | `completed` |
 | `F4` Horizontal all-state Chemistry topic pass | `completed` |
-| `F5` Cutover and maintenance | `active` |
+| `F5` Cutover, maintenance, and evidence watch | `active` |
 
 ## State phase scale
 

--- a/docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md
+++ b/docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md
@@ -1,6 +1,6 @@
 # Canonical Gymnasium Chemistry Evidence Watch Delta
 
-Snapshot: `2026-05-12T00:49:38Z`
+Snapshot: `2026-05-12T01:14:26Z`
 
 This file is generated from:
 
@@ -10,7 +10,7 @@ This file is generated from:
 
 ## Headline
 
-- Baseline snapshot: `2026-05-12T00:49:35Z`
+- Baseline snapshot: `2026-05-12T01:06:50Z`
 - Current watched files: `137`
 - Unchanged watched files: `137`
 - Changed watched files: `0`

--- a/docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md
+++ b/docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md
@@ -176,7 +176,7 @@ This file is generated from:
 | `curricula/DE/Gymnasium/mapping/DE-TH/lower-secondary/th_chemistry_lower_secondary_to_canonical_chemistry.json` | `yes` | `9d7e465d5199` | `2026-05-11T23:38:28Z` |
 | `curricula/DE/Gymnasium/mapping/DE-TH/upper-secondary/th_chemistry_upper_secondary_source_extraction_to_canonical_chemistry.review.json` | `yes` | `e3310405c9d2` | `2026-05-11T20:16:54Z` |
 | `curricula/DE/Gymnasium/mapping/DE-TH/upper-secondary/th_chemistry_upper_secondary_to_canonical_chemistry.json` | `yes` | `96b6c8283587` | `2026-05-11T23:38:28Z` |
-| `curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json` | `yes` | `4a02266a50b7` | `2026-05-11T23:39:34Z` |
+| `curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json` | `yes` | `8d5b1a12a19a` | `2026-05-12T01:06:36Z` |
 
 ## `chemistry_canonical_and_tracker_watch`
 
@@ -191,7 +191,7 @@ This file is generated from:
 | File | Exists | SHA256-12 | Last modified (UTC) |
 | --- | --- | --- | --- |
 | `curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json` | `yes` | `caf2314e8166` | `2026-05-11T23:54:30Z` |
-| `curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json` | `yes` | `4a02266a50b7` | `2026-05-11T23:39:34Z` |
+| `curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json` | `yes` | `8d5b1a12a19a` | `2026-05-12T01:06:36Z` |
 
 ## `chemistry_source_evidence_watch`
 

--- a/scripts/render_canonical_chemistry_bundesland_status.py
+++ b/scripts/render_canonical_chemistry_bundesland_status.py
@@ -95,6 +95,7 @@ def render() -> str:
     states = tracker["states"]
     canonical_corridors = tracker.get("canonicalCorridors", [])
     steering_model = tracker.get("steeringModel", {})
+    evidence_watch = tracker.get("evidenceWatch", {})
     priority_order = {"active": 0, "next_wave": 1, "backlog": 2}
 
     rows = []
@@ -159,6 +160,9 @@ def render() -> str:
     lines.append(f"- `{tracker['landscapePath']}`")
     lines.append(f"- `{QUALITY_STATUS_PATH.relative_to(REPO_ROOT)}`")
     lines.append(f"- Chemistry `*.source-extraction.json` files under `{SOURCE_EXTRACTION_ROOT.relative_to(REPO_ROOT)}`")
+    manifest_path = evidence_watch.get("manifestPath")
+    if isinstance(manifest_path, str):
+        lines.append(f"- `{manifest_path}`")
     lines.append(f"- `{Path(__file__).relative_to(REPO_ROOT)}`")
     lines.append("")
     lines.append("## Headline")
@@ -197,6 +201,29 @@ def render() -> str:
     for priority in sorted(priority_counts, key=lambda value: priority_order.get(value, 99)):
         lines.append(f"- Priority `{priority}`: `{priority_counts[priority]}`")
     lines.append("")
+
+    if evidence_watch:
+        lines.append("## Evidence watch")
+        lines.append("")
+        status_view_path = evidence_watch.get("statusViewPath")
+        delta_view_path = evidence_watch.get("deltaViewPath")
+        run_command = evidence_watch.get("runCommand")
+        workflow_path = evidence_watch.get("workflowPath")
+        if isinstance(manifest_path, str):
+            lines.append(f"- Manifest: `{manifest_path}`")
+        if isinstance(status_view_path, str):
+            lines.append(f"- Status view: `{status_view_path}`")
+        if isinstance(delta_view_path, str):
+            lines.append(f"- Delta view: `{delta_view_path}`")
+        if isinstance(run_command, str):
+            lines.append(f"- Local run: `{run_command}`")
+        if isinstance(workflow_path, str):
+            lines.append(f"- Scheduled workflow: `{workflow_path}`")
+        lines.append(
+            "- Interpretation: file-level deltas are maintenance signals; active rollout reopens only when "
+            "the watch manifest's documented reopen rules are satisfied."
+        )
+        lines.append("")
 
     if steering_model:
         lines.append("## Steering model")


### PR DESCRIPTION
## Summary
- connect the chemistry rollout tracker to the evidence watch manifest, generated status, delta view, local runner, and scheduled workflow
- render an explicit Evidence watch section in the generated chemistry Bundeslaender status page
- update the all-state cutover audit with the new watch maintenance rule

## Validation
- python3 scripts/render_canonical_chemistry_bundesland_status.py
- ./scripts/run_canonical_chemistry_evidence_watch.sh
- python3 -m py_compile scripts/render_canonical_chemistry_bundesland_status.py scripts/canonical_chemistry_evidence_watch.py
- python3 -m json.tool curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json
- python3 -m json.tool curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json
- git diff --check
- git diff --cached --check
- ./run_ci.sh