### PR TITLE
[codex] Gate chemistry exam pipeline in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
         run: cd .. && python scripts/validate_hessen_upper_secondary_archive_paths.py
       - name: Validate Hessen Upper-Secondary Legacy References
         run: cd .. && python scripts/validate_hessen_upper_secondary_legacy_refs.py
+      - name: Validate Hessen Chemistry Exam Pipeline
+        run: cd .. && python scripts/validate_chemistry_exam_pipeline.py
       - name: Validate Hessen Lower-Secondary Archive Paths
         run: cd .. && python scripts/validate_hessen_lower_secondary_archive_paths.py
       - name: Validate Hessen Lower-Secondary Legacy References

--- a/docs/qa-ci/ci.md
+++ b/docs/qa-ci/ci.md
@@ -37,10 +37,11 @@ Steps:
 6. `python scripts/validate_goal_ids_uuid.py`
 7. `python scripts/validate_hessen_upper_secondary_archive_paths.py`
 8. `python scripts/validate_hessen_upper_secondary_legacy_refs.py`
-9. `python scripts/validate_hessen_lower_secondary_archive_paths.py`
-10. `python scripts/validate_hessen_lower_secondary_legacy_refs.py`
-11. `python scripts/validate_bavaria_gymnasium_archive_paths.py`
-12. `python scripts/validate_bavaria_gymnasium_legacy_refs.py`
+9. `python scripts/validate_chemistry_exam_pipeline.py`
+10. `python scripts/validate_hessen_lower_secondary_archive_paths.py`
+11. `python scripts/validate_hessen_lower_secondary_legacy_refs.py`
+12. `python scripts/validate_bavaria_gymnasium_archive_paths.py`
+13. `python scripts/validate_bavaria_gymnasium_legacy_refs.py`
 
 The graph rule catalog is documented in:
 
@@ -60,6 +61,7 @@ Current scope note:
 - it additionally validates explicit learner-facing composition-view files via `validate:composition-views`
 - it additionally enforces the Hessen Oberstufe retained-asset boundary: under `curricula/DE/Gymnasium/input/DE-HE/abi`, legacy `Gymnasiale_Oberstufe` path strings may only remain inside allowlisted raw archival provenance files from `curricula/DE/Gymnasium/input/DE-HE/retained-asset-registry.json`
 - it also enforces the Hessen Oberstufe repo-handoff boundary: the retired legacy tree must stay absent from the active repo, and active tooling/runtime/test surfaces may mention it only from the explicit allowlist in `curricula/DE/Gymnasium/provenance/hessen-upper-secondary-retirement-registry.json`
+- it validates the Hessen 2026 chemistry exam pipeline artifacts (`slot_matrix.json`, `coverage_requirements.json`, `task_bank.json`, and source-landscape release anchors)
 - it now also enforces the Hessen Sek-I retained-asset boundary: under `curricula/DE/Gymnasium/input/DE-HE/lower-secondary`, legacy `Gymnasium_9_Mittelstufe` path strings are forbidden in retained operational archive content
 - it also enforces the Hessen Sek-I repo-handoff boundary: active tooling/runtime/test surfaces may mention the lower-secondary legacy tree only from the explicit allowlist in `curricula/DE/Gymnasium/provenance/hessen-lower-secondary-retirement-registry.json`
 - the current CI scope for `validate:view-filters` is the reviewed canonical DE Gymnasium set (`Mathematik`, `Physik`, `Chemie`, `Biologie`, `Informatik`, `Deutsch`, `Englisch`, `Französisch`, `Griechisch`, `Chinesisch`, `Geschichte`, `Politik und Wirtschaft`, `Musik`, `Latein`, `Spanisch`, `Wirtschaft`, `Overview`)
@@ -98,5 +100,5 @@ bash run_ci.sh
 This runs:
 
 1. app checks (`validate:graph`, `validate:view-filters`, `validate:composition-views`, `lint`, `build`)
-2. repo-level data checks (`validate_schemas.py`, `validate_goal_ids_uuid.py`, `validate_hessen_upper_secondary_archive_paths.py`, `validate_hessen_upper_secondary_legacy_refs.py`, `validate_hessen_lower_secondary_archive_paths.py`, `validate_hessen_lower_secondary_legacy_refs.py`, `validate_bavaria_gymnasium_archive_paths.py`, `validate_bavaria_gymnasium_legacy_refs.py`)
+2. repo-level data checks (`validate_schemas.py`, `validate_goal_ids_uuid.py`, `validate_hessen_upper_secondary_archive_paths.py`, `validate_hessen_upper_secondary_legacy_refs.py`, `validate_chemistry_exam_pipeline.py`, `validate_hessen_lower_secondary_archive_paths.py`, `validate_hessen_lower_secondary_legacy_refs.py`, `validate_bavaria_gymnasium_archive_paths.py`, `validate_bavaria_gymnasium_legacy_refs.py`)
 3. backend checks (`./gradlew clean check --no-daemon`)

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -36,6 +36,8 @@ echo "--> Validating Hessen Upper-Secondary Archive Paths"
 SKILLPILOT_DISABLE_RG=1 python3 scripts/validate_hessen_upper_secondary_archive_paths.py
 echo "--> Validating Hessen Upper-Secondary Legacy References"
 SKILLPILOT_DISABLE_RG=1 python3 scripts/validate_hessen_upper_secondary_legacy_refs.py
+echo "--> Validating Hessen Chemistry Exam Pipeline"
+python3 scripts/validate_chemistry_exam_pipeline.py
 echo "--> Validating Hessen Lower-Secondary Archive Paths"
 SKILLPILOT_DISABLE_RG=1 python3 scripts/validate_hessen_lower_secondary_archive_paths.py
 echo "--> Validating Hessen Lower-Secondary Legacy References"

--- a/scripts/hessen_upper_secondary_paths.py
+++ b/scripts/hessen_upper_secondary_paths.py
@@ -99,7 +99,7 @@ def resolve_hessen_upper_secondary_landscape_directory(subject_key: str) -> Path
 
 def resolve_hessen_upper_secondary_abi_directory(subject_key: str) -> Path:
     subject = _subject_registry(subject_key)
-    return ROOT / _tooling_registry()["abiArchivePath"] / subject["abiDirectory"]
+    return ROOT / _normalize_tooling_path(_tooling_registry()["abiArchivePath"]) / subject["abiDirectory"]
 
 
 def resolve_hessen_upper_secondary_mapping_path(subject_key: str) -> Path:

--- a/scripts/run_hessen_upper_secondary_delete_handoff_dry_run.sh
+++ b/scripts/run_hessen_upper_secondary_delete_handoff_dry_run.sh
@@ -17,6 +17,7 @@ run_checks() {
   python3 scripts/validate_hessen_upper_secondary_legacy_refs.py
   python3 scripts/validate_math_exam_pipeline.py
   python3 scripts/validate_physics_exam_pipeline.py
+  python3 scripts/validate_chemistry_exam_pipeline.py
 
   cd "$ROOT_DIR/app"
   ./node_modules/.bin/tsx ../scripts/deploy_curriculum_decks.ts


### PR DESCRIPTION
## Summary

- normalize the Hessen upper-secondary ABI archive path in the Python path resolver
- add the chemistry exam pipeline validator to GitHub graph-validation and local run_ci.sh
- include chemistry in the upper-secondary delete-handoff dry run and CI docs

## Validation

- python3 scripts/validate_chemistry_exam_pipeline.py
- python3 scripts/validate_math_exam_pipeline.py
- python3 scripts/validate_physics_exam_pipeline.py
- python3 scripts/validate_hessen_upper_secondary_archive_paths.py
- python3 scripts/validate_hessen_upper_secondary_legacy_refs.py
- bash -n run_ci.sh scripts/run_hessen_upper_secondary_delete_handoff_dry_run.sh