### PR TITLE
[codex] Promote chemistry route coverage to M5

### DIFF
--- a/backend/src/test/java/com/skillpilot/backend/service/LearnerServiceCanonicalProjectionTest.java
+++ b/backend/src/test/java/com/skillpilot/backend/service/LearnerServiceCanonicalProjectionTest.java
@@ -171,6 +171,7 @@ class LearnerServiceCanonicalProjectionTest {
     private static final String CANONICAL_CHEMISTRY_GALVANIC_ID = "f0939f88-a6af-5334-ac4d-5d54732af25a";
     private static final String CANONICAL_CHEMISTRY_UPPER_ELECTROLYSIS_ID = "fd7977bf-1d8e-5c5e-9c37-bd76bb2ffeef";
     private static final String CANONICAL_CHEMISTRY_BOND_MODELS_ID = "15e73664-8c3f-5aa6-ac65-b455fc3ed6d6";
+    private static final String CANONICAL_CHEMISTRY_BOND_TYPES_ID = "448815cc-4127-54b7-96bf-e54b3d2a38c5";
     private static final String CANONICAL_BIOLOGY_SEK1_CLUSTER_ID = "b530a382-2786-5794-8821-3e01a62d88fd";
     private static final String CANONICAL_BIOLOGY_SEK1_SCIENCE_ID = "8d35381e-d646-512c-b0c2-bb90c4974208";
     private static final String CANONICAL_BIOLOGY_SEK1_CHARACTERISTICS_ID = "55bdfb1d-5c14-5b1c-bc8e-4ab428ef59ba";
@@ -548,11 +549,14 @@ class LearnerServiceCanonicalProjectionTest {
     }
 
     @Test
-    void canonicalChemistryBondModelsDependOnProjectedSek1IonicBondingBridge() {
-        LearningGoal goal = landscapeService.getGoalDefinition(CANONICAL_CHEMISTRY_BOND_MODELS_ID);
+    void canonicalChemistryBondModelEntrypointDependsOnProjectedSek1IonicBondingBridge() {
+        LearningGoal cluster = landscapeService.getGoalDefinition(CANONICAL_CHEMISTRY_BOND_MODELS_ID);
+        LearningGoal entrypoint = landscapeService.getGoalDefinition(CANONICAL_CHEMISTRY_BOND_TYPES_ID);
 
-        assertThat(goal).isNotNull();
-        assertThat(goal.getRequires())
+        assertThat(cluster).isNotNull();
+        assertThat(cluster.getRequires()).isEmpty();
+        assertThat(entrypoint).isNotNull();
+        assertThat(entrypoint.getRequires())
                 .contains(CANONICAL_CHEMISTRY_SEK1_IONIC_BONDING_ID);
     }
 

--- a/curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json
+++ b/curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json
@@ -1626,7 +1626,8 @@
       ],
       "contains": [],
       "requires": [
-        "b6327e98-8ab9-5d7f-b826-4023bc1a56a7"
+        "b6327e98-8ab9-5d7f-b826-4023bc1a56a7",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -2698,7 +2699,8 @@
       "description": "Die lernende Person kann soziale, kulturelle, technologische, historische, ökologische und ökonomische Einflüsse auf die Entwicklung naturwissenschaftlichen Wissens sowie Auswirkungen chemischer Produkte, Verfahren, Methoden und Erkenntnisse in aktuellen und historischen gesellschaftlichen Zusammenhängen beschreiben und im Sinne nachhaltiger Entwicklung bewerten.",
       "descriptionEn": "The learner can describe and evaluate social, cultural, technological, historical, ecological, and economic influences on the development of scientific knowledge as well as impacts of chemical products, processes, methods, and findings in current and historical social contexts from the perspective of sustainable development.",
       "requires": [
-        "542822de-cb96-56cf-a487-0fc3b5820f57"
+        "542822de-cb96-56cf-a487-0fc3b5820f57",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -4205,9 +4207,7 @@
         "3bc48951-025c-5144-99b1-924db611a5f9",
         "a138d7bf-163a-59e0-a50a-8438ef4f5168"
       ],
-      "requires": [
-        "1e803ef8-fc76-493d-85c5-de877cd38fda"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB2",
@@ -4268,7 +4268,9 @@
       "contains": [],
       "requires": [
         "f5efab9d-2c61-44ea-b36a-87f873b51fd8",
-        "e9d74940-1e0e-4511-9718-4851f49ad7a5"
+        "e9d74940-1e0e-4511-9718-4851f49ad7a5",
+        "1e803ef8-fc76-493d-85c5-de877cd38fda",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -6494,9 +6496,7 @@
         "e8c02335-d4e5-565c-8830-628067ce51c3",
         "1848c806-a7b6-5e77-bd16-356a82d0dfd9"
       ],
-      "requires": [
-        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -7737,7 +7737,8 @@
       ],
       "contains": [],
       "requires": [
-        "950c73c6-4ed1-488a-9267-1142e95e0055"
+        "950c73c6-4ed1-488a-9267-1142e95e0055",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -7790,7 +7791,9 @@
         "LK"
       ],
       "contains": [],
-      "requires": [],
+      "requires": [
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
+      ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -7899,9 +7902,7 @@
         "e1214210-406e-5075-b83c-086b3972ed66",
         "cd9ec99b-b694-5673-863c-55528e31250a"
       ],
-      "requires": [
-        "3d3231f9-039d-5ce5-9e8e-af219c7fee08"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -8500,7 +8501,8 @@
       ],
       "contains": [],
       "requires": [
-        "1286f2fe-89b7-4454-8e11-85b6abd6e278"
+        "1286f2fe-89b7-4454-8e11-85b6abd6e278",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -8693,7 +8695,8 @@
       "contains": [],
       "requires": [
         "d4928773-3be8-5cf1-907c-ef07c96751e8",
-        "b6327e98-8ab9-5d7f-b826-4023bc1a56a7"
+        "b6327e98-8ab9-5d7f-b826-4023bc1a56a7",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -9024,9 +9027,7 @@
         "66fcf3e4-771f-5092-95fb-949087d6d3d5",
         "47a40c98-ab20-5246-85e3-3abe5a9e95ed"
       ],
-      "requires": [
-        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -9153,9 +9154,7 @@
         "448815cc-4127-54b7-96bf-e54b3d2a38c5",
         "9b56d01e-c2d7-51d8-b78e-237592c1ed20"
       ],
-      "requires": [
-        "950c73c6-4ed1-488a-9267-1142e95e0055"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -9208,7 +9207,8 @@
       ],
       "contains": [],
       "requires": [
-        "950c73c6-4ed1-488a-9267-1142e95e0055"
+        "950c73c6-4ed1-488a-9267-1142e95e0055",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -9431,9 +9431,7 @@
         "3fb7dea4-f832-5e23-b518-68b13a655b92",
         "622f09e5-a5bb-5ccf-919f-bae990c7c116"
       ],
-      "requires": [
-        "5a30273a-98d5-5163-bb16-c250b7ed4e7f"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -9707,11 +9705,7 @@
         "f0f67a7a-b06a-50b9-8edc-1f2a0d97520d",
         "17ab1148-7383-5cab-8b91-73aff795f1e4"
       ],
-      "requires": [
-        "e5aefd51-2de4-590c-903f-286d043a8c30",
-        "3fb7dea4-f832-5e23-b518-68b13a655b92",
-        "f85b4651-50ea-5b42-b193-3465c05257a7"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB3",
@@ -9998,9 +9992,7 @@
         "345fdca9-038f-51e2-9bea-b6ac416a734a",
         "e9b61d96-a271-5e69-b872-8c463f822be1"
       ],
-      "requires": [
-        "5a30273a-98d5-5163-bb16-c250b7ed4e7f"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -10283,9 +10275,7 @@
         "73547696-e225-5f14-839b-c77f54c32bae",
         "2bc1a15b-a677-5612-a564-33e826d11327"
       ],
-      "requires": [
-        "49235cbe-6658-5e7e-8bd4-398416bcebdc"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB2",
@@ -10332,7 +10322,8 @@
       ],
       "contains": [],
       "requires": [
-        "49235cbe-6658-5e7e-8bd4-398416bcebdc"
+        "49235cbe-6658-5e7e-8bd4-398416bcebdc",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -10479,9 +10470,7 @@
         "fbc5a920-05d6-53c8-9fc0-a5f4e57f2c6d",
         "386e28af-505a-5eb9-87fe-9c6946f10433"
       ],
-      "requires": [
-        "0acc8cd2-be6d-567e-a023-1d9e90475510"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB2",
@@ -10725,9 +10714,7 @@
         "707998c1-872d-582d-a2d6-14e7d967cbdb",
         "321d801d-28e4-54a2-bd31-8c07bda2f392"
       ],
-      "requires": [
-        "37b4081a-244a-58d8-b448-88ed83344210"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB2",
@@ -11034,9 +11021,7 @@
         "d4928773-3be8-5cf1-907c-ef07c96751e8",
         "41396457-d97b-55f3-9804-2af1bb188e79"
       ],
-      "requires": [
-        "91cd4728-b811-562a-970b-18b81dfb4bdf"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -11257,9 +11242,7 @@
         "5851b53a-162b-5c17-9269-510ee54ad846",
         "973c12d9-d863-5292-8c68-9c80cdacf9e2"
       ],
-      "requires": [
-        "91cd4728-b811-562a-970b-18b81dfb4bdf"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -11937,9 +11920,7 @@
         "bd36dc58-c93e-5247-9e82-da2f9e4e2bed",
         "4da0839d-ab6d-53c1-ac21-c9872555ae16"
       ],
-      "requires": [
-        "667bc303-e9b8-570b-84f1-61cc8bdfd006"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB3",
@@ -12586,9 +12567,7 @@
         "b856a8ac-5210-533d-b27f-e0aeeafcf962",
         "84440802-ae93-5978-b4ba-0ba3028dcc3f"
       ],
-      "requires": [
-        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -12730,7 +12709,8 @@
       ],
       "contains": [],
       "requires": [
-        "b6327e98-8ab9-5d7f-b826-4023bc1a56a7"
+        "b6327e98-8ab9-5d7f-b826-4023bc1a56a7",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -13220,7 +13200,8 @@
       ],
       "contains": [],
       "requires": [
-        "ca216bc6-5205-5b46-abbd-fd5628e4ca5b"
+        "ca216bc6-5205-5b46-abbd-fd5628e4ca5b",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -13326,7 +13307,8 @@
       ],
       "contains": [],
       "requires": [
-        "973c12d9-d863-5292-8c68-9c80cdacf9e2"
+        "973c12d9-d863-5292-8c68-9c80cdacf9e2",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -13467,7 +13449,8 @@
       "description": "Die lernende Person kann ausgewählte Zucker anhand ihres molekularen Baus vergleichen und daraus ihr chemisches Reaktionsverhalten begründen.",
       "descriptionEn": "The learner can compare selected sugars based on their molecular structure and use this to justify their chemical reactivity.",
       "requires": [
-        "973c12d9-d863-5292-8c68-9c80cdacf9e2"
+        "973c12d9-d863-5292-8c68-9c80cdacf9e2",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "extendedData": {
         "provenance": {
@@ -13491,7 +13474,8 @@
       ],
       "contains": [],
       "requires": [
-        "70b34ae7-4481-590c-9a02-516464750832"
+        "70b34ae7-4481-590c-9a02-516464750832",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -13610,10 +13594,7 @@
         "1654b644-f03d-59db-9f31-d63998cb0439",
         "a853069e-2ebb-5a19-8edf-b767cdb41ed7"
       ],
-      "requires": [
-        "55f35372-d7a3-5299-bf9e-9828d6720366",
-        "3681e688-7880-5bb4-9ab9-ef78289345c8"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB2",
@@ -13669,7 +13650,8 @@
       ],
       "contains": [],
       "requires": [
-        "3681e688-7880-5bb4-9ab9-ef78289345c8"
+        "3681e688-7880-5bb4-9ab9-ef78289345c8",
+        "55f35372-d7a3-5299-bf9e-9828d6720366"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -13779,7 +13761,9 @@
       "requires": [
         "f7f35d71-927a-511c-a49e-65a66794a9bc",
         "0b5342b9-512d-573f-90d5-7522aee35efa",
-        "1df17884-96ae-57d7-9da9-dbebd082596f"
+        "1df17884-96ae-57d7-9da9-dbebd082596f",
+        "55f35372-d7a3-5299-bf9e-9828d6720366",
+        "3681e688-7880-5bb4-9ab9-ef78289345c8"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -13833,7 +13817,10 @@
       "contains": [],
       "requires": [
         "7990387d-f254-5d3b-a589-a3e7ed9502a3",
-        "b6327e98-8ab9-5d7f-b826-4023bc1a56a7"
+        "b6327e98-8ab9-5d7f-b826-4023bc1a56a7",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08",
+        "55f35372-d7a3-5299-bf9e-9828d6720366",
+        "3681e688-7880-5bb4-9ab9-ef78289345c8"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -13889,7 +13876,9 @@
       "contains": [],
       "requires": [
         "70b34ae7-4481-590c-9a02-516464750832",
-        "197bc2c5-835e-59e7-9263-5684e89799cc"
+        "197bc2c5-835e-59e7-9263-5684e89799cc",
+        "55f35372-d7a3-5299-bf9e-9828d6720366",
+        "3681e688-7880-5bb4-9ab9-ef78289345c8"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -14282,7 +14271,8 @@
       "contains": [],
       "requires": [
         "e5aefd51-2de4-590c-903f-286d043a8c30",
-        "3fb7dea4-f832-5e23-b518-68b13a655b92"
+        "3fb7dea4-f832-5e23-b518-68b13a655b92",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -14612,7 +14602,8 @@
       "contains": [],
       "requires": [
         "e5aefd51-2de4-590c-903f-286d043a8c30",
-        "3fb7dea4-f832-5e23-b518-68b13a655b92"
+        "3fb7dea4-f832-5e23-b518-68b13a655b92",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -14943,9 +14934,7 @@
         "ccab1e1c-b595-5c36-9370-3a3958c9b784",
         "e4bd561d-1da3-5007-930c-40216f1a4a0d"
       ],
-      "requires": [
-        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -15064,7 +15053,8 @@
       ],
       "contains": [],
       "requires": [
-        "70b34ae7-4481-590c-9a02-516464750832"
+        "70b34ae7-4481-590c-9a02-516464750832",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -15489,7 +15479,8 @@
       ],
       "contains": [],
       "requires": [
-        "b4777001-f4ed-5fe9-9d98-02319abdea09"
+        "b4777001-f4ed-5fe9-9d98-02319abdea09",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -16227,7 +16218,8 @@
       "contains": [],
       "requires": [
         "04fa0ba1-eb6e-53c8-93d4-dfa28bb4b162",
-        "4961130b-1ee8-58f2-a319-dff0a864db6a"
+        "4961130b-1ee8-58f2-a319-dff0a864db6a",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "type": "atomic",
       "examples": []
@@ -16245,7 +16237,8 @@
       ],
       "contains": [],
       "requires": [
-        "16da6a4d-8e9c-5f5d-b69d-338d67a2d362"
+        "16da6a4d-8e9c-5f5d-b69d-338d67a2d362",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -16304,7 +16297,8 @@
       "contains": [],
       "requires": [
         "4961130b-1ee8-58f2-a319-dff0a864db6a",
-        "4928d5d1-e790-5883-9349-3b03a1c63b99"
+        "4928d5d1-e790-5883-9349-3b03a1c63b99",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -16884,7 +16878,9 @@
         "LK"
       ],
       "contains": [],
-      "requires": [],
+      "requires": [
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
+      ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -17095,9 +17091,7 @@
         "e4f2332c-9d04-5220-b4e1-501b9ac3a0c7",
         "1aee5c7f-2370-54c2-b3c3-fcb1bd3f7e1e"
       ],
-      "requires": [
-        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB2",
@@ -17215,7 +17209,8 @@
       ],
       "contains": [],
       "requires": [
-        "8ece9beb-9458-5ea1-8e45-9be04670f464"
+        "8ece9beb-9458-5ea1-8e45-9be04670f464",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -17326,7 +17321,8 @@
       ],
       "contains": [],
       "requires": [
-        "4928d5d1-e790-5883-9349-3b03a1c63b99"
+        "4928d5d1-e790-5883-9349-3b03a1c63b99",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -17571,7 +17567,8 @@
       ],
       "contains": [],
       "requires": [
-        "3ce81f96-4fbb-5022-88b7-337a000315ed"
+        "3ce81f96-4fbb-5022-88b7-337a000315ed",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -17739,7 +17736,8 @@
       ],
       "contains": [],
       "requires": [
-        "b759d50d-0e82-5b10-89a2-fe5271106e50"
+        "b759d50d-0e82-5b10-89a2-fe5271106e50",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -17853,7 +17851,8 @@
       "contains": [],
       "requires": [
         "efa24b77-0f98-5835-9d82-3e539ab20253",
-        "c8844ac6-c414-5a0e-9fcd-7d0a82177d09"
+        "c8844ac6-c414-5a0e-9fcd-7d0a82177d09",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -17967,7 +17966,8 @@
       ],
       "contains": [],
       "requires": [
-        "bebea164-dfd7-51d9-a54a-7029c78b7f5f"
+        "bebea164-dfd7-51d9-a54a-7029c78b7f5f",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -18019,7 +18019,8 @@
       ],
       "contains": [],
       "requires": [
-        "8761cfd2-aa1a-56f1-9272-9cf66ef4b271"
+        "8761cfd2-aa1a-56f1-9272-9cf66ef4b271",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -18071,7 +18072,8 @@
       ],
       "contains": [],
       "requires": [
-        "6b82f80e-f493-5e6b-9709-2d4eca98c137"
+        "6b82f80e-f493-5e6b-9709-2d4eca98c137",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -18176,7 +18178,8 @@
       ],
       "contains": [],
       "requires": [
-        "6966df95-f125-5ecc-af8e-0442545d9f17"
+        "6966df95-f125-5ecc-af8e-0442545d9f17",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -18429,9 +18432,7 @@
         "9decc36b-a69a-5599-a9f0-fcebdf0203d8",
         "85342c52-9722-54b0-8fbb-513d9d648363"
       ],
-      "requires": [
-        "5a30273a-98d5-5163-bb16-c250b7ed4e7f"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB3",
@@ -20314,7 +20315,8 @@
         "04fa0ba1-eb6e-53c8-93d4-dfa28bb4b162",
         "4961130b-1ee8-58f2-a319-dff0a864db6a",
         "f0939f88-a6af-5334-ac4d-5d54732af25a",
-        "fd7977bf-1d8e-5c5e-9c37-bd76bb2ffeef"
+        "fd7977bf-1d8e-5c5e-9c37-bd76bb2ffeef",
+        "323a222e-5db8-53c5-b2dc-6f9c1d0d277c"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -20395,9 +20397,7 @@
         "23fc54ce-3519-5292-af90-71bc869f4ff1",
         "9746ff9a-c423-5504-9d4d-0fced93fa382"
       ],
-      "requires": [
-        "323a222e-5db8-53c5-b2dc-6f9c1d0d277c"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB3",
@@ -20439,7 +20439,8 @@
         "db66635f-f1d1-5f70-bcc0-fed1ae424e52",
         "d76b80a2-5156-54f4-b3a1-546beddf0e14",
         "a3788e40-b540-5bed-be37-b33053528422",
-        "ca216bc6-5205-5b46-abbd-fd5628e4ca5b"
+        "ca216bc6-5205-5b46-abbd-fd5628e4ca5b",
+        "a0893975-1677-5dae-bbfb-675789be4f17"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -20521,9 +20522,7 @@
         "c91350bc-7d2e-523c-bd50-0324bccfcf98",
         "bf6c39f0-1e44-53b2-8ff6-025f2e36e125"
       ],
-      "requires": [
-        "a0893975-1677-5dae-bbfb-675789be4f17"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB3",
@@ -20565,7 +20564,8 @@
         "197bc2c5-835e-59e7-9263-5684e89799cc",
         "3e9eb5d0-3407-5a1e-9492-ad87f98d303d",
         "9b942490-ad8f-52ba-8c5a-f8a9792b7db5",
-        "8721d943-8368-5304-bd3c-7d7944099662"
+        "8721d943-8368-5304-bd3c-7d7944099662",
+        "ae683d59-06a5-59be-87b5-b8648fd138c8"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -20647,9 +20647,7 @@
         "8872d828-a025-5e45-af74-3d84caedfb73",
         "954b55d6-8a2b-533d-8aff-dadaf6306916"
       ],
-      "requires": [
-        "ae683d59-06a5-59be-87b5-b8648fd138c8"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB3",
@@ -20690,7 +20688,8 @@
         "81373fb7-2a4a-5b2c-acd0-b4e775acaa65",
         "20f92ba0-f7f4-5407-bb96-07e30da9002f",
         "5a24dae0-6d33-5227-8d8b-e8f74c2ccc4c",
-        "d9cce642-4f89-57f8-832a-abeb62586195"
+        "d9cce642-4f89-57f8-832a-abeb62586195",
+        "633f4fd4-1c36-5377-8fe6-44d8eeac3c56"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -20772,9 +20771,7 @@
         "bacf2568-03bc-5655-8798-cda078c897e3",
         "c31fa777-89c0-52f5-a6d9-d054027aabf5"
       ],
-      "requires": [
-        "633f4fd4-1c36-5377-8fe6-44d8eeac3c56"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB3",
@@ -20815,7 +20812,8 @@
         "4a08f31f-204c-5339-9d9f-5d2af28d5d5c",
         "ecce0306-13dc-5563-a097-afe69805a8d6",
         "e64a79df-7f21-5651-9b5d-e7d17580569e",
-        "551d81a7-2308-540f-8323-df35c6871d62"
+        "551d81a7-2308-540f-8323-df35c6871d62",
+        "f4fa58e7-5c6c-58dd-82db-19e7e0abe822"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -20896,9 +20894,7 @@
         "31a630bc-ee86-5316-8ce5-e522b14fd607",
         "4a2477e3-3bae-5452-8058-58e6ed9cc3e3"
       ],
-      "requires": [
-        "f4fa58e7-5c6c-58dd-82db-19e7e0abe822"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
         "demandLevel": "AB3",
@@ -20940,7 +20936,8 @@
         "f1ed86f0-534d-57d7-8952-a004a331cc54",
         "02634fdd-c8ba-591a-b240-77129b1bebb8",
         "1c1420c2-a8e2-520f-8015-6df637a973bd",
-        "b4777001-f4ed-5fe9-9d98-02319abdea09"
+        "b4777001-f4ed-5fe9-9d98-02319abdea09",
+        "323a222e-5db8-53c5-b2dc-6f9c1d0d277c"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -21022,7 +21019,8 @@
         "eb7537dd-d11b-50e9-a6d7-51a78e96fc4e",
         "5a30273a-98d5-5163-bb16-c250b7ed4e7f",
         "e9b61d96-a271-5e69-b872-8c463f822be1",
-        "973c12d9-d863-5292-8c68-9c80cdacf9e2"
+        "973c12d9-d863-5292-8c68-9c80cdacf9e2",
+        "a0893975-1677-5dae-bbfb-675789be4f17"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -21103,7 +21101,8 @@
       "requires": [
         "6765f741-42a6-55c5-a218-81b883b1f5ae",
         "6966df95-f125-5ecc-af8e-0442545d9f17",
-        "1837690e-cfb1-5b1c-96c8-0fb40d6d5d69"
+        "1837690e-cfb1-5b1c-96c8-0fb40d6d5d69",
+        "a0893975-1677-5dae-bbfb-675789be4f17"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -21184,7 +21183,8 @@
       "requires": [
         "62149f36-87c0-5a2d-8a78-e7d4203f58c2",
         "197bc2c5-835e-59e7-9263-5684e89799cc",
-        "065d764c-daec-5d35-95da-3e922d2029c7"
+        "065d764c-daec-5d35-95da-3e922d2029c7",
+        "ae683d59-06a5-59be-87b5-b8648fd138c8"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -21266,7 +21266,8 @@
         "3e9eb5d0-3407-5a1e-9492-ad87f98d303d",
         "6eb14e47-187c-5ba1-8b08-a0ee95ad88a9",
         "9b942490-ad8f-52ba-8c5a-f8a9792b7db5",
-        "8721d943-8368-5304-bd3c-7d7944099662"
+        "8721d943-8368-5304-bd3c-7d7944099662",
+        "ae683d59-06a5-59be-87b5-b8648fd138c8"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -21347,7 +21348,8 @@
       "requires": [
         "48115ff7-7aca-5d0b-a9e7-7fc6c78434ef",
         "28c90c6a-3020-5c51-ac40-d802f3f12d2d",
-        "2a8a13b8-f96a-5ff1-92fa-fe6c19973a0e"
+        "2a8a13b8-f96a-5ff1-92fa-fe6c19973a0e",
+        "633f4fd4-1c36-5377-8fe6-44d8eeac3c56"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -21428,7 +21430,8 @@
       "requires": [
         "8be14f15-2258-58e6-ae4e-38953f5d0570",
         "642d5ea5-b62f-50c8-b0bd-cf132619725f",
-        "0c9fe376-0fbd-5dc1-b8d4-d56d658a00e3"
+        "0c9fe376-0fbd-5dc1-b8d4-d56d658a00e3",
+        "633f4fd4-1c36-5377-8fe6-44d8eeac3c56"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -21510,7 +21513,8 @@
         "4a08f31f-204c-5339-9d9f-5d2af28d5d5c",
         "d465d82b-4bf2-5527-bb7c-dad5a92605fe",
         "a78aacf9-92ea-5627-8776-a595111f754c",
-        "551d81a7-2308-540f-8323-df35c6871d62"
+        "551d81a7-2308-540f-8323-df35c6871d62",
+        "f4fa58e7-5c6c-58dd-82db-19e7e0abe822"
       ],
       "dimensionTags": {
         "framework": "hessen-kc-2024-chemistry",
@@ -22320,10 +22324,7 @@
         "e22a34d4-ac1e-5afe-8f77-0dfa4fd9f44f",
         "ba621c67-b750-5e45-ab37-a51ea45e3ccf"
       ],
-      "requires": [
-        "49b13b33-34b7-5e4e-861c-b21082cb9922",
-        "f1ed86f0-534d-57d7-8952-a004a331cc54"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB2",
@@ -22367,7 +22368,8 @@
       "descriptionEn": "The learner can perform and evaluate complexometric titrations with EDTA solution to determine concentrations of metal cations in aqueous solutions.",
       "requires": [
         "363c5740-8a3c-50b8-8c3a-5548c80c36ea",
-        "f1ed86f0-534d-57d7-8952-a004a331cc54"
+        "f1ed86f0-534d-57d7-8952-a004a331cc54",
+        "49b13b33-34b7-5e4e-861c-b21082cb9922"
       ],
       "weight": 1,
       "tags": [
@@ -22700,9 +22702,7 @@
         "188bd684-e894-5753-8a50-798220b04d97",
         "34da1a4c-5082-54c8-9084-a94826fd36cd"
       ],
-      "requires": [
-        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
-      ],
+      "requires": [],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB2",
@@ -22763,7 +22763,9 @@
         "SekII"
       ],
       "contains": [],
-      "requires": [],
+      "requires": [
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
+      ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB1",
@@ -22879,7 +22881,9 @@
         "SekII"
       ],
       "contains": [],
-      "requires": [],
+      "requires": [
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
+      ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB2",
@@ -22991,7 +22995,9 @@
         "SekII"
       ],
       "contains": [],
-      "requires": [],
+      "requires": [
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
+      ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB2",
@@ -23047,7 +23053,9 @@
         "SekII"
       ],
       "contains": [],
-      "requires": [],
+      "requires": [
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
+      ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB2",
@@ -23104,7 +23112,8 @@
       ],
       "contains": [],
       "requires": [
-        "17ab1148-7383-5cab-8b91-73aff795f1e4"
+        "17ab1148-7383-5cab-8b91-73aff795f1e4",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -23162,7 +23171,8 @@
       ],
       "contains": [],
       "requires": [
-        "0b6a6a15-b355-5be8-abc9-4ef8df11bcb6"
+        "0b6a6a15-b355-5be8-abc9-4ef8df11bcb6",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -23218,7 +23228,8 @@
       ],
       "contains": [],
       "requires": [
-        "4961130b-1ee8-58f2-a319-dff0a864db6a"
+        "4961130b-1ee8-58f2-a319-dff0a864db6a",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -23273,7 +23284,8 @@
       ],
       "contains": [],
       "requires": [
-        "b3c9c4b8-5575-5200-86cf-26c14ebcc3d8"
+        "b3c9c4b8-5575-5200-86cf-26c14ebcc3d8",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -23328,7 +23340,9 @@
         "SekII"
       ],
       "contains": [],
-      "requires": [],
+      "requires": [
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
+      ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
         "demandLevel": "AB2",
@@ -24322,7 +24336,8 @@
       "contains": [],
       "requires": [
         "04fa0ba1-eb6e-53c8-93d4-dfa28bb4b162",
-        "22133f29-ef02-4408-8f8d-2bbea3275d91"
+        "22133f29-ef02-4408-8f8d-2bbea3275d91",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -24438,7 +24453,8 @@
       "contains": [],
       "requires": [
         "cc803809-fa7f-517c-b356-9f2f7caf21a5",
-        "93b914d4-747d-5b22-90ff-ac6320514b44"
+        "93b914d4-747d-5b22-90ff-ac6320514b44",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -24493,7 +24509,8 @@
       "contains": [],
       "requires": [
         "c21a611c-1069-5b32-b673-4f37a89b094f",
-        "94a62b39-d4a2-5882-99d1-6886ead07726"
+        "94a62b39-d4a2-5882-99d1-6886ead07726",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -24552,7 +24569,8 @@
       ],
       "contains": [],
       "requires": [
-        "04fa0ba1-eb6e-53c8-93d4-dfa28bb4b162"
+        "04fa0ba1-eb6e-53c8-93d4-dfa28bb4b162",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -24805,11 +24823,7 @@
         "3351fe47-5b0c-5407-a3bf-05229cfbf0c5",
         "ebe2f6db-95a3-5157-a27d-2624f6c82e4e"
       ],
-      "requires": [
-        "266a2b2a-9ee2-52f6-ae09-59343da9a60b",
-        "c7d4d9f7-d23f-44fc-bf22-3872e0f2b9a0",
-        "91238ba1-5c63-50c7-a4fd-9bbe492c6b61"
-      ],
+      "requires": [],
       "applicability": {
         "jurisdiction": [
           "DE-BB",
@@ -24894,7 +24908,9 @@
       "descriptionEn": "The learner can safely and professionally conduct qualitative and quantitative scientific investigations, biological preparations, and synthesis, isolation, and work-up procedures.",
       "requires": [
         "266a2b2a-9ee2-52f6-ae09-59343da9a60b",
-        "c7d4d9f7-d23f-44fc-bf22-3872e0f2b9a0"
+        "c7d4d9f7-d23f-44fc-bf22-3872e0f2b9a0",
+        "91238ba1-5c63-50c7-a4fd-9bbe492c6b61",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -24944,7 +24960,11 @@
       "description": "Die lernende Person kann Untersuchungsergebnisse in eine sach-, adressaten- und situationsgerechte Darstellungsform ueberfuehren und die Eignung dieser Darstellung reflektieren.",
       "descriptionEn": "The learner can transform investigation results into a subject-, audience-, and situation-appropriate representation and reflect on the suitability of that representation.",
       "requires": [
-        "49b13b33-34b7-5e4e-861c-b21082cb9922"
+        "49b13b33-34b7-5e4e-861c-b21082cb9922",
+        "266a2b2a-9ee2-52f6-ae09-59343da9a60b",
+        "c7d4d9f7-d23f-44fc-bf22-3872e0f2b9a0",
+        "91238ba1-5c63-50c7-a4fd-9bbe492c6b61",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "dimensionTags": {
         "framework": "canonical-gymnasium-chemistry",
@@ -26067,7 +26087,8 @@
       ],
       "requires": [
         "1286f2fe-89b7-4454-8e11-85b6abd6e278",
-        "542d88e9-4cd3-5f90-bd20-b50ab030d72a"
+        "542d88e9-4cd3-5f90-bd20-b50ab030d72a",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "contains": [],
       "examples": [],
@@ -26206,7 +26227,8 @@
         "canonical"
       ],
       "requires": [
-        "1286f2fe-89b7-4454-8e11-85b6abd6e278"
+        "1286f2fe-89b7-4454-8e11-85b6abd6e278",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "contains": [],
       "examples": [],
@@ -26335,7 +26357,8 @@
         "canonical"
       ],
       "requires": [
-        "3de28598-672f-5753-8a45-8f559c2f9dc2"
+        "3de28598-672f-5753-8a45-8f559c2f9dc2",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "contains": [],
       "examples": [],
@@ -26512,7 +26535,8 @@
         "canonical"
       ],
       "requires": [
-        "5e2eb826-6e60-5273-91d6-c23f6dfa33b1"
+        "5e2eb826-6e60-5273-91d6-c23f6dfa33b1",
+        "a9c22adc-b543-5b0c-a2d8-3189facdff08"
       ],
       "contains": [],
       "examples": [],

--- a/curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json
+++ b/curricula/DE/Gymnasium/provenance/chemistry-evidence-watch-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-05-12T09:56:29Z",
+  "updatedAt": "2026-05-12T10:30:49Z",
   "manifestVersion": 1,
   "manifestUpdatedAt": "2026-05-12T00:00:00Z",
   "mode": "maintenance_evidence_watch",
@@ -9,8 +9,8 @@
     {
       "relativePath": "curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json",
       "exists": true,
-      "sha256": "e3949818791e5268e6c76ec9ebaef81203a64f185628cacdfe4b4b17417ab2fd",
-      "lastModifiedUtc": "2026-05-12T09:52:53Z"
+      "sha256": "5f67006e9d0d968bbdcf963ee63459293a3a8d5454bb5820fe99540816cca8c3",
+      "lastModifiedUtc": "2026-05-12T10:30:13Z"
     },
     {
       "relativePath": "curricula/DE/Gymnasium/composition-views/chemie/de-bb-gk.view.json",

--- a/docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md
+++ b/docs/dev/canonical-gymnasium-chemistry-evidence-watch-delta.md
@@ -1,6 +1,6 @@
 # Canonical Gymnasium Chemistry Evidence Watch Delta
 
-Snapshot: `2026-05-12T09:56:42Z`
+Snapshot: `2026-05-12T10:48:30Z`
 
 This file is generated from:
 
@@ -10,7 +10,7 @@ This file is generated from:
 
 ## Headline
 
-- Baseline snapshot: `2026-05-12T09:56:29Z`
+- Baseline snapshot: `2026-05-12T10:30:49Z`
 - Current watched files: `137`
 - Unchanged watched files: `137`
 - Changed watched files: `0`

--- a/docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md
+++ b/docs/dev/canonical-gymnasium-chemistry-evidence-watch-status.md
@@ -40,7 +40,7 @@ This file is generated from:
 
 | File | Exists | SHA256-12 | Last modified (UTC) |
 | --- | --- | --- | --- |
-| `curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json` | `yes` | `e3949818791e` | `2026-05-12T09:52:53Z` |
+| `curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json` | `yes` | `5f67006e9d0d` | `2026-05-12T10:30:13Z` |
 | `curricula/DE/Gymnasium/composition-views/chemie/de-bb-gk.view.json` | `yes` | `41be795c3ab0` | `2026-05-11T15:47:52Z` |
 | `curricula/DE/Gymnasium/composition-views/chemie/de-bb-lk.view.json` | `yes` | `7b2b8027aa32` | `2026-05-11T15:47:52Z` |
 | `curricula/DE/Gymnasium/composition-views/chemie/de-be-gk.view.json` | `yes` | `00de28f46bfc` | `2026-05-11T15:47:52Z` |
@@ -190,7 +190,7 @@ This file is generated from:
 
 | File | Exists | SHA256-12 | Last modified (UTC) |
 | --- | --- | --- | --- |
-| `curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json` | `yes` | `e3949818791e` | `2026-05-12T09:52:53Z` |
+| `curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json` | `yes` | `5f67006e9d0d` | `2026-05-12T10:30:13Z` |
 | `curricula/DE/Gymnasium/provenance/chemistry-bundesland-rollout-tracker.json` | `yes` | `8d5b1a12a19a` | `2026-05-12T01:19:23Z` |
 
 ## `chemistry_source_evidence_watch`

--- a/docs/qa-ci/status/curriculum-quality-status.json
+++ b/docs/qa-ci/status/curriculum-quality-status.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "rulesVersion": "curriculum-quality-v1",
-  "generatedAt": "2026-05-12T09:54:33.132Z",
+  "generatedAt": "2026-05-12T10:30:49.339Z",
   "generatedBy": "app/scripts/generateCurriculumQualityStatus.ts",
   "sources": {
     "canonicalRoot": "curricula/DE/Gymnasium/canonical",
@@ -19,14 +19,14 @@
     "maturity": {
       "M0": 18,
       "M1": 0,
-      "M2": 1,
+      "M2": 0,
       "M3": 0,
       "M4": 0,
-      "M5": 2
+      "M5": 3
     },
     "ruleStatus": {
-      "pass": 98,
-      "warn": 19,
+      "pass": 100,
+      "warn": 17,
       "fail": 19,
       "not_configured": 71
     }
@@ -1001,7 +1001,7 @@
       "subject": "Chemie",
       "frameworkId": "canonical-gymnasium-chemistry",
       "path": "curricula/DE/Gymnasium/canonical/DE_DEU_S_GYM_CANONICAL_CHEMIE.de.json",
-      "maturity": "M2",
+      "maturity": "M5",
       "goals": 467,
       "atomicGoals": 399,
       "clusterGoals": 68,
@@ -6452,7 +6452,7 @@
           "scopeId": "canonical-chemistry-sek2",
           "label": "Sekundarstufe II",
           "selectedAtomicGoals": 276,
-          "maturity": "M1",
+          "maturity": "M3",
           "rules": [
             {
               "id": "CQR-101",
@@ -6466,65 +6466,21 @@
             },
             {
               "id": "CQR-102",
-              "status": "warn",
-              "summary": "Direct atomic route coverage still needs migration work.",
+              "status": "pass",
+              "summary": "Direct atomic route coverage is complete for the configured scope.",
               "metrics": {
                 "selectedAtomicGoals": 276,
-                "missingDirectMotivationPath": 209,
+                "missingDirectMotivationPath": 0,
                 "missingDirectTerminalPath": 0
-              },
-              "details": [
-                "No direct atomic motivation path: Stoffe nach Struktur und Eigenschaften ordnen [02dc29ae-4046-556a-b048-d64a0feb8f16]",
-                "No direct atomic motivation path: Chemische Sachverhalte fachlich diskutieren [1f354a60-be44-512b-8f8b-f67c8c456035]",
-                "No direct atomic motivation path: Einflüsse auf naturwissenschaftliches Wissen bewerten [b3c9c4b8-5575-5200-86cf-26c14ebcc3d8]",
-                "No direct atomic motivation path: Unterenergiestufen aus Spektren und Ionisierungsenergien ableiten [49235cbe-6658-5e7e-8bd4-398416bcebdc]",
-                "No direct atomic motivation path: Quantenzahlen und Besetzungsregeln zur PSE-Anordnung nutzen [3bc48951-025c-5144-99b1-924db611a5f9]",
-                "No direct atomic motivation path: Ionenladungen von Nebengruppenelementen orbitalenergetisch begründen [a138d7bf-163a-59e0-a50a-8438ef4f5168]",
-                "No direct atomic motivation path: Alkane, Alkene und Alkine beschreiben [dd58c029-176f-5d99-923e-1c1fda6cf58e]",
-                "No direct atomic motivation path: Eigenschaften über Wechselwirkungen erklären [3d3231f9-039d-5ce5-9e8e-af219c7fee08]",
-                "No direct atomic motivation path: Radikalische Substitution nachvollziehen [3be2d0b7-c22f-57d4-886a-10fc04a629f5]",
-                "No direct atomic motivation path: Ethanol-Eigenschaften aus der Hydroxygruppe ableiten [e1214210-406e-5075-b83c-086b3972ed66]",
-                "No direct atomic motivation path: Gesundheitliche und gesellschaftliche Alkoholrisiken beurteilen [cd9ec99b-b694-5673-863c-55528e31250a]",
-                "No direct atomic motivation path: Rohstoffvorkommen reflektieren [2be9e61a-88ea-56fe-8294-ee46e3c9a8ef]",
-                "No direct atomic motivation path: Funktionelle Gruppen qualitativ nachweisen [3de28598-672f-5753-8a45-8f559c2f9dc2]",
-                "No direct atomic motivation path: Fraktionierung und Cracken erklären [8ceb1749-fce0-584f-a2b8-0a309282329a]",
-                "No direct atomic motivation path: Brennstoffe vergleichen [8ece9beb-9458-5ea1-8e45-9be04670f464]",
-                "No direct atomic motivation path: Fossile und nachwachsende Rohstoffe nachhaltig bewerten [a0e8f0f2-24e2-5945-a511-597d32e73796]",
-                "No direct atomic motivation path: Maßnahmen zu organischen Rohstoffen quellenkritisch ableiten [8b98d8ba-65c6-58d7-92f0-45f4b2456573]",
-                "No direct atomic motivation path: Innere Energie und Enthalpie in Reaktionssystemen abgrenzen [4928d5d1-e790-5883-9349-3b03a1c63b99]",
-                "No direct atomic motivation path: Reaktionsenthalpien aus Bindungsverhältnissen begründen [3e433dae-99f9-5a95-ad63-d5fa0b5f6836]",
-                "No direct atomic motivation path: Standard-Reaktionsenthalpien aus Bildungsenthalpien berechnen [4663fd80-1618-5211-8020-18f4b80979fc]"
-              ]
+              }
             },
             {
               "id": "CQR-103",
-              "status": "warn",
-              "summary": "27 scoped cluster-level requires remain.",
+              "status": "pass",
+              "summary": "No scoped cluster-level requires remain.",
               "metrics": {
-                "scopedClusterRequires": 27
-              },
-              "details": [
-                "Oberstufen-Atombau und Periodensystem [6e050336-6322-52e2-b40e-c26e5a95a613] has 1 requires",
-                "Einführungsphase Reaktionsgrundlagen [323a222e-5db8-53c5-b2dc-6f9c1d0d277c] has 1 requires",
-                "Ethanol gesundheitlich und gesellschaftlich einordnen [dd843c85-bf60-58c3-861b-fb531ba69b17] has 1 requires",
-                "Stoffgruppen [a0893975-1677-5dae-bbfb-675789be4f17] has 1 requires",
-                "Bindungsmodelle sicher nutzen [15e73664-8c3f-5aa6-ac65-b455fc3ed6d6] has 1 requires",
-                "Reaktionstypen beschreiben [9aec52cb-1f7d-5343-b5f9-a8e72ddd25fa] has 1 requires",
-                "Aromaten vertieft analysieren (LK) [ac700167-001f-5ff8-9a7d-85909f5daa4f] has 3 requires",
-                "Alkanole klassifizieren [0aaf0cc6-b059-56ef-9284-4cb7a0c5bff5] has 1 requires",
-                "Antreffwahrscheinlichkeit quantenmodellhaft begründen [7d84f40f-d1da-5b78-8c1b-4d02091e77b4] has 1 requires",
-                "Wellenfunktionen und MO-Energieniveauschemata verknüpfen [c0c0f6e4-56be-5196-9408-20efc4504783] has 1 requires",
-                "Hybridisierungsmodell und Molecular Modelling nutzen [18f09dab-e25b-59e7-951d-f9ff85e85207] has 1 requires",
-                "Nukleophile Substitution anwenden [c2d3f72b-e28a-5cae-b52a-7ffaa39d17c2] has 1 requires",
-                "Oxidation von Alkanolen vergleichen [61446285-4415-5bd9-9fdc-c19bb9ec1b02] has 1 requires",
-                "Mehrfunktionelle Säuren und Esterhydrolyse vertiefen (LK) [60719b87-f311-5d3e-8e80-7265ec80cb5b] has 1 requires",
-                "Naturstoffe und Synthesechemie [ae683d59-06a5-59be-87b5-b8648fd138c8] has 1 requires",
-                "Q2 Pharmazie [4a98bbee-41cb-5aef-91c6-f18d7bf2a214] has 2 requires",
-                "Chemisches Gleichgewicht [633f4fd4-1c36-5377-8fe6-44d8eeac3c56] has 1 requires",
-                "Energie und Nachhaltigkeit [f4fa58e7-5c6c-58dd-82db-19e7e0abe822] has 1 requires",
-                "Stereochemie einordnen [eae2a380-601c-53ed-be30-03c69c1f4f54] has 1 requires",
-                "Übungen E-Phase [9abac0f3-308d-536d-8454-56ed4fd98312] has 1 requires"
-              ]
+                "scopedClusterRequires": 0
+              }
             },
             {
               "id": "CQR-201",

--- a/docs/qa-ci/status/curriculum-quality-status.md
+++ b/docs/qa-ci/status/curriculum-quality-status.md
@@ -1,6 +1,6 @@
 # Curriculum Quality Status
 
-Generated: 2026-05-12T09:54:33.132Z
+Generated: 2026-05-12T10:30:49.339Z
 Rules version: curriculum-quality-v1
 
 ## Summary
@@ -10,17 +10,17 @@ Rules version: curriculum-quality-v1
 | Curricula | 21 |
 | M0 | 18 |
 | M1 | 0 |
-| M2 | 1 |
+| M2 | 0 |
 | M3 | 0 |
 | M4 | 0 |
-| M5 | 2 |
+| M5 | 3 |
 
 ## Curricula
 
 | Curriculum | Maturity | Goals | Atomic | Passage extraction | Bundeslaender | QA scopes | Warn | Fail |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | Biologie (Gymnasium, DE) | M0 | 216 | 182 | 0/3 | 0/16 | 0 | 0 | 2 |
-| Chemie (Gymnasium, DE) | M2 | 467 | 399 | 32/32 | 16/16 | 1 | 2 | 0 |
+| Chemie (Gymnasium, DE) | M5 | 467 | 399 | 32/32 | 16/16 | 1 | 0 | 0 |
 | Chinesisch (Gymnasium, DE) | M0 | 192 | 181 | 0/2 | 0/16 | 0 | 1 | 1 |
 | Deutsch (Gymnasium, DE) | M0 | 181 | 144 | 0/2 | 0/16 | 0 | 1 | 1 |
 | Englisch (Gymnasium, DE) | M0 | 130 | 104 | 0/2 | 0/16 | 0 | 1 | 1 |


### PR DESCRIPTION
## Summary

- moves canonical chemistry Sek II sequencing off scoped cluster-level `requires` and onto atomic entrypoints
- anchors the remaining direct atomic route roots to the chemistry motivation goal so `CQR-102` is explicit instead of inherited
- regenerates curriculum quality status and chemistry evidence-watch artifacts
- updates the learner projection regression test to assert the Sek-I ionic bonding bridge on the atomic bond-model entrypoint, not the now-clean cluster

## Why

The dashboard showed all Bundesland source coverage as green, but the chemistry curriculum was still below the top maturity level because the route QA lane had transition debt. `CQR-102` still had direct atomic motivation gaps, and `CQR-103` still found cluster-level route prerequisites.

## Validation

- `npm --prefix app run quality:curriculum-status`
- `./scripts/run_canonical_chemistry_evidence_watch.sh`
- `./gradlew test --tests com.skillpilot.backend.service.LearnerServiceCanonicalProjectionTest --no-daemon` from `backend/`
- `NPM_CONFIG_INCLUDE=optional ./run_ci.sh`
