### PR TITLE
[codex] Add Bavaria biology source extraction

### DIFF
--- a/curricula/DE/Gymnasium/input/BY/gymnasium/source-extraction/DE_BY_BIOLOGIE_GYMNASIUM_LEHRPLANPLUS.source-extraction.json
+++ b/curricula/DE/Gymnasium/input/BY/gymnasium/source-extraction/DE_BY_BIOLOGIE_GYMNASIUM_LEHRPLANPLUS.source-extraction.json
@@ -1,0 +1,14601 @@
+{
+  "schemaVersion": 1,
+  "extractionId": "DE-BY-BIOLOGIE-GYMNASIUM-LEHRPLANPLUS",
+  "title": "DE-BY - Biologie Gymnasium (Bayern, LehrplanPLUS Source-Extraction)",
+  "sourceLandscapeId": "357a7003-b636-570e-a0bd-6bb63518d2f6",
+  "jurisdiction": "DE-BY",
+  "subject": "Biologie",
+  "stage": "SekI+SekII",
+  "sourceDocument": {
+    "key": "LEHRPLANPLUS_BIOLOGIE_GYMNASIUM",
+    "title": "LehrplanPLUS Gymnasium Bayern - Biologie",
+    "path": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+    "role": "binding-core",
+    "official": true,
+    "url": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie"
+  },
+  "sourceDocuments": [
+    {
+      "key": "LEHRPLANPLUS_BIOLOGIE_GYMNASIUM",
+      "title": "LehrplanPLUS Gymnasium Bayern - Biologie",
+      "path": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "role": "binding-core",
+      "official": true,
+      "url": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie"
+    }
+  ],
+  "method": {
+    "sourceAcquisition": "Die strukturierte lokale LehrplanPLUS-Biologie-Quelle fuer Gymnasium Bayern ist registriert; die offizielle LehrplanPLUS-Fachseite ist als Kontroll-URL hinterlegt.",
+    "passageExtraction": "Aus der strukturierten LehrplanPLUS-Biologie-Quelle wurden alle zieltragenden Lernbereichsabschnitte als Passage-Einheiten persistiert; synthetische Jahrgangs- und Motivationsknoten werden nicht als Lehrplanpassagen gewertet.",
+    "sourceGoalExtraction": "Alle in den Passage-Einheiten enthaltenen Kompetenzerwartungen mit Zieltext wurden als Source-Ziele persistiert; identische Kompetenzformulierungen aus parallelen GA/EA-Profilen werden normalisiert und ueber sourceOccurrences nachvollziehbar gehalten."
+  },
+  "expectedTopicCodes": [
+    "B8.1",
+    "B8.2",
+    "B8.3",
+    "B8.4",
+    "B8.5",
+    "B8.6",
+    "B9.1",
+    "B9.2",
+    "B9.3",
+    "B9.4",
+    "B9.5",
+    "B9.6",
+    "B10.1",
+    "B10.2",
+    "B10.3",
+    "B10.4",
+    "B12-EA.1",
+    "B12-EA.2",
+    "B12-EA.3",
+    "B12-EA.4",
+    "B12-GA.1",
+    "B12-GA.2",
+    "B12-GA.3",
+    "B12-GA.4",
+    "B13-EA.1",
+    "B13-EA.2",
+    "B13-EA.3",
+    "B13-EA.4",
+    "B13-GA.1",
+    "B13-GA.2",
+    "B13-GA.3",
+    "B13-GA.4"
+  ],
+  "pipelineStatus": {
+    "version": 1,
+    "currentStep": "MAPPING-3",
+    "steps": [
+      {
+        "id": "MAPPING-1",
+        "label": "Original-Lehrplanpassagen extrahiert",
+        "status": "complete",
+        "dependsOn": [],
+        "checks": [
+          {
+            "id": "source-document-present",
+            "label": "Strukturierte LehrplanPLUS-Biologie-Quelle liegt lokal vor",
+            "passed": true,
+            "details": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json"
+          },
+          {
+            "id": "topic-passages-extracted",
+            "label": "Alle zieltragenden LehrplanPLUS-Biologie-Lernbereiche sind als Passagen extrahiert",
+            "passed": true,
+            "details": "Erfasst: 32/32 Passagen."
+          },
+          {
+            "id": "no-legacy-snapshot-counted",
+            "label": "Kein alter Pilot-Quellsnapshot wird als Passage-Extraction gewertet",
+            "passed": true,
+            "details": "Verwendet wird curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json als strukturierte LehrplanPLUS-Quelle; alte Mappingdateien werden nur als M3-Seed verwendet."
+          }
+        ]
+      },
+      {
+        "id": "MAPPING-2",
+        "label": "Source-Ziele aus Lehrplanpassagen erstellt",
+        "status": "complete",
+        "dependsOn": [
+          "MAPPING-1"
+        ],
+        "checks": [
+          {
+            "id": "source-goals-created",
+            "label": "Aus den LehrplanPLUS-Kompetenzerwartungen wurden Source-Ziele erzeugt",
+            "passed": true,
+            "details": "222/362 normalisierte Source-Ziele"
+          },
+          {
+            "id": "source-goal-ids-unique",
+            "label": "Source-Ziel-IDs sind eindeutig",
+            "passed": true,
+            "details": "Doppelte IDs: -"
+          },
+          {
+            "id": "source-goals-reference-passages",
+            "label": "Jedes Source-Ziel referenziert eine vorhandene Originalpassage",
+            "passed": true,
+            "details": "Ohne Passage: -"
+          },
+          {
+            "id": "source-goal-text-present",
+            "label": "Jedes Source-Ziel enthält den LehrplanPLUS-Originaltext",
+            "passed": true,
+            "details": "Ohne Text: -"
+          }
+        ]
+      },
+      {
+        "id": "MAPPING-3",
+        "label": "Source-Ziele auf SkillPilot-Ziele gemappt",
+        "status": "incomplete",
+        "dependsOn": [
+          "MAPPING-1",
+          "MAPPING-2"
+        ],
+        "checks": [
+          {
+            "id": "mapping-2-complete",
+            "label": "MAPPING-2 abgeschlossen",
+            "passed": true,
+            "details": "222 Source-Ziele liegen vor; MAPPING-3 kann gegen diese Source-Extraction-IDs laufen."
+          },
+          {
+            "id": "m3-review-file-present",
+            "label": "M3-Review-Datei ist vorhanden",
+            "passed": true,
+            "details": "curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_biology_source_extraction_to_canonical_biology.review.json"
+          },
+          {
+            "id": "m3-review-decisions-reference-source-goals",
+            "label": "M3-Review-Entscheidungen referenzieren gültige Source-Ziele",
+            "passed": false,
+            "details": "Noch keine fachlichen M3-Review-Entscheidungen; die Datei enthält nur Seed-Mappingkanten aus der Legacy-Biologie-Zuordnung."
+          },
+          {
+            "id": "m3-review-targets-exist",
+            "label": "M3-Review-Ziele referenzieren vorhandene Canonical-Ziele",
+            "passed": false,
+            "details": "Wird nach fachlicher M3-Review gegen den kanonischen Biologiegraphen geprüft."
+          },
+          {
+            "id": "m3-all-source-goals-reviewed",
+            "label": "Alle Source-Ziele haben eine fachliche M3-Entscheidung",
+            "passed": false,
+            "details": "0/222 Source-Ziele fachlich reviewed."
+          },
+          {
+            "id": "m3-all-source-goals-covered-by-canonical",
+            "label": "Alle Source-Ziele sind durch SkillPilot-Ziele abgedeckt",
+            "passed": false,
+            "details": "Seed-Mappings: 62/222; fachliche M3-Review steht aus."
+          }
+        ]
+      }
+    ]
+  },
+  "passages": [
+    {
+      "id": "by-bio:B8.1",
+      "topicCode": "B8.1",
+      "title": "B8 Lernbereich 1: Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "text": "1) formulieren ausgehend von einfach strukturierten Alltags- und Naturphänomenen biologische Fragestellungen und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren vorwiegend qualitativer Beantwortung.\n2) führen einfache naturwissenschaftliche Untersuchungen zu vorgegebenen und eigenen Themen und Fragestellungen durch. Dabei fertigen sie mit Hilfestellung ein naturwissenschaftliches Protokoll an.\n3) beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren mit Hilfestellungen in einem naturwissenschaftlichen Protokoll strukturiert ihre Beobachtungen, werten sie aus und veranschaulichen sie.\n4) bestimmen häufig vorkommende Lebewesen mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk), um ihre Artenkenntnis zu erweitern.\n5) interpretieren erhobene oder recherchierte Daten unter Einbezug möglicher Fehlerquellen und setzen diese zur Eingangshypothese in Beziehung.\n6) erklären die Bedeutung des naturwissenschaftlichen Erkenntnisweges zur Erweiterung des Wissens und schätzen ab, ob eine vorgegebene Fragestellung mithilfe biologischer Methoden zu beantworten ist.\n7) beschreiben Wechselwirkungen und Prozesse (z. B. im menschlichen Organismus, zur Suchtentstehung, zum Einfluss des Menschen auf Ökosysteme) mithilfe von Modellen und schätzen die Grenzen von Modellen ab.\n8) beantworten biologische Fragestellungen, indem sie vorgegebene, auf einfachen Texten und wenigen Darstellungsformen beruhende, auch digitale, Quellen auswerten. Dabei berücksichtigen sie u. a. die Intention der jeweiligen Quelle.\n9) wägen Folgen menschlichen Handelns auf die lokale und globale nachhaltige Entwicklung ab und erörtern Handlungsoptionen, indem sie vorgegebene Pro- und Kontra-Argumente (z. B. zum Einkaufsverhalten oder zur Transportmittelnutzung) auswerten, um bewusste, wertorientierte Entscheidungen treffen zu können.\n10) wägen Folgen von eigenen Verhaltensweisen sowie Verhaltensweisen anderer für die eigene Gesundheit und die Gesundheit anderer ab, um bewusste, wertorientierte Entscheidungen für die Gesunderhaltung (z. B. des Gehörs) treffen zu können.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B8 Lernbereich 1: Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "sourceGoalIds": [
+        "f4ec5855-6377-5afe-92b5-1d851429c1b9",
+        "97e3d9cf-c20b-5fdd-abb8-7f54a459d706",
+        "6df7fcd0-d87f-5b27-88b0-acd38a2adb80",
+        "ab7e59b3-9608-59d4-a025-cafd16fa38ab",
+        "d4ef55b7-0e93-529d-8fb8-fb48f0e596c5",
+        "d6433d0b-1f90-5e71-9d7e-7cb411fa6450",
+        "e703768e-1db3-5148-9757-4070eafe0231",
+        "1f52dec9-c041-52f8-a098-222e00df3940",
+        "debcb740-e2bb-5c43-b0c7-bd8f1da70d64",
+        "54792497-6ad1-5aae-a22e-1dca9f679766"
+      ]
+    },
+    {
+      "id": "by-bio:B8.2",
+      "topicCode": "B8.2",
+      "title": "B8 Lernbereich 2: Informationsaufnahme, ‑verarbeitung und Reaktion beim Menschen (ca. 20 Std.)",
+      "text": "1) beschreiben den Aufbau einer Nervenzelle und die Kommunikation zwischen den verschiedenen Elementen einer Reiz-Reaktions-Kette, um das komplexe Zusammenwirken von Sinnesorganen, Nervensystem und Erfolgsorganen bei der Reaktion des Organismus auf Reize zu erklären.\n2) erklären die Wahrnehmung von Licht als Zusammenwirken von lichtbrechendem Apparat des Auges, den Sehsinneszellen der Netzhaut sowie dem Gehirn und leiten Ursachen von Sehfehlern sowie Möglichkeiten für deren Korrektur ab.\n3) leiten aus den Kenntnissen zum Hörvorgang Maßnahmen zur Vermeidung von Hörschäden ab.\n4) beschreiben mithilfe von Modellvorstellungen den Wirkungsmechanismus von Hormonen und deren Bedeutung für die Informationsübertragung im menschlichen Körper.\n5) erläutern die Regulation des Blutzuckerspiegels durch Hormone und stellen einen Zusammenhang zwischen Lebensgewohnheiten sowie Veranlagung und dem Auftreten von Diabetes her, indem sie erklären, welche Faktoren die Regulation des Blutzuckerspiegels beeinflussen.\n6) erklären das Auftreten körperlicher Symptome bei der Stressreaktion durch das Zusammenspiel von Nervensystem und hormonellen Faktoren und nutzen ihre Kenntnisse für die individuelle Stressbewältigung.\n7) vergleichen die Informationsübertragung im Nervensystem mit der Informationsübertragung durch Hormone.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B8 Lernbereich 2: Informationsaufnahme, ‑verarbeitung und Reaktion beim Menschen (ca. 20 Std.)",
+      "sourceGoalIds": [
+        "091a3a55-29bf-50dd-a701-bed0026280fe",
+        "ad855269-70c3-526c-951b-cc2d54106f36",
+        "92e3879a-12e7-56d6-b8c0-94e61db932c4",
+        "f9d70cb7-d9fa-5351-bd87-b5a1ac48c918",
+        "8b2bc52e-c75a-52f8-8d6e-c889098b1b63",
+        "65529a29-8e40-5c29-ab13-43c5e9d91fe0",
+        "0236413c-a800-5cc7-94d8-071e45ed8948"
+      ]
+    },
+    {
+      "id": "by-bio:B8.3",
+      "topicCode": "B8.3",
+      "title": "B8 Lernbereich 3: Fortpflanzung und Individualentwicklung des Menschen (ca. 10 Std.)",
+      "text": "1) verständigen sich in medizinischen und gesellschaftlichen Kontexten sowie in Partnerschaften in geeigneter Sprache und respektvoll über Sexualität und begegnen medial vermittelter sexueller Belästigung und Gewalt sowie der unterschwelligen Bedrohung durch sexualisierten, abwertenden Sprachgebrauch angemessen.\n2) bewerten unterschiedliche Verhaltensweisen im Hinblick auf die sexuelle Selbstbestimmung, die Achtung von persönlicher Würde und freier Selbstentfaltung und stellen Rollen- und Körperbilder und die Sexualisierung von Alltagsthemen in den Medien infrage.\n3) charakterisieren psychische und physische Veränderungen während der Pubertät als Teil eines biologischen Entwicklungsprozesses, um diese Veränderungen dadurch bei sich und bei anderen besser annehmen und verstehen zu können. Dabei erkennen sie den Einfluss der Medien auf eigene Vorstellungen von Sexualität und Schönheit.\n4) beschreiben den Menstruationszyklus und erklären dessen Steuerung durch das Zusammenspiel verschiedener Hormone.\n5) bewerten verschiedene Verhaltensweisen im Vorfeld und während der Schwangerschaft im Hinblick auf mögliche gesundheitliche Folgen für das Kind.\n6) erklären die Wirkungsweise verschiedener Methoden der Empfängnisregulation, um deren Vor- und Nachteile abzuwägen und so Familienplanung aktiv und verantwortlich gestalten zu können.\n7) nutzen Wissen zu sexuell übertragbaren Erkrankungen und deren Übertragungswegen, um sich und andere vor einer Infektion zu schützen.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B8 Lernbereich 3: Fortpflanzung und Individualentwicklung des Menschen (ca. 10 Std.)",
+      "sourceGoalIds": [
+        "5d142d10-554b-533a-9457-c8abe3b9cd7c",
+        "6ceddf31-0bb9-5fac-a286-d635bbca600b",
+        "540b60bd-556d-55a8-8814-ad99ccc4ecd8",
+        "5d2a6bed-9958-5753-8fb4-9703d5a15752",
+        "b89ae127-06b7-5752-a60a-c96d4c53db6e",
+        "24c2aaf9-e4b2-5b71-9449-7d954795ba6c",
+        "b0a2fbf6-bf74-5e9f-8ca1-39ae90ffe0b8"
+      ]
+    },
+    {
+      "id": "by-bio:B8.4",
+      "topicCode": "B8.4",
+      "title": "B8 Lernbereich 4: Verhalten – genetisch bedingt und erlernt (ca. 10 Std.)",
+      "text": "1) beobachten und vergleichen einfache Verhaltensweisen auch mithilfe von Attrappenversuchen, um sie als Ergebnis des Zusammenwirkens von inneren Faktoren und reaktionsauslösenden Reizen zu beschreiben.\n2) beurteilen auf der Grundlage von Daten aus Verhaltensbeobachtungen, ob eine Verhaltensweise v. a. auf genetisch bedingten oder erworbenen Anteilen beruht.\n3) planen Experimente zur Konditionierung, um die Beeinflussbarkeit von Verhaltensweisen durch Umwelteinflüsse zu ermitteln, und grenzen ggf. die Lernfähigkeit des Menschen von der anderer Lebewesen ab.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B8 Lernbereich 4: Verhalten – genetisch bedingt und erlernt (ca. 10 Std.)",
+      "sourceGoalIds": [
+        "ed0a0007-5c26-5a6c-954b-9840ee344563",
+        "dd94b698-5c06-5a28-966f-b0294fa78805",
+        "f2c5e33a-178f-54e1-9f8c-5d1a4910870a"
+      ]
+    },
+    {
+      "id": "by-bio:B8.5",
+      "topicCode": "B8.5",
+      "title": "B8 Lernbereich 5: Suchtgefahren und Gesundheit (ca. 6 Std.)",
+      "text": "1) erläutern die Grenze zwischen Genuss und Sucht, um sich eigener Suchtrisiken bewusst zu werden.\n2) erklären mithilfe von Modellen die Entstehung von Suchtverhalten, beschreiben Folgen für Betroffene und sind dadurch für die Gefahren einer Sucht sensibilisiert.\n3) erklären die Bedeutung von Lebenskompetenzen für eine starke Persönlichkeit, die die Anforderungen des Alltags bewältigen kann und ihre Zufriedenheit nicht von bestimmten Verhaltensweisen oder Substanzen abhängig macht, um Strategien für die eigene Persönlichkeitsentwicklung ableiten zu können.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B8 Lernbereich 5: Suchtgefahren und Gesundheit (ca. 6 Std.)",
+      "sourceGoalIds": [
+        "039a2c9c-f2f8-5f1e-b20e-21d6a503546a",
+        "e2600c5b-3f63-5b03-be78-50d01912e0d0",
+        "33ee5392-408e-5a7e-a764-8b95b66ecb79"
+      ]
+    },
+    {
+      "id": "by-bio:B8.6",
+      "topicCode": "B8.6",
+      "title": "B8 Lernbereich 6: Ökosysteme unter dem Einfluss des Menschen (ca. 10 Std.)",
+      "text": "1) charakterisieren die Veränderung eines ortsnahen Ökosystems im Lauf der Zeit, um die Entwicklung dieses Ökosystems unter dem Einfluss des Menschen von einer natürlichen Entwicklung zu unterscheiden.\n2) beschreiben Eingriffe des Menschen in die Natur, erörtern Handlungsoptionen unter dem Aspekt einer nachhaltigen Entwicklung und treffen so begründete Entscheidungen für oder gegen diese Eingriffe.\n3) bewerten die Beeinflussung globaler Stoffströme unter dem Aspekt der nachhaltigen Entwicklung und beschreiben politische und persönliche Möglichkeiten, Einfluss auf diese Systeme zu nehmen.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B8 Lernbereich 6: Ökosysteme unter dem Einfluss des Menschen (ca. 10 Std.)",
+      "sourceGoalIds": [
+        "d275b9f4-09ed-5b32-951c-df550720204d",
+        "d51e6243-8b61-5bb5-b9e8-99456895d22a",
+        "a161e6be-c302-513e-ba6b-ae217ed84a78"
+      ]
+    },
+    {
+      "id": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "title": "B9 Lernbereich 1: Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "text": "1) leiten ausgehend von für sie vorstrukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zur Beantwortung dieser Fragestellungen vermehrt auch aus quantitativer Sicht.\n2) führen einfache selbstgeplante oder komplexe angeleitete naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten bei bekannten Sachverhalten selbständig und bei unbekannten mit Hilfestellung (ggf. auch mit digitalen Hilfsmitteln) vor.\n3) beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren überwiegend selbständig ihre Beobachtungen, werten sie aus und veranschaulichen sie.\n4) verwenden ein Lichtmikroskop oder Binokular, um Präparate zu betrachten, und erstellen selbständig beschriftete Zeichnungen der betrachteten biologischen Strukturen.\n5) vergleichen Lebewesen und deren Merkmale kriteriengeleitet, um Rückschlüsse auf die Ursachen von Ähnlichkeiten zu ziehen.\n6) systematisieren u. a. Insekten mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk) und sind sich dadurch der Artenvielfalt der Wirbellosen bewusst.\n7) interpretieren erhobene oder recherchierte Daten und schätzen deren Gültigkeit ein. Sie benennen mögliche Fehlerquellen und leiten Maßnahmen zur Fehlervermeidung ab.\n8) beschreiben ausgewählte Eigenschaften naturwissenschaftlichen Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab (z. B. Evolutionsforschung).\n9) beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Kohlenstoffatomkreislauf, DNA-Replikation) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken, Schwächen und Grenzen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten.\n10) beantworten biologische Fragestellungen, indem sie vorgegebene und selbst recherchierte, auch digitale Quellen situations- und adressatengerecht auswerten.\n11) bewerten selbständig biologische Sachverhalte und Folgen menschlichen Handelns, indem sie Pro- und Kontra-Argumente formulieren und diese abwägen, um Handlungsoptionen zu entwickeln. Dabei berücksichtigen sie auch die Notwendigkeit des Einbezugs vielfältiger Gesichtspunkte bei der Urteilsfindung.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B9 Lernbereich 1: Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "sourceGoalIds": [
+        "f4bbc76c-c071-5370-8596-0a2f94a82569",
+        "9a1f283e-03c8-5f29-81b5-c4306f4972a4",
+        "1b2d5534-d17e-574c-982a-194934ddc6c7",
+        "ea1d4041-df5d-55e4-8286-3898c3063826",
+        "0cf1cee3-5715-597d-8108-65f47d9624b6",
+        "cc6b48b2-27c7-55aa-addd-123e31080217",
+        "55e67047-03c8-5551-a360-d8f91ef65c7b",
+        "a4c628d9-cf4b-5a6f-80a6-32512acd9004",
+        "39e911cd-891b-5aa3-af27-bf5d3053d6ff",
+        "211c8f83-7a8b-5ba0-b794-69bdad821ba5",
+        "9a0c77f1-b6ae-5c8f-a894-1a3634c3a512"
+      ]
+    },
+    {
+      "id": "by-bio:B9.2",
+      "topicCode": "B9.2",
+      "title": "B9 Lernbereich 2: Mikroorganismen in der Biotechnologie (ca. 8 Std.)",
+      "text": "1) erklären die biotechnologische Nutzbarkeit von Mikroorganismen, indem sie deren Besonderheiten im Grundbauplan, bei der Fortpflanzung und im Stoffwechsel beschreiben.\n2) erklären die Bedeutung von Mikroorganismen beim Lebensmittelverderb anhand des Stoffwechsels, der Fortpflanzung und der Ausbreitung von Mikroorganismen und leiten daraus Verhaltensweisen zur Lebensmittelhygiene ab.\n3) erklären die Wirkungsweise verschiedener Konservierungsmethoden und vergleichen die Auswirkung dieser Methoden auf die Lebensmittelqualität.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B9 Lernbereich 2: Mikroorganismen in der Biotechnologie (ca. 8 Std.)",
+      "sourceGoalIds": [
+        "dc5044f4-bf54-5642-8201-49dcf8dce9e1",
+        "b564e60e-832b-55bd-b01d-9607a1e8a2a2",
+        "f0f89514-0f46-5f3d-9a2b-c75352d5a8ba"
+      ]
+    },
+    {
+      "id": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "title": "B9 Lernbereich 3: Genetik und Gentechnik (ca. 18 Std.)",
+      "text": "1) erklären verschiedene Funktionen von Proteinen im Organismus anhand ihrer strukturellen Vielfalt.\n2) beschreiben ein Modell der DNA und erklären anhand dieses Modells die Zusammenhänge zwischen ihrer Struktur und ihrer Funktion als Informationsspeicher.\n3) erklären das Prinzip der Bildung von Proteinen durch die Proteinbiosynthese und die Rolle der Proteine bei der Merkmalsausbildung.\n4) vergleichen die Organisation des genetischen Materials bei Pro- und Eukaryoten.\n5) erklären die Bedeutung der Replikation von DNA und stellen den Ablauf mithilfe eines einfachen DNA-Modells dar.\n6) beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Fortpflanzung.\n7) beschreiben das Prinzip der Meiose zur Bildung von Keimzellen und erklären die Bedeutung dieses Prozesses für die geschlechtliche Fortpflanzung und die genetische Vielfalt.\n8) erklären Genommutationen beim Menschen als Folge von Fehlern bei der Meiose.\n9) unterscheiden im Kontext von Genommutationen zwischen einer Änderung des Phänotyps und einer Krankheit.\n10) bewerten medizinische, soziale und ethische Aspekte der reproduktionsmedizinischen Diagnostik, um an gesellschaftlichen Diskussionen aktiv teilnehmen zu können.\n11) erläutern die prinzipielle Verfahrensweise zur technischen Neukombination von Erbinformationen und bewerten durch sie geschaffene Möglichkeiten unter medizinischen, gesellschaftlichen und ethischen Aspekten.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B9 Lernbereich 3: Genetik und Gentechnik (ca. 18 Std.)",
+      "sourceGoalIds": [
+        "caa62aba-fb03-5b28-8df1-d09624168990",
+        "e4f857b8-85da-58e5-9fb4-b4f05048d3b5",
+        "a6ad1554-558e-51e4-9d05-aa9b38ebfa40",
+        "673d3825-e43d-585c-9ee7-58bb143fd382",
+        "b9b18077-88f5-57ed-981e-2f7e2512af4c",
+        "55793844-76b0-57d8-a3c1-e5db5fa2e370",
+        "e0bbe3b2-96d7-5e7a-b8c1-d649a084e355",
+        "706204f2-4768-56d3-984a-85e9ec6fc370",
+        "a3e24e24-e489-57ad-88f1-64e85633225d",
+        "2802979c-6270-521c-87e0-1ed9360d6bea",
+        "1ad96d9d-03d9-565f-94b2-94f6ed17c523"
+      ]
+    },
+    {
+      "id": "by-bio:B9.4",
+      "topicCode": "B9.4",
+      "title": "B9 Lernbereich 4: Evolution (ca. 8 Std.)",
+      "text": "1) beschreiben die Stammesgeschichte der Lebewesen als fortlaufendes Evolutionsgeschehen, das mithilfe von naturwissenschaftlichen Befunden belegt werden kann.\n2) erklären die Entstehung einer heute lebenden Art als evolutionären Prozess, indem sie deren stammesgeschichtliche Entwicklung auf die Wirkung der Evolutionsfaktoren zurückführen.\n3) erklären Angepasstheiten an die jeweiligen biotischen und abiotischen Umweltfaktoren als Selektionsvorteil.\n4) erklären die Bedeutung der geographischen Isolation für die Entstehung der biologischen Vielfalt.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B9 Lernbereich 4: Evolution (ca. 8 Std.)",
+      "sourceGoalIds": [
+        "b17074cd-317a-512a-a4d8-6fbd5d037dd4",
+        "efe8409f-0ba6-58e4-80ae-3967c4e9f4be",
+        "dc172e4b-d8df-5b79-85ca-1116c2b64019",
+        "2310bc26-c562-59d5-a45e-343d6b031c94"
+      ]
+    },
+    {
+      "id": "by-bio:B9.5",
+      "topicCode": "B9.5",
+      "title": "B9 Lernbereich 5: Biodiversität bei Wirbellosen – Variabilität und Angepasstheit (ca. 16 Std.)",
+      "text": "1) vergleichen das Skelett und den Bewegungsapparat von Insekten mit denen von Wirbeltieren und ggf. mit denen einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.\n2) vergleichen die Angepasstheit der aktiven Bewegung bei Insekten an verschiedene Lebensräume.\n3) vergleichen Vertreter der Insekten mit Wirbeltieren und ggf. Vertretern einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten zum Stofftransport und -austausch. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.\n4) vergleichen die Angepasstheiten der Mundwerkzeuge bei Insekten an verschiedene Nahrungsquellen und schätzen die Auswirkungen dieser Nutzung unterschiedlicher Nahrungsquellen auf den Menschen ab.\n5) vergleichen Vertreter der Insekten untereinander, mit Vertretern der Wirbeltiere und ggf. mit Vertretern weiterer Gruppen der Wirbellosen hinsichtlich ihrer Fortpflanzung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.\n6) vergleichen Vertreter der Insekten untereinander und mit Vertretern der Wirbeltiere hinsichtlich ihrer Individualentwicklung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.\n7) vergleichen das Nervensystem von Insekten mit dem von Wirbeltieren und ggf. dem Nervensystem von Vertretern einer weiteren Gruppe der Wirbellosen. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.\n8) vergleichen Vertreter der Insekten mit Wirbeltieren hinsichtlich ihrer Sinnesorgane und Sinnesleistungen.\n9) erklären die Bedeutung verschiedener Signale zur inner- und zwischenartlichen Kommunikation bei Insekten.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B9 Lernbereich 5: Biodiversität bei Wirbellosen – Variabilität und Angepasstheit (ca. 16 Std.)",
+      "sourceGoalIds": [
+        "b43f3efe-487c-5210-aad4-6e3eb1468e91",
+        "298c2060-c761-5029-9090-91b2292a679c",
+        "49770c26-6652-584b-80f5-625465cfa897",
+        "bea8c52c-bdba-5ae1-97a7-87b9af9fe8f8",
+        "6fe6a4af-3d6a-5afa-85fe-ae2b2202e42e",
+        "7be0e13a-2a59-5463-b44d-a9233a48aad0",
+        "3a0d3bc3-598d-54a2-8932-73a600c3e166",
+        "7a28147c-b531-563c-845d-b397997c6639",
+        "0ddc9d8b-c3d5-5df9-bbd3-96b26de53470"
+      ]
+    },
+    {
+      "id": "by-bio:B9.6",
+      "topicCode": "B9.6",
+      "title": "B9 Lernbereich 6: Ökosystem Boden (ca. 6 Std.)",
+      "text": "1) untersuchen Boden, protokollieren die Ergebnisse ggf. mithilfe digitaler Medien und erkunden so das Biotop und die Biozönose des Bodens.\n2) stellen den Stoff- und Energiefluss innerhalb der Biozönose des Bodens dar und beschreiben die Humusbildung und Mineralisierung als zeitliche Veränderung.\n3) stellen einen einfachen Kohlenstoffatomkreislauf als Wechselwirkungen zwischen Organismen und zwischen Organismen und unbelebter Materie dar.\n4) beurteilen die Bedeutung des Bodens für eine nachhaltige Produktion von Lebensmitteln, charakterisieren Gefahren für dieses Ökosystem durch die komplexe Verkettung menschlicher Einflüsse und sind sich dabei der Folgen für die Menschen bewusst.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B9 Lernbereich 6: Ökosystem Boden (ca. 6 Std.)",
+      "sourceGoalIds": [
+        "e1b4d7fa-ea04-544f-a04f-630865810b71",
+        "1107a269-d9dd-5cac-9ab5-fe7086d7a3e3",
+        "6a34dc00-ba46-565f-93c4-5748f5bd2fc9",
+        "0afc5a61-e1cf-5b36-8d3c-aa41e19a0de5"
+      ]
+    },
+    {
+      "id": "by-bio:B10.1",
+      "topicCode": "B10.1",
+      "title": "B10 Lernbereich 1: Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "text": "1) leiten aus komplex strukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren qualitativer und quantitativer Beantwortung.\n2) führen u. a. selbstgeplante naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten (auch mit digitalen Hilfsmitteln) selbständig vor.\n3) beurteilen die Gültigkeit von erhobenen oder recherchierten Daten und finden in diesen Daten Trends, Strukturen und Beziehungen.\n4) beschreiben Grenzen des im Rahmen eines naturwissenschaftlichen Erkenntniswegs generierten Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab.\n5) beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Enzymatik) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken und Schwächen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten und weiterzuentwickeln.\n6) unterscheiden zwischen alltags- und fachsprachlichen Texten. Sie wählen mediale Informationsquellen begründet aus und entnehmen gezielt Inhalte zur adressaten- und situationsgerechten Beantwortung biologischer Fragestellungen.\n7) formulieren unter Nutzung fachwissenschaftlicher Erkenntnisse der Biologie systematisch und begründet Handlungsoptionen, wenden dabei Entscheidungsstrategien an und reflektieren über getroffene Entscheidungen.\n8) beurteilen die Folgen von Maßnahmen und Verhaltensweisen für die eigene Gesundheit und die Gesundheit anderer, um auch unter Einbezug gesellschaftlicher Perspektiven bewusste wertorientierte Entscheidungen für die Gesunderhaltung treffen zu können (z. B. Impfungen).",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B10 Lernbereich 1: Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "sourceGoalIds": [
+        "08e4882b-46a2-5e58-b1bd-b9e95995dd87",
+        "cd4d29ab-121e-5b5e-8db2-1cce371cd93c",
+        "c7a6f8a0-04af-59c5-bc49-b9b428a816aa",
+        "c8154bd2-306a-5875-8609-cf35ec63a901",
+        "d0cf0ae9-8943-5c29-9708-b394592d214c",
+        "42123cb1-f0a6-5787-b95e-43a86388d3d2",
+        "f2c82a1a-6e62-5150-ad3f-ae42bc79f42b",
+        "94d9d6c7-bbda-5ddc-b755-5c0c2baa8ec3"
+      ]
+    },
+    {
+      "id": "by-bio:B10.2",
+      "topicCode": "B10.2",
+      "title": "B10 Lernbereich 2: Ökosystem Mensch (ca. 16 Std.)",
+      "text": "1) beschreiben Wechselbeziehungen zwischen dem Menschen und anderen Lebewesen, die auf und im menschlichen Körper leben, um Maßnahmen und Verhaltensweisen für eine gesundheitsbewusste Lebensführung abzuleiten.\n2) unterscheiden bakterielle und virale Infektionen, beschreiben an ausgewählten Beispielen deren Verlauf und beurteilen Möglichkeiten und Grenzen des Infektionsschutzes und der Therapie.\n3) erläutern körpereigene unspezifische sowie spezifische Abwehrmechanismen zum Schutz vor Parasiten und Krankheitserregern und beschreiben Allergien als Fehlreaktionen des Immunsystems.\n4) erläutern das Prinzip der aktiven und passiven Immunisierung sowie die Notwendigkeit von vorbeugenden Schutzimpfungen, um in entsprechenden Lebenssituationen sachgerecht handeln zu können.\n5) beurteilen am Beispiel des Einsatzes von Antibiotika die Auswirkungen eines Eingriffes in die Biozönose des Ökosystems Mensch und erläutern die Risiken einer nichtsachgemäßen Verwendung.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B10 Lernbereich 2: Ökosystem Mensch (ca. 16 Std.)",
+      "sourceGoalIds": [
+        "31582972-78fe-53b8-82e2-6c239087140a",
+        "04fcb49f-b677-56c9-bcdd-7808efa9c7c8",
+        "9ffecbe5-ed7b-5a1b-9a59-5e6b5a23a165",
+        "57c704e7-0ed0-50f5-8e9f-2043bfe0ccc3",
+        "eddfa569-9406-57be-ada7-d9b737c0675e"
+      ]
+    },
+    {
+      "id": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "title": "B10 Lernbereich 3: Stoff- und Energieumwandlung im Menschen (ca. 33 Std.)",
+      "text": "1) beschreiben den Menschen als offenes System, der für die Aufrechterhaltung seines Stoffwechsels und damit für sein Überleben Energieträger und Baustoffe zu sich nehmen muss.\n2) vergleichen ausgewählte Inhaltsstoffe von Nahrungsmitteln anhand des molekularen Baus, um sie den Makronährstoffgruppen (Kohlenhydrate, Fette, Proteine) zuzuordnen.\n3) leiten aus der Bedeutung von Makronährstoffen und Mikronährstoffen (Vitamine und Mineralsalze) für den Körper und der Zusammensetzung von Nahrungsmitteln ein den Lebensumständen angepasstes, ausgewogenes Ernährungskonzept ab.\n4) erläutern am Beispiel der Verdauung die allgemeine Wirkungsweise von Enzymen auf der Stoff- und der Teilchenebene, indem sie das Energiekonzept und das Schlüssel-Schloss-Modell auf enzymkatalysierte Reaktionen anwenden.\n5) erläutern die Enzymausstattung des Menschen als Angepasstheit, indem sie die Beeinflussung der Enzymaktivität durch Außenfaktoren beschreiben.\n6) erklären das Zusammenwirken der Bestandteile des Verdauungssystems beim Transport des Nahrungsbreis und beim stufenweisen enzymatischen Abbau von Kohlenhydraten, Fetten und Proteinen zu resorbierbaren Teilchen.\n7) beschreiben den Aufbau der Dünndarmwand, um mithilfe des Struktur-Funktions-Konzepts die Resorption zu erläutern.\n8) erklären den Gasaustausch durch Diffusion mithilfe des Struktur-Funktions-Konzepts.\n9) erläutern die Funktion des Herz-Kreislauf-Systems als Transportsystem zwischen der Umgebung und allen Zellen des menschlichen Körpers bei der Stoffaufnahme und ‐abgabe.\n10) erklären die Bedeutung einer aktiven Gesundheitsvorsorge zur Vermeidung von Schädigungen und Erkrankungen der Lunge und des Herz-Kreislauf-Systems und erläutern medizinische Möglichkeiten ihrer Behandlung.\n11) beschreiben den Glucoseabbau als exotherme Redoxreaktion, in deren Verlauf die abgegebene Energie im Energieträger ATP gespeichert wird, und erläutern die Notwendigkeit dieses mobilen und universellen Energieträgers.\n12) vergleichen die Stoff- und Energiebilanz des aeroben und anaeroben Abbaus von Glucose in menschlichen Zellen, um die Bedeutung beider Stoffwechselwege für den menschlichen Organismus zu erläutern.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B10 Lernbereich 3: Stoff- und Energieumwandlung im Menschen (ca. 33 Std.)",
+      "sourceGoalIds": [
+        "d8d1e189-9d47-5e5c-9f9f-450a357c8ffb",
+        "5a48b62b-a6b8-5a82-ab80-d43003960cd0",
+        "71c526b6-8c6d-50d9-9d1d-529e5e7e3f21",
+        "bd5adfd4-8da0-5872-9152-0be6cbdba487",
+        "d211a55b-11e7-5596-89ac-2021cb49cc97",
+        "3696816f-4126-5fc3-a2ca-a84927b7ff6c",
+        "637df96d-52aa-52ee-8a6b-db2748122e5e",
+        "a53d4b2b-5d39-5b7c-98a6-3287f5b024f1",
+        "efcf0167-7143-59a2-91b3-f0fbbc2153e4",
+        "013209a3-9dd2-5fb2-9347-c7f21572bd99",
+        "2aa63a1f-2267-50c6-9fe6-1ade7ec30b50",
+        "93d6d931-debc-5f17-9e41-baafe529dcf4"
+      ]
+    },
+    {
+      "id": "by-bio:B10.4",
+      "topicCode": "B10.4",
+      "title": "B10 Lernbereich 4: Vergangenheit und Zukunft des Menschen (ca. 7 Std.)",
+      "text": "1) skizzieren den Verlauf der Geschichte des Lebens, um zu verdeutlichen, dass der moderne Mensch eine erdgeschichtlich junge Art ist.\n2) ordnen den modernen Menschen (Homo sapiens) unter Berücksichtigung anatomischer und molekularbiologischer Merkmale in das natürliche System ein.\n3) leiten aus Merkmalen fossiler Funde Hypothesen zur biologischen Evolution des modernen Menschen ab, um die zeitliche Reihenfolge eines Evolutionsprozesses zu rekonstruieren, und analysieren die Bedeutung der kulturellen Evolution für den heutigen Menschen in seiner Umwelt.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "B10 Lernbereich 4: Vergangenheit und Zukunft des Menschen (ca. 7 Std.)",
+      "sourceGoalIds": [
+        "b957227d-cd28-5d10-8de4-9a487b70a3ec",
+        "bb2200a1-389f-5ce4-ad80-5c599c9cd59e",
+        "791145f3-650f-5e1a-84f7-2619aceb6a6a"
+      ]
+    },
+    {
+      "id": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "title": "Biologie 12 (erhöhtes Anforderungsniveau): B12 Lernbereich 1: Biologische Sachverhalte und Zusammenhänge betrachten – Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "text": "1) beschreiben und erläutern biologische Sachverhalte, Phänomene und Anwendungen der Biologie sachgerecht. Zur Strukturierung und Erschließung nutzen sie Basiskonzepte und binden fachübergreifende Aspekte ein.\n2) formulieren zu biologischen Phänomenen sowie Anwendungen der Biologie theoriegeleitet Hypothesen und Aussagen.\n3) erschließen und erläutern mithilfe von Basiskonzepten strukturiert die Eigenschaften lebender Systeme unter qualitativen und quantitativen Aspekten. Dabei stellen sie Vernetzungen zwischen Systemebenen (Molekular- bis Biosphärenebene) her.\n4) erläutern Prozesse in und zwischen lebenden Systemen sowie zwischen lebenden Systemen und ihrer Umwelt.\n5) erläutern die Entstehung und Bedeutung von Biodiversität sowie Gründe für deren Schutz und nachhaltige Nutzung.\n6) identifizieren und entwickeln ausgehend von Phänomenen und Beobachtungen Fragestellungen zu biologischen Sachverhalten und stellen theoriegeleitet Hypothesen zu ihrer Bearbeitung auf.\n7) planen und führen hypothesengeleitete Beobachtungen, Vergleiche, Experimente und Modellierungen unter Berücksichtigung des jeweiligen Variablengefüges bzw. der Variablenkontrolle durch und protokollieren sie.\n8) nehmen qualitative und quantitative Daten auch mithilfe digitaler Werkzeuge auf und werten sie aus.\n9) wenden Labor- und freilandbiologische Geräte und Techniken sachgerecht und unter Berücksichtigung der Sicherheitsbestimmungen an.\n10) finden in erhobenen oder recherchierten Daten Strukturen, Beziehungen und Trends, erklären diese theoriebezogen und ziehen Schlussfolgerungen.\n11) reflektieren die eigenen Ergebnisse und den eigenen Prozess der Erkenntnisgewinnung, indem sie die Gültigkeit von Daten beurteilen, mögliche Fehlerquellen ermitteln sowie Möglichkeiten und Grenzen von Modellen diskutieren.\n12) widerlegen oder stützen die Hypothese (Hypothesenrückbezug).\n13) stellen bei der Interpretation von Untersuchungsbefunden fachübergreifende Bezüge her.\n14) reflektieren Möglichkeiten und Grenzen des konkreten Erkenntnisgewinnungsprozesses sowie der gewonnenen Erkenntnisse (z. B. Reproduzierbarkeit, Falsifizierbarkeit, Intersubjektivität, logische Konsistenz, Vorläufigkeit).\n15) reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung), sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.\n16) recherchieren zu biologischen Sachverhalten und anwendungsbezogenen Fragestellungen zielgerichtet in analogen und digitalen Medien. Sie wählen aus für ihre Zwecke passenden Quellen relevante und aussagekräftige Informationen und Daten aus. Dabei erschließen sie Informationen aus Darstellungsformen unterschiedlicher Komplexität.\n17) analysieren Herkunft, Qualität und Vertrauenswürdigkeit von verwendeten Quellen und Medien sowie darin enthaltene Darstellungsformen im Zusammenhang mit der Intention der Autorin/des Autors. Sie prüfen die Übereinstimmung verschiedener Quellen im Hinblick auf deren Aussagen.\n18) strukturieren und interpretieren ausgewählte Informationen und leiten Schlussfolgerungen ab. Dazu nutzen sie geeignete Darstellungsformen und überführen diese ineinander.\n19) unterscheiden zwischen Alltags- und Fachsprache sowie zwischen funktionalen und kausalen Erklärungen. Sie erklären Sachverhalte aus proximater und ultimater Sicht, ohne dabei finale Begründungen zu nutzen.\n20) verarbeiten sach-, adressaten- und situationsgerecht Informationen zu biologischen Sachverhalten.\n21) präsentieren biologische Sachverhalte sowie Lern- und Arbeitsergebnisse unter Einsatz sach-, adressaten- und situationsgerechter Darstellungsformen mithilfe analoger und digitaler Medien.\n22) prüfen die Urheberschaft, belegen verwendete Quellen und kennzeichnen Zitate.\n23) tauschen sich mit anderen konstruktiv über biologische Sachverhalte aus. Sie argumentieren dabei wissenschaftlich kriterien- und evidenzbasiert sowie situationsgerecht. Sie vertreten, reflektieren und korrigieren gegebenenfalls den eigenen Standpunkt.\n24) analysieren Sachverhalte im Hinblick auf ihre Bewertungsrelevanz und betrachten relevante Sachverhalte aus unterschiedlichen Perspektiven.\n25) unterscheiden deskriptive und normative Aussagen und identifizieren Werte, die den normativen Aussagen zugrunde liegen.\n26) beurteilen Quellen hinsichtlich ihrer Herkunft und in Bezug auf spezifische Interessenlagen.\n27) beurteilen Möglichkeiten und Grenzen biologischer Sichtweisen.\n28) stellen Bewertungskriterien auf, auch unter Berücksichtigung außerfachlicher Aspekte.\n29) bilden sich kriteriengeleitet Meinungen, indem sie die Handlungsoptionen auf der Basis reflektierter Wertvorstellungen abwägen, und treffen so Entscheidungen auf der Grundlage von Sachinformationen und Werten.\n30) reflektieren kurz- und langfristige, lokale und globale Folgen eigener und gesellschaftlicher Entscheidungen.\n31) reflektieren den Prozess der Bewertung aus persönlicher, gesellschaftlicher und ethischer Perspektive.\n32) beurteilen und bewerten Auswirkungen von Anwendungen der Biologie im Sinne einer nachhaltigen Entwicklung aus ökologischer, ökonomischer, politischer und sozialer Perspektive.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 12 (erhöhtes Anforderungsniveau): B12 Lernbereich 1: Biologische Sachverhalte und Zusammenhänge betrachten – Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "sourceGoalIds": [
+        "93208e54-7814-5738-b753-e30df89dcd5d",
+        "c86da1fa-e9b1-53e1-8a71-ebeda357eb72",
+        "66dbee5c-ffd7-5ffc-bace-0898d13479b2",
+        "14c703b4-fcc6-5e15-8027-1696a3024ab6",
+        "16b8c298-6574-5eb5-81d6-e6d68839ee68",
+        "d128f994-616b-5bd7-a01a-ecf428ee54df",
+        "28e9a9ec-76d4-57f8-a8b2-a14bfe2f0dc4",
+        "258ad6b8-86fb-5300-b3b9-43626e1b6ab5",
+        "6be93217-c8d5-5db7-bb9f-7fb4996c7f0c",
+        "5b33bfb3-b22f-52e0-a0d2-a5931dcbdbe6",
+        "cacf5cc8-5dd2-56f0-aa7f-289b23c30f2a",
+        "3258593f-0a53-52f4-b067-6c05f76937e0",
+        "d1acb51b-f547-567a-a0e6-2f24dd78bebb",
+        "361dc7c8-154c-5919-abc7-34405877cfd1",
+        "4d662fc7-15ce-5b6d-a5a1-287b48af2145",
+        "8a1f3103-4b49-5daa-a0d8-58723438305a",
+        "9f8601f9-64b9-5ea1-9ce1-7ecd54fa2f1c",
+        "705566d5-ceab-5a71-a17b-5d740fa9dfa0",
+        "8963b296-06f3-523a-b9e9-e3d45c3a23a6",
+        "15ac8e5e-6111-545f-b582-0cf12d44d39a",
+        "0abbbcd7-302f-5eb1-af4d-fb05e1cc949a",
+        "72038809-f11a-50dd-a273-a968e0cd9dbf",
+        "089ead71-0bc3-578a-91b9-3bea7d06db52",
+        "bcf192b7-fa63-5ac3-b13f-0039feb00b0b",
+        "ebcdf533-a915-57e4-b5f9-e1b790d7f620",
+        "ee7bfa35-b97d-5714-8aaf-78f1184e0215",
+        "7ea5fd68-c411-50f2-8697-711c12fa28d4",
+        "540f78e7-e84a-511b-ad72-30aaf732c529",
+        "b8f0ab01-fc00-50df-85b0-cd19387f0731",
+        "be7422d3-8de7-5907-8e5f-657484b6270b",
+        "ab4b91cc-3e72-5413-9a0b-7144a2502e56",
+        "50f29a21-d711-596b-88cd-89399509c8d6"
+      ]
+    },
+    {
+      "id": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "title": "Biologie 12 (erhöhtes Anforderungsniveau): B12 Lernbereich 2: Genetik und Gentechnik (ca. 86 Std.)",
+      "text": "1) beschreiben ein Modell zum Bau der DNA und vergleichen es mit einem entsprechenden Modell zum Bau der RNA.\n2) leiten aus Basensequenzen der DNA Aminosäuresequenzen von Proteinen sowie aus der Aminosäuresequenz von Proteinen mögliche Basensequenzen für eine codierende DNA ab, indem sie den genetischen Code anwenden.\n3) beschreiben den Mechanismus der Bildung von Proteinen durch die Proteinbiosynthese und erklären deren Bedeutung für das Leben.\n4) erklären die Bedeutung des alternativen Spleißens für die Erhöhung der Proteinvielfalt bei Eukaryoten, die eine Voraussetzung für Selektionsprozesse in der Evolution darstellt.\n5) beschreiben den Eingriff von Viren in die Proteinbiosynthese ihres Wirts und den Vermehrungszyklus von Viren, um Auswirkungen auf den Wirt und mögliche Therapieansätze erläutern zu können.\n6) erläutern die Wirkung von Antisense-RNA auf die Proteinbiosynthese, um daraus Anwendungsmöglichkeiten in der Medizin abzuleiten.\n7) leiten mögliche Angriffsorte in Prokaryoten für Antibiotika aus Unterschieden zwischen der Proteinbiosynthese bei Prokaryoten und Eukaryoten ab.\n8) erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen und erklären die Auswirkungen der Unterbrechung einer Genwirkkette.\n9) beschreiben mögliche Mechanismen zur Regulation der Genaktivität, um zu erklären, warum trotz gleicher genetischer Ausstattung von Zellen diese unterschiedliche Eigenschaften aufweisen können und so eine flexible Anpassung an Umweltbedingungen sowie eine Entwicklung und Spezialisierung in lebendigen Systemen möglich ist.\n10) beurteilen die Bedeutung von Stammzellen für die Forschung und für medizinische Anwendungen und bewerten deren Einsatz aus ethischer Sicht.\n11) vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären. Hierbei beschreiben sie die Bedeutung von Reparaturenzymen bei der natürlichen DNA-Replikation.\n12) beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Reproduktion.\n13) erklären am Beispiel der Tumorbildung Ursachen und Auswirkungen von Störungen des Zellzyklus und der Apoptose auf einen Organismus.\n14) beschreiben den Ablauf der Meiose bei den unterschiedlichen Geschlechtern und erklären ihre Bedeutung für die geschlechtliche Fortpflanzung.\n15) erklären den Zusammenhang zwischen genetischen Neukombinationsprozessen und der Evolution der bisherigen sowie zukünftigen Biodiversität.\n16) leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen auf verschiedenen Organisationsebenen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.\n17) unterscheiden verschiedene durch mutagene Einflüsse ausgelöste Genmutationen und erläutern deren Auswirkung auf die Funktion des codierten Proteins, um für die Bedeutung des Schutzes vor mutagenen Einflüssen sensibilisiert zu sein.\n18) erläutern die prinzipielle Verfahrensweise und eine konkrete Technik zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.\n19) werten (ggf. selbst durchgeführte) Kreuzungsexperimente aus, um den statistischen Charakter der Vererbung abzuleiten.\n20) treffen Vorhersagen zur Genotypen- und Phänotypenverteilung bei Kreuzungen, indem sie Gesetzmäßigkeiten der Vererbung auf mono- und dihybride Erbgänge anwenden.\n21) erklären den direkten Einfluss von Umweltbedingungen auf die Genaktivität der nächsten Generation als Folge epigenetischer Regulationsmechanismen.\n22) beschreiben die Veränderung des Wissens und die Bedeutung neuer Erkenntnisse bei der Erklärung von biologischen Phänomenen am Beispiel der Aufdeckung von Gesetzmäßigkeiten der Vererbung.\n23) analysieren Erbgänge mithilfe von Familienstammbäumen und treffen so Vorhersagen über Wahrscheinlichkeiten des Auftretens unterschiedlicher genetisch bedingter Krankheiten.\n24) grenzen Methoden der genetischen Familienberatung gegeneinander ab, um ihre Vor- und Nachteile zu bewerten und in entsprechenden Entscheidungssituationen eine begründete Entscheidung auch aus ethischer Sicht treffen zu können.\n25) erläutern die Bedeutung der DNA-Analytik beim Menschen in medizinischen sowie gesellschaftlichen Kontexten. Sie analysieren und bewerten die DNA-Analytik unter ethischen Gesichtspunkten.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 12 (erhöhtes Anforderungsniveau): B12 Lernbereich 2: Genetik und Gentechnik (ca. 86 Std.)",
+      "sourceGoalIds": [
+        "0c7566f2-be2c-5880-b132-23664d7ebf50",
+        "39a861e6-5be9-5b14-ad36-dc85159c3ff3",
+        "fab3d1ba-1f52-5f40-a682-7e6b51323fc1",
+        "fdd172c5-62c9-58e4-accb-84ffe4871f9c",
+        "a1f72875-f66a-523b-b0f3-10f35e309c18",
+        "282c7e7c-9abb-5a5f-aba4-e9e37ef8eb2b",
+        "cdfda558-fe26-54dd-a59a-2b3f74088ce7",
+        "8611455a-c279-54e1-ab6e-5d19389b3b2b",
+        "925fc9a9-6e86-54ff-a294-de755d5ba47a",
+        "c641a2ae-ff77-5c32-8fa4-8ef984832282",
+        "7e1b0310-b857-5d05-b722-acc00ec5d7cb",
+        "bf1337aa-15f3-58ba-b75e-f420ec5a6fac",
+        "ae888e32-ca41-555b-9fe6-c00c77c234c8",
+        "15143e1e-c3ac-5034-b584-5d1d036b0d7d",
+        "2727ed1c-a4e6-5433-8d1b-1a71b73f7139",
+        "50786132-04c6-5b1a-8639-30977924532e",
+        "ef3a58c6-09b3-5e91-80a0-fb3857268603",
+        "8509c74f-0657-555e-92f5-b01c7f298eee",
+        "f50c0050-ccf5-51e0-b0b4-05b89c659b82",
+        "94009a44-3060-505a-876e-18e92796e0f5",
+        "71c14f91-5d14-5c88-aba2-d149fec0812f",
+        "716c9998-c11d-5399-be7f-57ff3aa69870",
+        "f368e24c-c167-5f00-82ba-2bbab5597740",
+        "b1eb1baa-2859-5fdc-9737-2220be2b6da3",
+        "43240b1a-10e4-5c51-ad89-92dbed53d3f1"
+      ]
+    },
+    {
+      "id": "by-bio:B12-EA.3",
+      "topicCode": "B12-EA.3",
+      "title": "Biologie 12 (erhöhtes Anforderungsniveau): B12 Lernbereich 3: Evolution (ca. 30 Std.)",
+      "text": "1) erstellen für ausgewählte Gruppen von Lebewesen einen Stammbaum (auch Kladogramm), indem sie molekulare Merkmale vergleichen.\n2) vergleichen unterschiedliche historische und aktuelle Ansätze zur Systematisierung von Lebewesen und beurteilen deren Aussagekraft.\n3) bestimmen unterschiedliche Tier- und Pflanzenarten.\n4) beurteilen die Aussagekraft verschiedener Erklärungsansätze zu Mechanismen der Evolution und überprüfen ihre Vereinbarkeit mit dem heutigen Wissensstand der Genetik.\n5) wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten u. a. in der Ordnung der Primaten als Zusammenspiel der Evolutionsfaktoren zu erklären.\n6) erklären u. a. auch beim Menschen wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.\n7) leiten Selektionsvorteile des Menschen ab, die sich durch die v. a. sprachliche Weitergabe von erlerntem Verhalten und Wissen an andere und an nachfolgende Generationen ergeben und erklären so die Bedeutung der sozialen und kulturellen Evolution des Menschen und seine weltweite Verbreitung.\n8) beschreiben, wie der Mensch seine Umwelt an seine Bedürfnisse aktiv anpasst, vergleichen dies mit den Mechanismen zur Entstehung von Angepasstheiten durch die natürliche Selektion und zeigen Grenzen und Gefahren eines menschlichen Eingriffs in natürliche Evolutionsprozesse auf.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 12 (erhöhtes Anforderungsniveau): B12 Lernbereich 3: Evolution (ca. 30 Std.)",
+      "sourceGoalIds": [
+        "550a30ba-48e0-5822-8733-38683473e37e",
+        "57f30f58-36b5-5cc6-8ae3-32d20bcdd6fb",
+        "b201be13-27a4-5d82-b407-85e930e3a7fa",
+        "851e9fa5-7931-5c0b-95f0-6a82b0a19382",
+        "eaab3236-03ce-5029-b5c5-88ee3115224e",
+        "fc865de8-bde4-5d64-a5f6-91718b8296a2",
+        "0cc6db35-8c8c-5819-8fab-a5d5553f1ab2",
+        "37f54cd5-3abd-53ae-8be4-9568258f1cf0"
+      ]
+    },
+    {
+      "id": "by-bio:B12-EA.4",
+      "topicCode": "B12-EA.4",
+      "title": "Biologie 12 (erhöhtes Anforderungsniveau): B12 Lernbereich 4: Verhaltensökologie – Evolution und Angepasstheit von Verhalten (ca. 24 Std.)",
+      "text": "1) erklären das Auftreten verschiedener Verhaltensweisen, indem sie deren Einfluss auf die Gesamtfitness des Lebewesens beurteilen.\n2) wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Kommunikation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.\n3) analysieren das Sozialverhalten der Primaten im Hinblick auf exogene und endogene Ursachen, um ausgewählte menschliche Verhaltensweisen zu erklären. Dabei treten sie einseitig biologistischen Erklärungsansätzen kritisch gegenüber.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 12 (erhöhtes Anforderungsniveau): B12 Lernbereich 4: Verhaltensökologie – Evolution und Angepasstheit von Verhalten (ca. 24 Std.)",
+      "sourceGoalIds": [
+        "1a12e377-cf64-553b-aac5-56e6591a3c19",
+        "317634d4-e406-5105-81a2-b46fa315cdc1",
+        "490877b0-809e-5ba7-bf56-d91053b3ec80"
+      ]
+    },
+    {
+      "id": "by-bio:B12-GA.1",
+      "topicCode": "B12-GA.1",
+      "title": "Biologie 12 (grundlegendes Anforderungsniveau): B12 Lernbereich 1: Biologische Sachverhalte und Zusammenhänge betrachten – Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "text": "1) beschreiben und erläutern biologische Sachverhalte, Phänomene und Anwendungen der Biologie sachgerecht. Zur Strukturierung und Erschließung nutzen sie Basiskonzepte und binden fachübergreifende Aspekte ein.\n2) formulieren zu biologischen Phänomenen sowie Anwendungen der Biologie theoriegeleitet Hypothesen und Aussagen.\n3) erschließen und erläutern mithilfe von Basiskonzepten strukturiert die Eigenschaften lebender Systeme unter qualitativen und quantitativen Aspekten. Dabei stellen sie Vernetzungen zwischen Systemebenen (Molekular- bis Biosphärenebene) her.\n4) erläutern Prozesse in und zwischen lebenden Systemen sowie zwischen lebenden Systemen und ihrer Umwelt.\n5) erläutern die Entstehung und Bedeutung von Biodiversität sowie Gründe für deren Schutz und nachhaltige Nutzung.\n6) identifizieren und entwickeln ausgehend von Phänomenen und Beobachtungen Fragestellungen zu biologischen Sachverhalten und stellen theoriegeleitet Hypothesen zu ihrer Bearbeitung auf.\n7) planen und führen hypothesengeleitete Beobachtungen, Vergleiche, Experimente und Modellierungen unter Berücksichtigung des jeweiligen Variablengefüges bzw. der Variablenkontrolle durch und protokollieren sie.\n8) nehmen qualitative und quantitative Daten auch mithilfe digitaler Werkzeuge auf und werten sie aus.\n9) wenden Labor- und freilandbiologische Geräte und Techniken sachgerecht und unter Berücksichtigung der Sicherheitsbestimmungen an.\n10) finden in erhobenen oder recherchierten Daten Strukturen, Beziehungen und Trends, erklären diese theoriebezogen und ziehen Schlussfolgerungen.\n11) reflektieren die eigenen Ergebnisse und den eigenen Prozess der Erkenntnisgewinnung, indem sie die Gültigkeit von Daten beurteilen, mögliche Fehlerquellen ermitteln sowie Möglichkeiten und Grenzen von Modellen diskutieren.\n12) widerlegen oder stützen die Hypothese (Hypothesenrückbezug).\n13) stellen bei der Interpretation von Untersuchungsbefunden fachübergreifende Bezüge her.\n14) reflektieren Möglichkeiten und Grenzen des konkreten Erkenntnisgewinnungsprozesses sowie der gewonnenen Erkenntnisse (z. B. Reproduzierbarkeit, Falsifizierbarkeit, Intersubjektivität, logische Konsistenz, Vorläufigkeit).\n15) reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung) sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.\n16) recherchieren zu biologischen Sachverhalten und anwendungsbezogenen Fragestellungen zielgerichtet in analogen und digitalen Medien. Sie wählen aus für ihre Zwecke passenden Quellen relevante und aussagekräftige Informationen und Daten aus. Dabei erschließen sie Informationen aus Darstellungsformen unterschiedlicher Komplexität.\n17) analysieren Herkunft, Qualität und Vertrauenswürdigkeit von verwendeten Quellen und Medien sowie darin enthaltene Darstellungsformen im Zusammenhang mit der Intention der Autorin/des Autors. Sie prüfen die Übereinstimmung verschiedener Quellen im Hinblick auf deren Aussagen.\n18) strukturieren und interpretieren ausgewählte Informationen und leiten Schlussfolgerungen ab. Dazu nutzen sie geeignete Darstellungsformen und überführen diese ineinander.\n19) unterscheiden zwischen Alltags- und Fachsprache sowie zwischen funktionalen und kausalen Erklärungen. Sie erklären Sachverhalte aus proximater und ultimater Sicht, ohne dabei finale Begründungen zu nutzen.\n20) verarbeiten sach-, adressaten- und situationsgerecht Informationen zu biologischen Sachverhalten.\n21) präsentieren biologische Sachverhalte sowie Lern- und Arbeitsergebnisse unter Einsatz sach-, adressaten- und situationsgerechter Darstellungsformen mithilfe analoger und digitaler Medien.\n22) prüfen die Urheberschaft, belegen verwendete Quellen und kennzeichnen Zitate.\n23) tauschen sich mit anderen konstruktiv über biologische Sachverhalte aus. Sie argumentieren dabei wissenschaftlich kriterien- und evidenzbasiert sowie situationsgerecht. Sie vertreten, reflektieren und korrigieren gegebenenfalls den eigenen Standpunkt.\n24) analysieren Sachverhalte im Hinblick auf ihre Bewertungsrelevanz und betrachten relevante Sachverhalte aus unterschiedlichen Perspektiven.\n25) unterscheiden deskriptive und normative Aussagen und identifizieren Werte, die den normativen Aussagen zugrunde liegen.\n26) beurteilen Quellen hinsichtlich ihrer Herkunft und in Bezug auf spezifische Interessenlagen.\n27) beurteilen Möglichkeiten und Grenzen biologischer Sichtweisen.\n28) stellen Bewertungskriterien auf, auch unter Berücksichtigung außerfachlicher Aspekte.\n29) bilden sich kriteriengeleitet Meinungen, indem sie die Handlungsoptionen auf der Basis reflektierter Wertvorstellungen abwägen, und treffen so Entscheidungen auf der Grundlage von Sachinformationen und Werten.\n30) reflektieren kurz- und langfristige, lokale und globale Folgen eigener und gesellschaftlicher Entscheidungen.\n31) reflektieren den Prozess der Bewertung aus persönlicher, gesellschaftlicher und ethischer Perspektive.\n32) beurteilen und bewerten Auswirkungen von Anwendungen der Biologie im Sinne einer nachhaltigen Entwicklung aus ökologischer, ökonomischer, politischer und sozialer Perspektive.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 12 (grundlegendes Anforderungsniveau): B12 Lernbereich 1: Biologische Sachverhalte und Zusammenhänge betrachten – Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "sourceGoalIds": [
+        "93208e54-7814-5738-b753-e30df89dcd5d",
+        "c86da1fa-e9b1-53e1-8a71-ebeda357eb72",
+        "66dbee5c-ffd7-5ffc-bace-0898d13479b2",
+        "14c703b4-fcc6-5e15-8027-1696a3024ab6",
+        "16b8c298-6574-5eb5-81d6-e6d68839ee68",
+        "d128f994-616b-5bd7-a01a-ecf428ee54df",
+        "28e9a9ec-76d4-57f8-a8b2-a14bfe2f0dc4",
+        "258ad6b8-86fb-5300-b3b9-43626e1b6ab5",
+        "6be93217-c8d5-5db7-bb9f-7fb4996c7f0c",
+        "5b33bfb3-b22f-52e0-a0d2-a5931dcbdbe6",
+        "cacf5cc8-5dd2-56f0-aa7f-289b23c30f2a",
+        "3258593f-0a53-52f4-b067-6c05f76937e0",
+        "d1acb51b-f547-567a-a0e6-2f24dd78bebb",
+        "361dc7c8-154c-5919-abc7-34405877cfd1",
+        "59dc19df-7734-536a-801e-2d1bce412f1a",
+        "8a1f3103-4b49-5daa-a0d8-58723438305a",
+        "9f8601f9-64b9-5ea1-9ce1-7ecd54fa2f1c",
+        "705566d5-ceab-5a71-a17b-5d740fa9dfa0",
+        "8963b296-06f3-523a-b9e9-e3d45c3a23a6",
+        "15ac8e5e-6111-545f-b582-0cf12d44d39a",
+        "0abbbcd7-302f-5eb1-af4d-fb05e1cc949a",
+        "72038809-f11a-50dd-a273-a968e0cd9dbf",
+        "089ead71-0bc3-578a-91b9-3bea7d06db52",
+        "bcf192b7-fa63-5ac3-b13f-0039feb00b0b",
+        "ebcdf533-a915-57e4-b5f9-e1b790d7f620",
+        "ee7bfa35-b97d-5714-8aaf-78f1184e0215",
+        "7ea5fd68-c411-50f2-8697-711c12fa28d4",
+        "540f78e7-e84a-511b-ad72-30aaf732c529",
+        "b8f0ab01-fc00-50df-85b0-cd19387f0731",
+        "be7422d3-8de7-5907-8e5f-657484b6270b",
+        "ab4b91cc-3e72-5413-9a0b-7144a2502e56",
+        "50f29a21-d711-596b-88cd-89399509c8d6"
+      ]
+    },
+    {
+      "id": "by-bio:B12-GA.2",
+      "topicCode": "B12-GA.2",
+      "title": "Biologie 12 (grundlegendes Anforderungsniveau): B12 Lernbereich 2: Genetik und Gentechnik (ca. 51 Std.)",
+      "text": "1) beschreiben ein Modell zum Bau der DNA und vergleichen es mit einem entsprechenden Modell zum Bau der RNA.\n2) leiten aus Basensequenzen der DNA Aminosäuresequenzen von Proteinen sowie aus der Aminosäuresequenz von Proteinen mögliche Basensequenzen für eine codierende DNA ab, indem sie den genetischen Code anwenden.\n3) beschreiben den Mechanismus der Bildung von Proteinen durch die Proteinbiosynthese und erklären deren Bedeutung für das Leben.\n4) erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen.\n5) beschreiben mögliche Mechanismen zur Regulation der Genaktivität, um zu erklären, warum trotz gleicher genetischer Ausstattung von Zellen diese unterschiedliche Eigenschaften aufweisen können und so eine flexible Anpassung an Umweltbedingungen sowie eine Entwicklung und Spezialisierung in lebendigen Systemen möglich ist.\n6) beurteilen die Bedeutung von Stammzellen für die Forschung und für medizinische Anwendungen und bewerten deren Einsatz aus ethischer Sicht.\n7) vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären.\n8) beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Reproduktion.\n9) beschreiben den Ablauf der Meiose bei den unterschiedlichen Geschlechtern und erklären ihre Bedeutung für die geschlechtliche Fortpflanzung.\n10) erklären den Zusammenhang zwischen genetischen Neukombinationsprozessen und der Evolution der bisherigen sowie zukünftigen Biodiversität.\n11) leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.\n12) unterscheiden verschiedene durch mutagene Einflüsse ausgelöste Genmutationen und erläutern deren Auswirkung auf die Funktion des codierten Proteins, um für die Bedeutung des Schutzes vor mutagenen Einflüssen sensibilisiert zu sein.\n13) erläutern die prinzipielle Verfahrensweise zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.\n14) treffen Vorhersagen zur Genotypen- und Phänotypenverteilung bei Kreuzungen, indem sie Gesetzmäßigkeiten der Vererbung auf mono- und dihybride Erbgänge anwenden.\n15) beschreiben die Veränderung des Wissens und die Bedeutung neuer Erkenntnisse bei der Erklärung von biologischen Phänomenen am Beispiel der Aufdeckung von Gesetzmäßigkeiten der Vererbung.\n16) analysieren Erbgänge mithilfe von Familienstammbäumen und treffen so Vorhersagen über Wahrscheinlichkeiten des Auftretens unterschiedlicher genetisch bedingter Krankheiten.\n17) grenzen Methoden der genetischen Familienberatung gegeneinander ab, um ihre Vor- und Nachteile zu bewerten und in entsprechenden Entscheidungssituationen eine begründete Entscheidung auch aus ethischer Sicht treffen zu können.\n18) erläutern die Bedeutung der DNA-Analytik beim Menschen in medizinischen sowie gesellschaftlichen Kontexten. Sie analysieren und bewerten die DNA-Analytik unter ethischen Gesichtspunkten.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 12 (grundlegendes Anforderungsniveau): B12 Lernbereich 2: Genetik und Gentechnik (ca. 51 Std.)",
+      "sourceGoalIds": [
+        "0c7566f2-be2c-5880-b132-23664d7ebf50",
+        "39a861e6-5be9-5b14-ad36-dc85159c3ff3",
+        "fab3d1ba-1f52-5f40-a682-7e6b51323fc1",
+        "f06e9a1f-f17c-56bf-9bb7-4571903e17f4",
+        "925fc9a9-6e86-54ff-a294-de755d5ba47a",
+        "c641a2ae-ff77-5c32-8fa4-8ef984832282",
+        "2170fbb3-d82f-56d1-bf7e-03f1cf9a3146",
+        "bf1337aa-15f3-58ba-b75e-f420ec5a6fac",
+        "15143e1e-c3ac-5034-b584-5d1d036b0d7d",
+        "2727ed1c-a4e6-5433-8d1b-1a71b73f7139",
+        "d6cb1a75-d31f-5195-8148-d079aa17abbf",
+        "ef3a58c6-09b3-5e91-80a0-fb3857268603",
+        "61a685c4-b335-5c2b-a803-60c1c9e2cea6",
+        "94009a44-3060-505a-876e-18e92796e0f5",
+        "716c9998-c11d-5399-be7f-57ff3aa69870",
+        "f368e24c-c167-5f00-82ba-2bbab5597740",
+        "b1eb1baa-2859-5fdc-9737-2220be2b6da3",
+        "43240b1a-10e4-5c51-ad89-92dbed53d3f1"
+      ]
+    },
+    {
+      "id": "by-bio:B12-GA.3",
+      "topicCode": "B12-GA.3",
+      "title": "Biologie 12 (grundlegendes Anforderungsniveau): B12 Lernbereich 3: Evolution (ca. 18 Std.)",
+      "text": "1) erstellen für ausgewählte Gruppen von Lebewesen einen Stammbaum (auch Kladogramm), indem sie molekulare Merkmale vergleichen.\n2) vergleichen unterschiedliche historische und aktuelle Ansätze zur Systematisierung von Lebewesen und beurteilen deren Aussagekraft.\n3) bestimmen unterschiedliche Tier- und Pflanzenarten.\n4) beurteilen die Aussagekraft verschiedener Erklärungsansätze zu Mechanismen der Evolution und überprüfen ihre Vereinbarkeit mit dem heutigen Wissensstand der Genetik.\n5) wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten als Zusammenspiel der Evolutionsfaktoren zu erklären.\n6) erklären wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 12 (grundlegendes Anforderungsniveau): B12 Lernbereich 3: Evolution (ca. 18 Std.)",
+      "sourceGoalIds": [
+        "550a30ba-48e0-5822-8733-38683473e37e",
+        "57f30f58-36b5-5cc6-8ae3-32d20bcdd6fb",
+        "b201be13-27a4-5d82-b407-85e930e3a7fa",
+        "851e9fa5-7931-5c0b-95f0-6a82b0a19382",
+        "f0fa6aa1-9abc-5d93-91e6-04eac282bc51",
+        "852535e6-de83-5661-93ff-b58a9228e132"
+      ]
+    },
+    {
+      "id": "by-bio:B12-GA.4",
+      "topicCode": "B12-GA.4",
+      "title": "Biologie 12 (grundlegendes Anforderungsniveau): B12 Lernbereich 4: Verhaltensökologie – Evolution und Angepasstheit von Verhalten (ca. 15 Std.)",
+      "text": "1) erklären das Auftreten verschiedener Verhaltensweisen, indem sie deren Einfluss auf die Gesamtfitness des Lebewesens beurteilen.\n2) wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 12 (grundlegendes Anforderungsniveau): B12 Lernbereich 4: Verhaltensökologie – Evolution und Angepasstheit von Verhalten (ca. 15 Std.)",
+      "sourceGoalIds": [
+        "1a12e377-cf64-553b-aac5-56e6591a3c19",
+        "6a1a0f1b-854e-5b5a-94e5-f4189f2f16d8"
+      ]
+    },
+    {
+      "id": "by-bio:B13-EA.1",
+      "topicCode": "B13-EA.1",
+      "title": "Biologie 13 (erhöhtes Anforderungsniveau): B13 Lernbereich 1: Biologische Sachverhalte und Zusammenhänge betrachten – Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "text": "1) beschreiben und erläutern biologische Sachverhalte, Phänomene und Anwendungen der Biologie sachgerecht. Zur Strukturierung und Erschließung nutzen sie Basiskonzepte und binden fachübergreifende Aspekte ein.\n2) formulieren zu biologischen Phänomenen sowie Anwendungen der Biologie theoriegeleitet Hypothesen und Aussagen.\n3) erschließen und erläutern mithilfe von Basiskonzepten strukturiert die Eigenschaften lebender Systeme unter qualitativen und quantitativen Aspekten. Dabei stellen sie Vernetzungen zwischen Systemebenen (Molekular- bis Biosphärenebene) her.\n4) erläutern Prozesse in und zwischen lebenden Systemen sowie zwischen lebenden Systemen und ihrer Umwelt.\n5) erläutern die Entstehung und Bedeutung von Biodiversität sowie Gründe für deren Schutz und nachhaltige Nutzung.\n6) identifizieren und entwickeln ausgehend von Phänomenen und Beobachtungen Fragestellungen zu biologischen Sachverhalten und stellen theoriegeleitet Hypothesen zu ihrer Bearbeitung auf.\n7) planen und führen hypothesengeleitete Beobachtungen, Vergleiche, Experimente und Modellierungen unter Berücksichtigung des jeweiligen Variablengefüges bzw. der Variablenkontrolle durch und protokollieren sie.\n8) nehmen qualitative und quantitative Daten auch mithilfe digitaler Werkzeuge auf und werten sie aus.\n9) wenden Labor- und freilandbiologische Geräte und Techniken sachgerecht und unter Berücksichtigung der Sicherheitsbestimmungen an.\n10) finden in erhobenen oder recherchierten Daten Strukturen, Beziehungen und Trends, erklären diese theoriebezogen und ziehen Schlussfolgerungen.\n11) reflektieren die eigenen Ergebnisse und den eigenen Prozess der Erkenntnisgewinnung, indem sie die Gültigkeit von Daten beurteilen, mögliche Fehlerquellen ermitteln sowie Möglichkeiten und Grenzen von Modellen diskutieren.\n12) widerlegen oder stützen die Hypothese (Hypothesenrückbezug).\n13) stellen bei der Interpretation von Untersuchungsbefunden fachübergreifende Bezüge her.\n14) reflektieren Möglichkeiten und Grenzen des konkreten Erkenntnisgewinnungsprozesses sowie der gewonnenen Erkenntnisse (z. B. Reproduzierbarkeit, Falsifizierbarkeit, Intersubjektivität, logische Konsistenz, Vorläufigkeit).\n15) reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung), sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.\n16) recherchieren zu biologischen Sachverhalten und anwendungsbezogenen Fragestellungen zielgerichtet in analogen und digitalen Medien. Sie wählen aus für ihre Zwecke passenden Quellen relevante und aussagekräftige Informationen und Daten aus. Dabei erschließen sie Informationen aus Darstellungsformen unterschiedlicher Komplexität.\n17) analysieren Herkunft, Qualität und Vertrauenswürdigkeit von verwendeten Quellen und Medien sowie darin enthaltene Darstellungsformen im Zusammenhang mit der Intention der Autorin/des Autors. Sie prüfen die Übereinstimmung verschiedener Quellen im Hinblick auf deren Aussagen.\n18) strukturieren und interpretieren ausgewählte Informationen und leiten Schlussfolgerungen ab. Dazu nutzen sie geeignete Darstellungsformen und überführen diese ineinander.\n19) unterscheiden zwischen Alltags- und Fachsprache sowie zwischen funktionalen und kausalen Erklärungen. Sie erklären Sachverhalte aus proximater und ultimater Sicht, ohne dabei finale Begründungen zu nutzen.\n20) verarbeiten sach-, adressaten- und situationsgerecht Informationen zu biologischen Sachverhalten.\n21) präsentieren biologische Sachverhalte sowie Lern- und Arbeitsergebnisse unter Einsatz sach-, adressaten- und situationsgerechter Darstellungsformen mithilfe analoger und digitaler Medien.\n22) prüfen die Urheberschaft, belegen verwendete Quellen und kennzeichnen Zitate.\n23) tauschen sich mit anderen konstruktiv über biologische Sachverhalte aus. Sie argumentieren dabei wissenschaftlich kriterien- und evidenzbasiert sowie situationsgerecht. Sie vertreten, reflektieren und korrigieren gegebenenfalls den eigenen Standpunkt.\n24) analysieren Sachverhalte im Hinblick auf ihre Bewertungsrelevanz und betrachten relevante Sachverhalte aus unterschiedlichen Perspektiven.\n25) unterscheiden deskriptive und normative Aussagen und identifizieren Werte, die den normativen Aussagen zugrunde liegen.\n26) beurteilen Quellen hinsichtlich ihrer Herkunft und in Bezug auf spezifische Interessenlagen.\n27) beurteilen Möglichkeiten und Grenzen biologischer Sichtweisen.\n28) stellen Bewertungskriterien auf, auch unter Berücksichtigung außerfachlicher Aspekte.\n29) bilden sich kriteriengeleitet Meinungen, indem sie die Handlungsoptionen auf der Basis reflektierter Wertvorstellungen abwägen, und treffen so Entscheidungen auf der Grundlage von Sachinformationen und Werten.\n30) reflektieren kurz- und langfristige, lokale und globale Folgen eigener und gesellschaftlicher Entscheidungen.\n31) reflektieren den Prozess der Bewertung aus persönlicher, gesellschaftlicher und ethischer Perspektive.\n32) beurteilen und bewerten Auswirkungen von Anwendungen der Biologie im Sinne einer nachhaltigen Entwicklung aus ökologischer, ökonomischer, politischer und sozialer Perspektive.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 13 (erhöhtes Anforderungsniveau): B13 Lernbereich 1: Biologische Sachverhalte und Zusammenhänge betrachten – Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "sourceGoalIds": [
+        "93208e54-7814-5738-b753-e30df89dcd5d",
+        "c86da1fa-e9b1-53e1-8a71-ebeda357eb72",
+        "66dbee5c-ffd7-5ffc-bace-0898d13479b2",
+        "14c703b4-fcc6-5e15-8027-1696a3024ab6",
+        "16b8c298-6574-5eb5-81d6-e6d68839ee68",
+        "d128f994-616b-5bd7-a01a-ecf428ee54df",
+        "28e9a9ec-76d4-57f8-a8b2-a14bfe2f0dc4",
+        "258ad6b8-86fb-5300-b3b9-43626e1b6ab5",
+        "6be93217-c8d5-5db7-bb9f-7fb4996c7f0c",
+        "5b33bfb3-b22f-52e0-a0d2-a5931dcbdbe6",
+        "cacf5cc8-5dd2-56f0-aa7f-289b23c30f2a",
+        "3258593f-0a53-52f4-b067-6c05f76937e0",
+        "d1acb51b-f547-567a-a0e6-2f24dd78bebb",
+        "361dc7c8-154c-5919-abc7-34405877cfd1",
+        "4d662fc7-15ce-5b6d-a5a1-287b48af2145",
+        "8a1f3103-4b49-5daa-a0d8-58723438305a",
+        "9f8601f9-64b9-5ea1-9ce1-7ecd54fa2f1c",
+        "705566d5-ceab-5a71-a17b-5d740fa9dfa0",
+        "8963b296-06f3-523a-b9e9-e3d45c3a23a6",
+        "15ac8e5e-6111-545f-b582-0cf12d44d39a",
+        "0abbbcd7-302f-5eb1-af4d-fb05e1cc949a",
+        "72038809-f11a-50dd-a273-a968e0cd9dbf",
+        "089ead71-0bc3-578a-91b9-3bea7d06db52",
+        "bcf192b7-fa63-5ac3-b13f-0039feb00b0b",
+        "ebcdf533-a915-57e4-b5f9-e1b790d7f620",
+        "ee7bfa35-b97d-5714-8aaf-78f1184e0215",
+        "7ea5fd68-c411-50f2-8697-711c12fa28d4",
+        "540f78e7-e84a-511b-ad72-30aaf732c529",
+        "b8f0ab01-fc00-50df-85b0-cd19387f0731",
+        "be7422d3-8de7-5907-8e5f-657484b6270b",
+        "ab4b91cc-3e72-5413-9a0b-7144a2502e56",
+        "50f29a21-d711-596b-88cd-89399509c8d6"
+      ]
+    },
+    {
+      "id": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "title": "Biologie 13 (erhöhtes Anforderungsniveau): B13 Lernbereich 2: Neuronale Informationsverarbeitung (ca. 28 Std.)",
+      "text": "1) skizzieren den Aufbau einer Nervenzelle und stellen die Besonderheiten dieses spezialisierten Zelltyps in einen Struktur-Funktions-Zusammenhang.\n2) beschreiben den Aufbau von Biomembranen nach dem Flüssig-Mosaik-Modell, um Transportvorgänge zwischen Kompartimenten zu erläutern.\n3) erklären anhand von Messdaten zur Ionenverteilung die Ladungsverhältnisse an der Biomembran einer Nervenzelle im Ruhezustand und leiten daraus ab, dass zur Aufrechterhaltung des Ruhepotentials Energie aufgewendet werden muss.\n4) erklären die auftretenden Potentialänderungen bei einem Aktionspotential, indem sie die Vorgänge auf der Teilchenebene bei überschwelliger Depolarisation an der Axonmembran beschreiben, und erklären, wie Informationen codiert werden.\n5) beschreiben und vergleichen die Weiterleitung der Potentialänderung an verschiedenen Nervenfasern, um die unterschiedliche Leistungsfähigkeit von Nervensystemen bei Wirbellosen und Wirbeltieren zu erklären.\n6) leiten aus den Vorgängen bei der Informationsübertragung an erregenden chemischen Synapsen Möglichkeiten ab, diese Informationsübertragung durch Zufuhr von Stoffen zu beeinflussen.\n7) beschreiben die Symptome der Krankheit Depression und erklären deren Ausbildung im Zusammenhang mit Veränderungen im Gehirnstoffwechsel vor dem Hintergrund eines multifaktoriellen Entstehungsmodells, um mit Betroffenen besser umzugehen sowie eine Therapiemöglichkeit abzuleiten.\n8) vergleichen die postsynaptischen Potentialänderungen, die sich aus der Verschaltung mehrerer Nervenzellen ergeben, und leiten die Notwendigkeit von erregenden und hemmenden Synapsen für eine geregelte Signalübertragung ab.\n9) erklären in Grundzügen die Möglichkeit sowie den medizinischen Nutzen, die elektrische Aktivität der Nervenzellen mithilfe neurophysiologischer Verfahren sichtbar zu machen.\n10) erläutern die Notwendigkeit der neuronalen Plastizität als Voraussetzung für Lernprozesse.\n11) erklären die Symptome von Multipler Sklerose und Parkinson als Störungen des neuronalen Systems.\n12) leiten aus dem Vergleich der Informationsübertragung von Nerven- und Hormonsystem am Beispiel der Stressreaktion die Bedeutung der Verschränkung dieser Organsysteme ab.\n13) beschreiben die Regulation einer Hormonkonzentration und erklären die Auswirkungen von chronischem Stress auch als Eingriff in einen weiteren hormonellen Regelkreis.\n14) erklären das Zustandekommen eines Rezeptorpotentials an einer Sinneszelle durch Beschreibung der bei Reizeinwirkung ablaufenden Vorgänge auf Teilchenebene und wenden ihr Wissen zur Erklärung sinnesphysiologischer Phänomene an.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 13 (erhöhtes Anforderungsniveau): B13 Lernbereich 2: Neuronale Informationsverarbeitung (ca. 28 Std.)",
+      "sourceGoalIds": [
+        "6f8d420f-8a58-5c17-86fd-32925065f51f",
+        "7b155c7c-c2f7-5c17-950d-df62a8ec5825",
+        "f4c6e71e-2d1b-5ccb-91d1-3930cf43fd62",
+        "269118af-aed0-52ff-8ed1-9fc787313313",
+        "3843a735-191d-5951-aa43-61620b96b8e9",
+        "1ab76608-e31b-5f03-822a-962c02ee922d",
+        "8832a55d-988a-5848-81d4-1dc529f7b6e9",
+        "644bde9d-2d47-57a2-aff3-5dc5bf956f31",
+        "e026e617-09d5-53d1-aa11-9cdb8f3d6b00",
+        "1935a0a9-d746-5b57-b1b7-82cc155ce91e",
+        "8c6774a3-2a98-5b76-9ecd-8ad97f97440c",
+        "453a6fad-aecc-502f-a5b3-a9e9c54aa9e2",
+        "8028cba5-0828-574a-a884-48e656649e0f",
+        "0a6b6a3f-47a1-5a90-bc23-75417cfecdd6"
+      ]
+    },
+    {
+      "id": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "title": "Biologie 13 (erhöhtes Anforderungsniveau): B13 Lernbereich 3: Stoffwechselphysiologie der Zelle (ca. 43 Std.)",
+      "text": "1) beschreiben das Grundprinzip der Assimilation und legen deren Bedeutung für das Leben auf der Erde dar.\n2) erklären, welche Außenfaktoren die Photosynthese beeinflussen, legen dar, wie sich Veränderungen der Außenfaktoren auf die Photosyntheserate auswirken, und beurteilen deren Folgen für Wild- und Nutzpflanzen.\n3) trennen die verschiedenen Photosynthesefarbstoffe in einem Blattextrakt durch Chromatographie, um zu zeigen, dass ein Farbstoffgemisch für die Absorption von Licht verantwortlich ist.\n4) stellen einen Zusammenhang zwischen molekularen, anatomischen und morphologischen Strukturen her, indem sie auf verschiedenen Organisationsebenen die Angepasstheiten einer Pflanze an die Photosynthese erläutern.\n5) beschreiben die Tracer-Methode als Werkzeug, um Stoffwechselwege, z. B. bei der Photosynthese, aufzuklären.\n6) erklären die Bildung von NADPH und ATP, die für den Glucose-Aufbau benötigt werden, mithilfe eines energetischen Modells und der chemiosmotischen Theorie zum Ablauf der lichtabhängigen Reaktionen.\n7) charakterisieren den Calvin-Zyklus als Schlüsselstelle für den Aufbau von energiereichen organischen Verbindungen unter Verwendung von NADPH und ATP aus den lichtabhängigen Reaktionen.\n8) vergleichen C3- und C4-Pflanzen im Hinblick auf anatomische Besonderheiten und biochemische Prozesse, um daraus abzuleiten, dass Stoffwechselwege von Pflanzen eine Angepasstheit an unterschiedliche Standorte sind.\n9) beschreiben, wie Pflanzen Stoffe ineinander umwandeln können und so Biomasse aufbauen, die sie und heterotrophe Lebewesen als Grundlage für ihren Energie- und Baustoffwechsel nutzen.\n10) planen selbstständig Experimente, um Hypothesen zur Beeinflussung der Enzymaktivität durch verschiedene Außenfaktoren zu überprüfen.\n11) erklären die Bedeutung von Enzymen für eine bedarfsgerechte Regulation des Stoffwechsels.\n12) erklären die Bildung von ATP unter Sauerstoffmangelbedingungen mithilfe verschiedener anaerober Abbauwege von Glucose.\n13) beschreiben im Überblick den aeroben Abbauweg von Glucose zu Kohlenstoffdioxid, die Bildung von Energieäquivalenten und die Regeneration von NAD+ und FAD zur Aufrechterhaltung der Abbaureaktionen und vergleichen sie mit den aufbauenden Stoffwechselwegen der Photosynthese, um grundlegende Prinzipien des Stoffwechsels abzuleiten.\n14) erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben und anaeroben Abbaus von Glucose, unter welchen Bedingungen die jeweiligen Abbauwege begünstigt werden.\n15) erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben Abbaus von Glucose und Fetten die besondere Eignung von Fetten als Energiespeicher.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 13 (erhöhtes Anforderungsniveau): B13 Lernbereich 3: Stoffwechselphysiologie der Zelle (ca. 43 Std.)",
+      "sourceGoalIds": [
+        "51a5bf48-51c9-518f-b4e6-fe4a8c073b7d",
+        "b342744e-60c2-5ce2-b281-5eb19943a1ce",
+        "2cc41e62-ec79-5add-9d43-2499b4e147b2",
+        "b0468d88-9a13-5f8c-ac3b-02c0761dda94",
+        "861204d6-ce05-53c9-979f-6a69513a2313",
+        "f9c70e85-e4e4-57ce-908a-6baa772ec0d9",
+        "b6e605f6-75ed-590f-8769-72e631f02a0f",
+        "a6d4b0eb-e267-558e-9e13-6eb671484c30",
+        "81a64cd9-7f21-59a7-9d2a-f34d2d76c939",
+        "14dde0e1-1b0e-5f7c-8adb-c318dd505cad",
+        "e22d6665-417a-5e63-aaa8-e2cbf1b3899f",
+        "e412f11f-bc30-5de4-b06d-8712fbf88b08",
+        "b1a59da6-a2e7-5cb1-94ae-84d59a40f303",
+        "a89a52a6-d175-57d8-9304-a3f9a02aa4a5",
+        "83c2d8a2-7922-5bb2-9082-e76c7c255b75"
+      ]
+    },
+    {
+      "id": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "title": "Biologie 13 (erhöhtes Anforderungsniveau): B13 Lernbereich 4: Ökologie und Biodiversität (ca. 34 Std.)",
+      "text": "1) charakterisieren ein Biotop, indem sie abiotische Faktoren messen und analysieren.\n2) nutzen Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose qualitativ zu erfassen.\n3) erheben Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose quantitativ zu erfassen.\n4) beschreiben Nahrungsbeziehungen zwischen Arten, ordnen sie einer Trophieebene zu und erläutern einen Stoffkreislauf sowie den Energiefluss in einem Ökosystem.\n5) erklären unter Einbeziehung von Laborversuchen die ökologische Potenz von Lebewesen bezüglich abiotischer Faktoren, um die Eignung von Lebensräumen für Lebewesen zu beurteilen.\n6) beschreiben die unterschiedliche Einflussnahme biotischer Faktoren auf ein Lebewesen und erklären das Konzept der ökologischen Nische als Zusammenspiel biotischer und abiotischer Faktoren, aus dem sich die Zusammensetzung der Biozönose eines Ökosystems ergibt.\n7) unterscheiden verschiedene Fortpflanzungsstrategien, erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.\n8) unterscheiden Bereiche, in denen der Mensch die Ressourcen von Ökosystemen nutzt und erklären die Bedeutung dieser Ökosystemleistungen für den Menschen.\n9) vergleichen verschieden stark beeinflusste Ökosysteme nach dem Konzept der Ökosystemleistungen, um den Wert von Erhalt bzw. Renaturierung durch einen Ökosystemmanagementprozess einzuschätzen.\n10) reflektieren die anthropozentrische Bewertung der Natur und sind sich dadurch der Notwendigkeit einer Werteabwägung bewusst.\n11) beschreiben abiotische Wechselwirkungen, mit denen sich Biome gegenseitig beeinflussen, um ihre weltweite Vernetzung zu erläutern und die Auswirkungen von Störungen auf die Biodiversität zu modellieren.\n12) erklären an konkreten Beispielen die globalen Auswirkungen lokaler menschlicher Eingriffe auf die Biosphäre.\n13) analysieren aus verschiedenen Perspektiven Dilemmata, die sich durch Interessenkonflikte aus der persönlichen Lebenswelt zwischen ökonomischen und ökologischen Erfordernissen ergeben und leiten durch eine individuelle Wertehierarchisierung Handlungsoptionen für eine nachhaltige Lebensweise auf persönlicher und gesellschaftlicher Ebene ab.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 13 (erhöhtes Anforderungsniveau): B13 Lernbereich 4: Ökologie und Biodiversität (ca. 34 Std.)",
+      "sourceGoalIds": [
+        "9c592678-5737-5cc2-a26b-129d21809937",
+        "e08c3873-98f8-575d-b3a7-29d02b096d33",
+        "cb9339eb-77ea-5101-a053-9d33d1ad9160",
+        "a1ad7b4e-8e58-5f07-976c-8917f3278ef6",
+        "1d8afbf7-53ac-5e23-9c55-017759c91883",
+        "344bc982-be2b-58ae-b270-72f9fac98ad9",
+        "cab06faf-bb5a-5f1e-8a50-6f2430dd6ebc",
+        "76396e7e-380d-5145-b80a-e07be34b1adb",
+        "e1e63025-54b6-51de-ba35-8343f70f6c30",
+        "aff07640-c257-575c-b4ed-0df8c4e63c42",
+        "64e79e74-14ce-5d51-8fb4-fbcea8bb1108",
+        "4fa3224c-60b1-51d9-9075-ba66439a729b",
+        "e8e2f7a6-c2e2-537e-85aa-cd00aeb61941"
+      ]
+    },
+    {
+      "id": "by-bio:B13-GA.1",
+      "topicCode": "B13-GA.1",
+      "title": "Biologie 13 (grundlegendes Anforderungsniveau): B13 Lernbereich 1: Biologische Sachverhalte und Zusammenhänge betrachten – Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "text": "1) beschreiben und erläutern biologische Sachverhalte, Phänomene und Anwendungen der Biologie sachgerecht. Zur Strukturierung und Erschließung nutzen sie Basiskonzepte und binden fachübergreifende Aspekte ein.\n2) formulieren zu biologischen Phänomenen sowie Anwendungen der Biologie theoriegeleitet Hypothesen und Aussagen.\n3) erläutern Prozesse in und zwischen lebenden Systemen sowie zwischen lebenden Systemen und ihrer Umwelt.\n4) erläutern die Entstehung und Bedeutung von Biodiversität sowie Gründe für deren Schutz und nachhaltige Nutzung.\n5) identifizieren und entwickeln ausgehend von Phänomenen und Beobachtungen Fragestellungen zu biologischen Sachverhalten und stellen theoriegeleitet Hypothesen zu ihrer Bearbeitung auf.\n6) planen und führen hypothesengeleitete Beobachtungen, Vergleiche, Experimente und Modellierungen unter Berücksichtigung des jeweiligen Variablengefüges bzw. der Variablenkontrolle durch und protokollieren sie.\n7) nehmen qualitative und quantitative Daten auch mithilfe digitaler Werkzeuge auf und werten sie aus.\n8) wenden Labor- und freilandbiologische Geräte und Techniken sachgerecht und unter Berücksichtigung der Sicherheitsbestimmungen an.\n9) finden in erhobenen oder recherchierten Daten Strukturen, Beziehungen und Trends, erklären diese theoriebezogen und ziehen Schlussfolgerungen.\n10) reflektieren die eigenen Ergebnisse und den eigenen Prozess der Erkenntnisgewinnung, indem sie die Gültigkeit von Daten beurteilen, mögliche Fehlerquellen ermitteln sowie Möglichkeiten und Grenzen von Modellen diskutieren.\n11) widerlegen oder stützen die Hypothese (Hypothesenrückbezug).\n12) stellen bei der Interpretation von Untersuchungsbefunden fachübergreifende Bezüge her.\n13) reflektieren Möglichkeiten und Grenzen des konkreten Erkenntnisgewinnungsprozesses sowie der gewonnenen Erkenntnisse (z. B. Reproduzierbarkeit, Falsifizierbarkeit, Intersubjektivität, logische Konsistenz, Vorläufigkeit).\n14) reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung), sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.\n15) recherchieren zu biologischen Sachverhalten und anwendungsbezogenen Fragestellungen zielgerichtet in analogen und digitalen Medien. Sie wählen aus für ihre Zwecke passenden Quellen relevante und aussagekräftige Informationen und Daten aus. Dabei erschließen sie Informationen aus Darstellungsformen unterschiedlicher Komplexität.\n16) analysieren Herkunft, Qualität und Vertrauenswürdigkeit von verwendeten Quellen und Medien sowie darin enthaltene Darstellungsformen im Zusammenhang mit der Intention der Autorin/des Autors. Sie prüfen die Übereinstimmung verschiedener Quellen im Hinblick auf deren Aussagen.\n17) strukturieren und interpretieren ausgewählte Informationen und leiten Schlussfolgerungen ab. Dazu nutzen sie geeignete Darstellungsformen und überführen diese ineinander.\n18) unterscheiden zwischen Alltags- und Fachsprache sowie zwischen funktionalen und kausalen Erklärungen. Sie erklären Sachverhalte aus proximater und ultimater Sicht, ohne dabei finale Begründungen zu nutzen.\n19) verarbeiten sach-, adressaten- und situationsgerecht Informationen zu biologischen Sachverhalten.\n20) präsentieren biologische Sachverhalte sowie Lern- und Arbeitsergebnisse unter Einsatz sach-, adressaten- und situationsgerechter Darstellungsformen mithilfe analoger und digitaler Medien.\n21) prüfen die Urheberschaft, belegen verwendete Quellen und kennzeichnen Zitate.\n22) tauschen sich mit anderen konstruktiv über biologische Sachverhalte aus. Sie argumentieren dabei wissenschaftlich kriterien- und evidenzbasiert sowie situationsgerecht. Sie vertreten, reflektieren und korrigieren gegebenenfalls den eigenen Standpunkt.\n23) analysieren Sachverhalte im Hinblick auf ihre Bewertungsrelevanz und betrachten relevante Sachverhalte aus unterschiedlichen Perspektiven.\n24) unterscheiden deskriptive und normative Aussagen und identifizieren Werte, die den normativen Aussagen zugrunde liegen.\n25) beurteilen Quellen hinsichtlich ihrer Herkunft und in Bezug auf spezifische Interessenlagen.\n26) beurteilen Möglichkeiten und Grenzen biologischer Sichtweisen.\n27) stellen Bewertungskriterien auf, auch unter Berücksichtigung außerfachlicher Aspekte.\n28) bilden sich kriteriengeleitet Meinungen, indem sie die Handlungsoptionen auf der Basis reflektierter Wertvorstellungen abwägen, und treffen so Entscheidungen auf der Grundlage von Sachinformationen und Werten.\n29) reflektieren kurz- und langfristige, lokale und globale Folgen eigener und gesellschaftlicher Entscheidungen.\n30) reflektieren den Prozess der Bewertung aus persönlicher, gesellschaftlicher und ethischer Perspektive.\n31) beurteilen und bewerten Auswirkungen von Anwendungen der Biologie im Sinne einer nachhaltigen Entwicklung aus ökologischer, ökonomischer, politischer und sozialer Perspektive.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 13 (grundlegendes Anforderungsniveau): B13 Lernbereich 1: Biologische Sachverhalte und Zusammenhänge betrachten – Erkenntnisse gewinnen – kommunizieren – bewerten",
+      "sourceGoalIds": [
+        "93208e54-7814-5738-b753-e30df89dcd5d",
+        "c86da1fa-e9b1-53e1-8a71-ebeda357eb72",
+        "14c703b4-fcc6-5e15-8027-1696a3024ab6",
+        "16b8c298-6574-5eb5-81d6-e6d68839ee68",
+        "d128f994-616b-5bd7-a01a-ecf428ee54df",
+        "28e9a9ec-76d4-57f8-a8b2-a14bfe2f0dc4",
+        "258ad6b8-86fb-5300-b3b9-43626e1b6ab5",
+        "6be93217-c8d5-5db7-bb9f-7fb4996c7f0c",
+        "5b33bfb3-b22f-52e0-a0d2-a5931dcbdbe6",
+        "cacf5cc8-5dd2-56f0-aa7f-289b23c30f2a",
+        "3258593f-0a53-52f4-b067-6c05f76937e0",
+        "d1acb51b-f547-567a-a0e6-2f24dd78bebb",
+        "361dc7c8-154c-5919-abc7-34405877cfd1",
+        "4d662fc7-15ce-5b6d-a5a1-287b48af2145",
+        "8a1f3103-4b49-5daa-a0d8-58723438305a",
+        "9f8601f9-64b9-5ea1-9ce1-7ecd54fa2f1c",
+        "705566d5-ceab-5a71-a17b-5d740fa9dfa0",
+        "8963b296-06f3-523a-b9e9-e3d45c3a23a6",
+        "15ac8e5e-6111-545f-b582-0cf12d44d39a",
+        "0abbbcd7-302f-5eb1-af4d-fb05e1cc949a",
+        "72038809-f11a-50dd-a273-a968e0cd9dbf",
+        "089ead71-0bc3-578a-91b9-3bea7d06db52",
+        "bcf192b7-fa63-5ac3-b13f-0039feb00b0b",
+        "ebcdf533-a915-57e4-b5f9-e1b790d7f620",
+        "ee7bfa35-b97d-5714-8aaf-78f1184e0215",
+        "7ea5fd68-c411-50f2-8697-711c12fa28d4",
+        "540f78e7-e84a-511b-ad72-30aaf732c529",
+        "b8f0ab01-fc00-50df-85b0-cd19387f0731",
+        "be7422d3-8de7-5907-8e5f-657484b6270b",
+        "ab4b91cc-3e72-5413-9a0b-7144a2502e56",
+        "50f29a21-d711-596b-88cd-89399509c8d6"
+      ]
+    },
+    {
+      "id": "by-bio:B13-GA.2",
+      "topicCode": "B13-GA.2",
+      "title": "Biologie 13 (grundlegendes Anforderungsniveau): B13 Lernbereich 2: Neuronale Informationsverarbeitung (ca. 15 Std.)",
+      "text": "1) skizzieren den Aufbau einer Nervenzelle und stellen die Besonderheiten dieses spezialisierten Zelltyps in einen Struktur-Funktions-Zusammenhang.\n2) beschreiben den Aufbau von Biomembranen nach dem Flüssig-Mosaik-Modell, um Transportvorgänge zwischen Kompartimenten zu erläutern.\n3) erklären anhand von Messdaten zur Ionenverteilung die Ladungsverhältnisse an der Biomembran einer Nervenzelle im Ruhezustand und leiten daraus ab, dass zur Aufrechterhaltung des Ruhepotentials Energie aufgewendet werden muss.\n4) erklären die auftretenden Potentialänderungen bei einem Aktionspotential, indem sie die Vorgänge auf der Teilchenebene bei überschwelliger Depolarisation an der Axonmembran beschreiben, und erklären, wie Informationen codiert werden.\n5) beschreiben und vergleichen die Weiterleitung der Potentialänderung an verschiedenen Nervenfasern, um die unterschiedliche Leistungsfähigkeit von Nervensystemen bei Wirbellosen und Wirbeltieren zu erklären.\n6) leiten aus den Vorgängen bei der Informationsübertragung an erregenden chemischen Synapsen Möglichkeiten ab, diese Informationsübertragung durch Zufuhr von Stoffen zu beeinflussen.\n7) beschreiben die Symptome der Krankheit Depression und erklären deren Ausbildung im Zusammenhang mit Veränderungen im Gehirnstoffwechsel vor dem Hintergrund eines multifaktoriellen Entstehungsmodells, um mit Betroffenen besser umzugehen sowie eine Therapiemöglichkeit abzuleiten.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 13 (grundlegendes Anforderungsniveau): B13 Lernbereich 2: Neuronale Informationsverarbeitung (ca. 15 Std.)",
+      "sourceGoalIds": [
+        "6f8d420f-8a58-5c17-86fd-32925065f51f",
+        "7b155c7c-c2f7-5c17-950d-df62a8ec5825",
+        "f4c6e71e-2d1b-5ccb-91d1-3930cf43fd62",
+        "269118af-aed0-52ff-8ed1-9fc787313313",
+        "3843a735-191d-5951-aa43-61620b96b8e9",
+        "1ab76608-e31b-5f03-822a-962c02ee922d",
+        "8832a55d-988a-5848-81d4-1dc529f7b6e9"
+      ]
+    },
+    {
+      "id": "by-bio:B13-GA.3",
+      "topicCode": "B13-GA.3",
+      "title": "Biologie 13 (grundlegendes Anforderungsniveau): B13 Lernbereich 3: Stoffwechselphysiologie der Zelle (ca. 27 Std.)",
+      "text": "1) beschreiben das Grundprinzip der Assimilation und legen deren Bedeutung für das Leben auf der Erde dar.\n2) erklären, welche Außenfaktoren die Photosynthese beeinflussen, legen dar, wie sich Veränderungen der Außenfaktoren auf die Photosyntheserate auswirken, und beurteilen deren Folgen für Wild- und Nutzpflanzen.\n3) trennen die verschiedenen Photosynthesefarbstoffe in einem Blattextrakt durch Chromatographie, um zu zeigen, dass ein Farbstoffgemisch für die Absorption von Licht verantwortlich ist.\n4) stellen einen Zusammenhang zwischen molekularen, anatomischen und morphologischen Strukturen her, indem sie auf verschiedenen Organisationsebenen die Angepasstheiten einer Pflanze an die Photosynthese erläutern.\n5) erklären die Bildung von NADPH und ATP, die für den Glucose-Aufbau benötigt werden, mithilfe eines energetischen Modells und der chemiosmotischen Theorie zum Ablauf der lichtabhängigen Reaktionen.\n6) charakterisieren den Calvin-Zyklus als Schlüsselstelle für den Aufbau von energiereichen organischen Verbindungen unter Verwendung von NADPH und ATP aus den lichtabhängigen Reaktionen.\n7) beschreiben, wie Pflanzen Stoffe ineinander umwandeln können und so Biomasse aufbauen, die sie und heterotrophe Lebewesen als Grundlage für ihren Energie- und Baustoffwechsel nutzen.\n8) erklären die Bedeutung von Enzymen für eine bedarfsgerechte Regulation des Stoffwechsels.\n9) erklären die Bildung von ATP unter Sauerstoffmangelbedingungen mithilfe verschiedener anaerober Abbauwege von Glucose.\n10) beschreiben im Überblick den aeroben Abbauweg von Glucose zu Kohlenstoffdioxid, die Bildung von Energieäquivalenten und die Regeneration von NAD+ und FAD zur Aufrechterhaltung der Abbaureaktionen und vergleichen sie mit den aufbauenden Stoffwechselwegen der Photosynthese, um grundlegende Prinzipien des Stoffwechsels abzuleiten.\n11) erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben und anaeroben Abbaus von Glucose, unter welchen Bedingungen die jeweiligen Abbauwege begünstigt werden.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 13 (grundlegendes Anforderungsniveau): B13 Lernbereich 3: Stoffwechselphysiologie der Zelle (ca. 27 Std.)",
+      "sourceGoalIds": [
+        "51a5bf48-51c9-518f-b4e6-fe4a8c073b7d",
+        "b342744e-60c2-5ce2-b281-5eb19943a1ce",
+        "2cc41e62-ec79-5add-9d43-2499b4e147b2",
+        "b0468d88-9a13-5f8c-ac3b-02c0761dda94",
+        "f9c70e85-e4e4-57ce-908a-6baa772ec0d9",
+        "b6e605f6-75ed-590f-8769-72e631f02a0f",
+        "81a64cd9-7f21-59a7-9d2a-f34d2d76c939",
+        "e22d6665-417a-5e63-aaa8-e2cbf1b3899f",
+        "e412f11f-bc30-5de4-b06d-8712fbf88b08",
+        "b1a59da6-a2e7-5cb1-94ae-84d59a40f303",
+        "a89a52a6-d175-57d8-9304-a3f9a02aa4a5"
+      ]
+    },
+    {
+      "id": "by-bio:B13-GA.4",
+      "topicCode": "B13-GA.4",
+      "title": "Biologie 13 (grundlegendes Anforderungsniveau): B13 Lernbereich 4: Ökologie und Biodiversität (ca. 21 Std.)",
+      "text": "1) charakterisieren ein Biotop, indem sie abiotische Faktoren messen und analysieren.\n2) nutzen Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose qualitativ zu erfassen.\n3) beschreiben Nahrungsbeziehungen zwischen Arten, ordnen sie einer Trophieebene zu und erläutern einen Stoffkreislauf sowie den Energiefluss in einem Ökosystem.\n4) erklären unter Einbeziehung von Laborversuchen die ökologische Potenz von Lebewesen bezüglich abiotischer Faktoren, um die Eignung von Lebensräumen für Lebewesen zu beurteilen.\n5) beschreiben die unterschiedliche Einflussnahme biotischer Faktoren auf ein Lebewesen und erklären das Konzept der ökologischen Nische als Zusammenspiel biotischer und abiotischer Faktoren, aus dem sich die Zusammensetzung der Biozönose eines Ökosystems ergibt.\n6) erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.\n7) unterscheiden Bereiche, in denen der Mensch die Ressourcen von Ökosystemen nutzt und erklären die Bedeutung dieser Ökosystemleistungen für den Menschen.\n8) vergleichen verschieden stark beeinflusste Ökosysteme nach dem Konzept der Ökosystemleistungen, um den Wert von Erhalt bzw. Renaturierung durch einen Ökosystemmanagementprozess einzuschätzen.\n9) reflektieren die anthropozentrische Bewertung der Natur und sind sich dadurch der Notwendigkeit einer Werteabwägung bewusst.\n10) analysieren aus verschiedenen Perspektiven Dilemmata, die sich durch Interessenkonflikte aus der persönlichen Lebenswelt zwischen ökonomischen und ökologischen Erfordernissen ergeben und leiten durch eine individuelle Wertehierarchisierung Handlungsoptionen für eine nachhaltige Lebensweise auf persönlicher und gesellschaftlicher Ebene ab.",
+      "sourcePath": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+      "sourceUrl": "https://www.lehrplanplus.bayern.de/schulart/gymnasium/fach/biologie",
+      "rawText": "Biologie 13 (grundlegendes Anforderungsniveau): B13 Lernbereich 4: Ökologie und Biodiversität (ca. 21 Std.)",
+      "sourceGoalIds": [
+        "9c592678-5737-5cc2-a26b-129d21809937",
+        "e08c3873-98f8-575d-b3a7-29d02b096d33",
+        "a1ad7b4e-8e58-5f07-976c-8917f3278ef6",
+        "1d8afbf7-53ac-5e23-9c55-017759c91883",
+        "344bc982-be2b-58ae-b270-72f9fac98ad9",
+        "869296c0-5dd5-5c02-9e9f-bf6fe53420e1",
+        "76396e7e-380d-5145-b80a-e07be34b1adb",
+        "e1e63025-54b6-51de-ba35-8343f70f6c30",
+        "aff07640-c257-575c-b4ed-0df8c4e63c42",
+        "e8e2f7a6-c2e2-537e-85aa-cd00aeb61941"
+      ]
+    }
+  ],
+  "sourceGoals": [
+    {
+      "id": "f4ec5855-6377-5afe-92b5-1d851429c1b9",
+      "passageId": "by-bio:B8.1",
+      "topicCode": "B8.1",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "formulieren ausgehend von einfach strukturierten Alltags- und Naturphänomenen biologische Fra...",
+      "description": "formulieren ausgehend von einfach strukturierten Alltags- und Naturphänomenen biologische Fragestellungen und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren vorwiegend qualitativer Beantwortung.",
+      "sourceText": "formulieren ausgehend von einfach strukturierten Alltags- und Naturphänomenen biologische Fragestellungen und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren vorwiegend qualitativer Beantwortung.",
+      "sourceSpan": "B8.1.1",
+      "parentBulletText": "formulieren ausgehend von einfach strukturierten Alltags- und Naturphänomenen biologische Fragestellungen und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren vorwiegend qualitativer Beantwortung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.1"
+      ],
+      "rawSourceText": "formulieren ausgehend von einfach strukturierten Alltags- und Naturphänomenen biologische Fragestellungen und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren vorwiegend qualitativer Beantwortung.",
+      "rawSourceSpan": "B8.1.1",
+      "rawParentBulletText": "formulieren ausgehend von einfach strukturierten Alltags- und Naturphänomenen biologische Fragestellungen und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren vorwiegend qualitativer Beantwortung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f4ec5855-6377-5afe-92b5-1d851429c1b9",
+          "passageId": "by-bio:B8.1",
+          "topicCode": "B8.1",
+          "sourceSpan": "B8.1.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.1"
+      ],
+      "mergedSourceSpans": [
+        "B8.1.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.1"
+      ]
+    },
+    {
+      "id": "97e3d9cf-c20b-5fdd-abb8-7f54a459d706",
+      "passageId": "by-bio:B8.1",
+      "topicCode": "B8.1",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "führen einfache naturwissenschaftliche Untersuchungen zu vorgegebenen und eigenen Themen und ...",
+      "description": "führen einfache naturwissenschaftliche Untersuchungen zu vorgegebenen und eigenen Themen und Fragestellungen durch. Dabei fertigen sie mit Hilfestellung ein naturwissenschaftliches Protokoll an.",
+      "sourceText": "führen einfache naturwissenschaftliche Untersuchungen zu vorgegebenen und eigenen Themen und Fragestellungen durch. Dabei fertigen sie mit Hilfestellung ein naturwissenschaftliches Protokoll an.",
+      "sourceSpan": "B8.1.2",
+      "parentBulletText": "führen einfache naturwissenschaftliche Untersuchungen zu vorgegebenen und eigenen Themen und Fragestellungen durch. Dabei fertigen sie mit Hilfestellung ein naturwissenschaftliches Protokoll an.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.1"
+      ],
+      "rawSourceText": "führen einfache naturwissenschaftliche Untersuchungen zu vorgegebenen und eigenen Themen und Fragestellungen durch. Dabei fertigen sie mit Hilfestellung ein naturwissenschaftliches Protokoll an.",
+      "rawSourceSpan": "B8.1.2",
+      "rawParentBulletText": "führen einfache naturwissenschaftliche Untersuchungen zu vorgegebenen und eigenen Themen und Fragestellungen durch. Dabei fertigen sie mit Hilfestellung ein naturwissenschaftliches Protokoll an.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "97e3d9cf-c20b-5fdd-abb8-7f54a459d706",
+          "passageId": "by-bio:B8.1",
+          "topicCode": "B8.1",
+          "sourceSpan": "B8.1.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.1"
+      ],
+      "mergedSourceSpans": [
+        "B8.1.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.2"
+      ]
+    },
+    {
+      "id": "6df7fcd0-d87f-5b27-88b0-acd38a2adb80",
+      "passageId": "by-bio:B8.1",
+      "topicCode": "B8.1",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von...",
+      "description": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren mit Hilfestellungen in einem naturwissenschaftlichen Protokoll strukturiert ihre Beobachtungen, werten sie aus und veranschaulichen sie.",
+      "sourceText": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren mit Hilfestellungen in einem naturwissenschaftlichen Protokoll strukturiert ihre Beobachtungen, werten sie aus und veranschaulichen sie.",
+      "sourceSpan": "B8.1.3",
+      "parentBulletText": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren mit Hilfestellungen in einem naturwissenschaftlichen Protokoll strukturiert ihre Beobachtungen, werten sie aus und veranschaulichen sie.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.1"
+      ],
+      "rawSourceText": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren mit Hilfestellungen in einem naturwissenschaftlichen Protokoll strukturiert ihre Beobachtungen, werten sie aus und veranschaulichen sie.",
+      "rawSourceSpan": "B8.1.3",
+      "rawParentBulletText": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren mit Hilfestellungen in einem naturwissenschaftlichen Protokoll strukturiert ihre Beobachtungen, werten sie aus und veranschaulichen sie.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "6df7fcd0-d87f-5b27-88b0-acd38a2adb80",
+          "passageId": "by-bio:B8.1",
+          "topicCode": "B8.1",
+          "sourceSpan": "B8.1.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.1"
+      ],
+      "mergedSourceSpans": [
+        "B8.1.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.3"
+      ]
+    },
+    {
+      "id": "ab7e59b3-9608-59d4-a025-cafd16fa38ab",
+      "passageId": "by-bio:B8.1",
+      "topicCode": "B8.1",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "bestimmen häufig vorkommende Lebewesen mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimm...",
+      "description": "bestimmen häufig vorkommende Lebewesen mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk), um ihre Artenkenntnis zu erweitern.",
+      "sourceText": "bestimmen häufig vorkommende Lebewesen mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk), um ihre Artenkenntnis zu erweitern.",
+      "sourceSpan": "B8.1.4",
+      "parentBulletText": "bestimmen häufig vorkommende Lebewesen mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk), um ihre Artenkenntnis zu erweitern.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.4",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.1"
+      ],
+      "rawSourceText": "bestimmen häufig vorkommende Lebewesen mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk), um ihre Artenkenntnis zu erweitern.",
+      "rawSourceSpan": "B8.1.4",
+      "rawParentBulletText": "bestimmen häufig vorkommende Lebewesen mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk), um ihre Artenkenntnis zu erweitern.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "ab7e59b3-9608-59d4-a025-cafd16fa38ab",
+          "passageId": "by-bio:B8.1",
+          "topicCode": "B8.1",
+          "sourceSpan": "B8.1.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.4",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.1"
+      ],
+      "mergedSourceSpans": [
+        "B8.1.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.4"
+      ]
+    },
+    {
+      "id": "d4ef55b7-0e93-529d-8fb8-fb48f0e596c5",
+      "passageId": "by-bio:B8.1",
+      "topicCode": "B8.1",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "interpretieren erhobene oder recherchierte Daten unter Einbezug möglicher Fehlerquellen und s...",
+      "description": "interpretieren erhobene oder recherchierte Daten unter Einbezug möglicher Fehlerquellen und setzen diese zur Eingangshypothese in Beziehung.",
+      "sourceText": "interpretieren erhobene oder recherchierte Daten unter Einbezug möglicher Fehlerquellen und setzen diese zur Eingangshypothese in Beziehung.",
+      "sourceSpan": "B8.1.5",
+      "parentBulletText": "interpretieren erhobene oder recherchierte Daten unter Einbezug möglicher Fehlerquellen und setzen diese zur Eingangshypothese in Beziehung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.5",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.1"
+      ],
+      "rawSourceText": "interpretieren erhobene oder recherchierte Daten unter Einbezug möglicher Fehlerquellen und setzen diese zur Eingangshypothese in Beziehung.",
+      "rawSourceSpan": "B8.1.5",
+      "rawParentBulletText": "interpretieren erhobene oder recherchierte Daten unter Einbezug möglicher Fehlerquellen und setzen diese zur Eingangshypothese in Beziehung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "d4ef55b7-0e93-529d-8fb8-fb48f0e596c5",
+          "passageId": "by-bio:B8.1",
+          "topicCode": "B8.1",
+          "sourceSpan": "B8.1.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.5",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.1"
+      ],
+      "mergedSourceSpans": [
+        "B8.1.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.5"
+      ]
+    },
+    {
+      "id": "d6433d0b-1f90-5e71-9d7e-7cb411fa6450",
+      "passageId": "by-bio:B8.1",
+      "topicCode": "B8.1",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "erklären die Bedeutung des naturwissenschaftlichen Erkenntnisweges zur Erweiterung des Wissen...",
+      "description": "erklären die Bedeutung des naturwissenschaftlichen Erkenntnisweges zur Erweiterung des Wissens und schätzen ab, ob eine vorgegebene Fragestellung mithilfe biologischer Methoden zu beantworten ist.",
+      "sourceText": "erklären die Bedeutung des naturwissenschaftlichen Erkenntnisweges zur Erweiterung des Wissens und schätzen ab, ob eine vorgegebene Fragestellung mithilfe biologischer Methoden zu beantworten ist.",
+      "sourceSpan": "B8.1.6",
+      "parentBulletText": "erklären die Bedeutung des naturwissenschaftlichen Erkenntnisweges zur Erweiterung des Wissens und schätzen ab, ob eine vorgegebene Fragestellung mithilfe biologischer Methoden zu beantworten ist.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.6",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.1"
+      ],
+      "rawSourceText": "erklären die Bedeutung des naturwissenschaftlichen Erkenntnisweges zur Erweiterung des Wissens und schätzen ab, ob eine vorgegebene Fragestellung mithilfe biologischer Methoden zu beantworten ist.",
+      "rawSourceSpan": "B8.1.6",
+      "rawParentBulletText": "erklären die Bedeutung des naturwissenschaftlichen Erkenntnisweges zur Erweiterung des Wissens und schätzen ab, ob eine vorgegebene Fragestellung mithilfe biologischer Methoden zu beantworten ist.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "d6433d0b-1f90-5e71-9d7e-7cb411fa6450",
+          "passageId": "by-bio:B8.1",
+          "topicCode": "B8.1",
+          "sourceSpan": "B8.1.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.6",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.1"
+      ],
+      "mergedSourceSpans": [
+        "B8.1.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.6"
+      ]
+    },
+    {
+      "id": "e703768e-1db3-5148-9757-4070eafe0231",
+      "passageId": "by-bio:B8.1",
+      "topicCode": "B8.1",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "beschreiben Wechselwirkungen und Prozesse (z. B. im menschlichen Organismus, zur Suchtentsteh...",
+      "description": "beschreiben Wechselwirkungen und Prozesse (z. B. im menschlichen Organismus, zur Suchtentstehung, zum Einfluss des Menschen auf Ökosysteme) mithilfe von Modellen und schätzen die Grenzen von Modellen ab.",
+      "sourceText": "beschreiben Wechselwirkungen und Prozesse (z. B. im menschlichen Organismus, zur Suchtentstehung, zum Einfluss des Menschen auf Ökosysteme) mithilfe von Modellen und schätzen die Grenzen von Modellen ab.",
+      "sourceSpan": "B8.1.7",
+      "parentBulletText": "beschreiben Wechselwirkungen und Prozesse (z. B. im menschlichen Organismus, zur Suchtentstehung, zum Einfluss des Menschen auf Ökosysteme) mithilfe von Modellen und schätzen die Grenzen von Modellen ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.7",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.1"
+      ],
+      "rawSourceText": "beschreiben Wechselwirkungen und Prozesse (z. B. im menschlichen Organismus, zur Suchtentstehung, zum Einfluss des Menschen auf Ökosysteme) mithilfe von Modellen und schätzen die Grenzen von Modellen ab.",
+      "rawSourceSpan": "B8.1.7",
+      "rawParentBulletText": "beschreiben Wechselwirkungen und Prozesse (z. B. im menschlichen Organismus, zur Suchtentstehung, zum Einfluss des Menschen auf Ökosysteme) mithilfe von Modellen und schätzen die Grenzen von Modellen ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "e703768e-1db3-5148-9757-4070eafe0231",
+          "passageId": "by-bio:B8.1",
+          "topicCode": "B8.1",
+          "sourceSpan": "B8.1.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.7",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.1"
+      ],
+      "mergedSourceSpans": [
+        "B8.1.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.7"
+      ]
+    },
+    {
+      "id": "1f52dec9-c041-52f8-a098-222e00df3940",
+      "passageId": "by-bio:B8.1",
+      "topicCode": "B8.1",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "beantworten biologische Fragestellungen, indem sie vorgegebene, auf einfachen Texten und weni...",
+      "description": "beantworten biologische Fragestellungen, indem sie vorgegebene, auf einfachen Texten und wenigen Darstellungsformen beruhende, auch digitale, Quellen auswerten. Dabei berücksichtigen sie u. a. die Intention der jeweiligen Quelle.",
+      "sourceText": "beantworten biologische Fragestellungen, indem sie vorgegebene, auf einfachen Texten und wenigen Darstellungsformen beruhende, auch digitale, Quellen auswerten. Dabei berücksichtigen sie u. a. die Intention der jeweiligen Quelle.",
+      "sourceSpan": "B8.1.8",
+      "parentBulletText": "beantworten biologische Fragestellungen, indem sie vorgegebene, auf einfachen Texten und wenigen Darstellungsformen beruhende, auch digitale, Quellen auswerten. Dabei berücksichtigen sie u. a. die Intention der jeweiligen Quelle.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.8",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.1"
+      ],
+      "rawSourceText": "beantworten biologische Fragestellungen, indem sie vorgegebene, auf einfachen Texten und wenigen Darstellungsformen beruhende, auch digitale, Quellen auswerten. Dabei berücksichtigen sie u. a. die Intention der jeweiligen Quelle.",
+      "rawSourceSpan": "B8.1.8",
+      "rawParentBulletText": "beantworten biologische Fragestellungen, indem sie vorgegebene, auf einfachen Texten und wenigen Darstellungsformen beruhende, auch digitale, Quellen auswerten. Dabei berücksichtigen sie u. a. die Intention der jeweiligen Quelle.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "1f52dec9-c041-52f8-a098-222e00df3940",
+          "passageId": "by-bio:B8.1",
+          "topicCode": "B8.1",
+          "sourceSpan": "B8.1.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.8",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.1"
+      ],
+      "mergedSourceSpans": [
+        "B8.1.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.8"
+      ]
+    },
+    {
+      "id": "debcb740-e2bb-5c43-b0c7-bd8f1da70d64",
+      "passageId": "by-bio:B8.1",
+      "topicCode": "B8.1",
+      "bulletIndex": 9,
+      "aspectIndex": 1,
+      "title": "wägen Folgen menschlichen Handelns auf die lokale und globale nachhaltige Entwicklung ab und ...",
+      "description": "wägen Folgen menschlichen Handelns auf die lokale und globale nachhaltige Entwicklung ab und erörtern Handlungsoptionen, indem sie vorgegebene Pro- und Kontra-Argumente (z. B. zum Einkaufsverhalten oder zur Transportmittelnutzung) auswerten, um bewusste, wertorientierte Entscheidungen treffen zu können.",
+      "sourceText": "wägen Folgen menschlichen Handelns auf die lokale und globale nachhaltige Entwicklung ab und erörtern Handlungsoptionen, indem sie vorgegebene Pro- und Kontra-Argumente (z. B. zum Einkaufsverhalten oder zur Transportmittelnutzung) auswerten, um bewusste, wertorientierte Entscheidungen treffen zu können.",
+      "sourceSpan": "B8.1.9",
+      "parentBulletText": "wägen Folgen menschlichen Handelns auf die lokale und globale nachhaltige Entwicklung ab und erörtern Handlungsoptionen, indem sie vorgegebene Pro- und Kontra-Argumente (z. B. zum Einkaufsverhalten oder zur Transportmittelnutzung) auswerten, um bewusste, wertorientierte Entscheidungen treffen zu können.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.9",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.1"
+      ],
+      "rawSourceText": "wägen Folgen menschlichen Handelns auf die lokale und globale nachhaltige Entwicklung ab und erörtern Handlungsoptionen, indem sie vorgegebene Pro- und Kontra-Argumente (z. B. zum Einkaufsverhalten oder zur Transportmittelnutzung) auswerten, um bewusste, wertorientierte Entscheidungen treffen zu können.",
+      "rawSourceSpan": "B8.1.9",
+      "rawParentBulletText": "wägen Folgen menschlichen Handelns auf die lokale und globale nachhaltige Entwicklung ab und erörtern Handlungsoptionen, indem sie vorgegebene Pro- und Kontra-Argumente (z. B. zum Einkaufsverhalten oder zur Transportmittelnutzung) auswerten, um bewusste, wertorientierte Entscheidungen treffen zu können.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "debcb740-e2bb-5c43-b0c7-bd8f1da70d64",
+          "passageId": "by-bio:B8.1",
+          "topicCode": "B8.1",
+          "sourceSpan": "B8.1.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.9",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.1"
+      ],
+      "mergedSourceSpans": [
+        "B8.1.9"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.9"
+      ]
+    },
+    {
+      "id": "54792497-6ad1-5aae-a22e-1dca9f679766",
+      "passageId": "by-bio:B8.1",
+      "topicCode": "B8.1",
+      "bulletIndex": 10,
+      "aspectIndex": 1,
+      "title": "wägen Folgen von eigenen Verhaltensweisen sowie Verhaltensweisen anderer für die eigene Gesun...",
+      "description": "wägen Folgen von eigenen Verhaltensweisen sowie Verhaltensweisen anderer für die eigene Gesundheit und die Gesundheit anderer ab, um bewusste, wertorientierte Entscheidungen für die Gesunderhaltung (z. B. des Gehörs) treffen zu können.",
+      "sourceText": "wägen Folgen von eigenen Verhaltensweisen sowie Verhaltensweisen anderer für die eigene Gesundheit und die Gesundheit anderer ab, um bewusste, wertorientierte Entscheidungen für die Gesunderhaltung (z. B. des Gehörs) treffen zu können.",
+      "sourceSpan": "B8.1.10",
+      "parentBulletText": "wägen Folgen von eigenen Verhaltensweisen sowie Verhaltensweisen anderer für die eigene Gesundheit und die Gesundheit anderer ab, um bewusste, wertorientierte Entscheidungen für die Gesunderhaltung (z. B. des Gehörs) treffen zu können.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.10",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.1"
+      ],
+      "rawSourceText": "wägen Folgen von eigenen Verhaltensweisen sowie Verhaltensweisen anderer für die eigene Gesundheit und die Gesundheit anderer ab, um bewusste, wertorientierte Entscheidungen für die Gesunderhaltung (z. B. des Gehörs) treffen zu können.",
+      "rawSourceSpan": "B8.1.10",
+      "rawParentBulletText": "wägen Folgen von eigenen Verhaltensweisen sowie Verhaltensweisen anderer für die eigene Gesundheit und die Gesundheit anderer ab, um bewusste, wertorientierte Entscheidungen für die Gesunderhaltung (z. B. des Gehörs) treffen zu können.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "54792497-6ad1-5aae-a22e-1dca9f679766",
+          "passageId": "by-bio:B8.1",
+          "topicCode": "B8.1",
+          "sourceSpan": "B8.1.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.10",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.1"
+      ],
+      "mergedSourceSpans": [
+        "B8.1.10"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.1.10"
+      ]
+    },
+    {
+      "id": "091a3a55-29bf-50dd-a701-bed0026280fe",
+      "passageId": "by-bio:B8.2",
+      "topicCode": "B8.2",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "beschreiben den Aufbau einer Nervenzelle und die Kommunikation zwischen den verschiedenen Ele...",
+      "description": "beschreiben den Aufbau einer Nervenzelle und die Kommunikation zwischen den verschiedenen Elementen einer Reiz-Reaktions-Kette, um das komplexe Zusammenwirken von Sinnesorganen, Nervensystem und Erfolgsorganen bei der Reaktion des Organismus auf Reize zu erklären.",
+      "sourceText": "beschreiben den Aufbau einer Nervenzelle und die Kommunikation zwischen den verschiedenen Elementen einer Reiz-Reaktions-Kette, um das komplexe Zusammenwirken von Sinnesorganen, Nervensystem und Erfolgsorganen bei der Reaktion des Organismus auf Reize zu erklären.",
+      "sourceSpan": "B8.2.1",
+      "parentBulletText": "beschreiben den Aufbau einer Nervenzelle und die Kommunikation zwischen den verschiedenen Elementen einer Reiz-Reaktions-Kette, um das komplexe Zusammenwirken von Sinnesorganen, Nervensystem und Erfolgsorganen bei der Reaktion des Organismus auf Reize zu erklären.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.2"
+      ],
+      "rawSourceText": "beschreiben den Aufbau einer Nervenzelle und die Kommunikation zwischen den verschiedenen Elementen einer Reiz-Reaktions-Kette, um das komplexe Zusammenwirken von Sinnesorganen, Nervensystem und Erfolgsorganen bei der Reaktion des Organismus auf Reize zu erklären.",
+      "rawSourceSpan": "B8.2.1",
+      "rawParentBulletText": "beschreiben den Aufbau einer Nervenzelle und die Kommunikation zwischen den verschiedenen Elementen einer Reiz-Reaktions-Kette, um das komplexe Zusammenwirken von Sinnesorganen, Nervensystem und Erfolgsorganen bei der Reaktion des Organismus auf Reize zu erklären.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "091a3a55-29bf-50dd-a701-bed0026280fe",
+          "passageId": "by-bio:B8.2",
+          "topicCode": "B8.2",
+          "sourceSpan": "B8.2.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.2"
+      ],
+      "mergedSourceSpans": [
+        "B8.2.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.1"
+      ]
+    },
+    {
+      "id": "ad855269-70c3-526c-951b-cc2d54106f36",
+      "passageId": "by-bio:B8.2",
+      "topicCode": "B8.2",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "erklären die Wahrnehmung von Licht als Zusammenwirken von lichtbrechendem Apparat des Auges, ...",
+      "description": "erklären die Wahrnehmung von Licht als Zusammenwirken von lichtbrechendem Apparat des Auges, den Sehsinneszellen der Netzhaut sowie dem Gehirn und leiten Ursachen von Sehfehlern sowie Möglichkeiten für deren Korrektur ab.",
+      "sourceText": "erklären die Wahrnehmung von Licht als Zusammenwirken von lichtbrechendem Apparat des Auges, den Sehsinneszellen der Netzhaut sowie dem Gehirn und leiten Ursachen von Sehfehlern sowie Möglichkeiten für deren Korrektur ab.",
+      "sourceSpan": "B8.2.2",
+      "parentBulletText": "erklären die Wahrnehmung von Licht als Zusammenwirken von lichtbrechendem Apparat des Auges, den Sehsinneszellen der Netzhaut sowie dem Gehirn und leiten Ursachen von Sehfehlern sowie Möglichkeiten für deren Korrektur ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.2"
+      ],
+      "rawSourceText": "erklären die Wahrnehmung von Licht als Zusammenwirken von lichtbrechendem Apparat des Auges, den Sehsinneszellen der Netzhaut sowie dem Gehirn und leiten Ursachen von Sehfehlern sowie Möglichkeiten für deren Korrektur ab.",
+      "rawSourceSpan": "B8.2.2",
+      "rawParentBulletText": "erklären die Wahrnehmung von Licht als Zusammenwirken von lichtbrechendem Apparat des Auges, den Sehsinneszellen der Netzhaut sowie dem Gehirn und leiten Ursachen von Sehfehlern sowie Möglichkeiten für deren Korrektur ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "ad855269-70c3-526c-951b-cc2d54106f36",
+          "passageId": "by-bio:B8.2",
+          "topicCode": "B8.2",
+          "sourceSpan": "B8.2.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.2"
+      ],
+      "mergedSourceSpans": [
+        "B8.2.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.2"
+      ]
+    },
+    {
+      "id": "92e3879a-12e7-56d6-b8c0-94e61db932c4",
+      "passageId": "by-bio:B8.2",
+      "topicCode": "B8.2",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "leiten aus den Kenntnissen zum Hörvorgang Maßnahmen zur Vermeidung von Hörschäden ab.",
+      "description": "leiten aus den Kenntnissen zum Hörvorgang Maßnahmen zur Vermeidung von Hörschäden ab.",
+      "sourceText": "leiten aus den Kenntnissen zum Hörvorgang Maßnahmen zur Vermeidung von Hörschäden ab.",
+      "sourceSpan": "B8.2.3",
+      "parentBulletText": "leiten aus den Kenntnissen zum Hörvorgang Maßnahmen zur Vermeidung von Hörschäden ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.2"
+      ],
+      "rawSourceText": "leiten aus den Kenntnissen zum Hörvorgang Maßnahmen zur Vermeidung von Hörschäden ab.",
+      "rawSourceSpan": "B8.2.3",
+      "rawParentBulletText": "leiten aus den Kenntnissen zum Hörvorgang Maßnahmen zur Vermeidung von Hörschäden ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "92e3879a-12e7-56d6-b8c0-94e61db932c4",
+          "passageId": "by-bio:B8.2",
+          "topicCode": "B8.2",
+          "sourceSpan": "B8.2.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.2"
+      ],
+      "mergedSourceSpans": [
+        "B8.2.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.3"
+      ]
+    },
+    {
+      "id": "f9d70cb7-d9fa-5351-bd87-b5a1ac48c918",
+      "passageId": "by-bio:B8.2",
+      "topicCode": "B8.2",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "beschreiben mithilfe von Modellvorstellungen den Wirkungsmechanismus von Hormonen und deren B...",
+      "description": "beschreiben mithilfe von Modellvorstellungen den Wirkungsmechanismus von Hormonen und deren Bedeutung für die Informationsübertragung im menschlichen Körper.",
+      "sourceText": "beschreiben mithilfe von Modellvorstellungen den Wirkungsmechanismus von Hormonen und deren Bedeutung für die Informationsübertragung im menschlichen Körper.",
+      "sourceSpan": "B8.2.4",
+      "parentBulletText": "beschreiben mithilfe von Modellvorstellungen den Wirkungsmechanismus von Hormonen und deren Bedeutung für die Informationsübertragung im menschlichen Körper.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.4",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.2"
+      ],
+      "rawSourceText": "beschreiben mithilfe von Modellvorstellungen den Wirkungsmechanismus von Hormonen und deren Bedeutung für die Informationsübertragung im menschlichen Körper.",
+      "rawSourceSpan": "B8.2.4",
+      "rawParentBulletText": "beschreiben mithilfe von Modellvorstellungen den Wirkungsmechanismus von Hormonen und deren Bedeutung für die Informationsübertragung im menschlichen Körper.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f9d70cb7-d9fa-5351-bd87-b5a1ac48c918",
+          "passageId": "by-bio:B8.2",
+          "topicCode": "B8.2",
+          "sourceSpan": "B8.2.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.4",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.2"
+      ],
+      "mergedSourceSpans": [
+        "B8.2.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.4"
+      ]
+    },
+    {
+      "id": "8b2bc52e-c75a-52f8-8d6e-c889098b1b63",
+      "passageId": "by-bio:B8.2",
+      "topicCode": "B8.2",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "erläutern die Regulation des Blutzuckerspiegels durch Hormone und stellen einen Zusammenhang ...",
+      "description": "erläutern die Regulation des Blutzuckerspiegels durch Hormone und stellen einen Zusammenhang zwischen Lebensgewohnheiten sowie Veranlagung und dem Auftreten von Diabetes her, indem sie erklären, welche Faktoren die Regulation des Blutzuckerspiegels beeinflussen.",
+      "sourceText": "erläutern die Regulation des Blutzuckerspiegels durch Hormone und stellen einen Zusammenhang zwischen Lebensgewohnheiten sowie Veranlagung und dem Auftreten von Diabetes her, indem sie erklären, welche Faktoren die Regulation des Blutzuckerspiegels beeinflussen.",
+      "sourceSpan": "B8.2.5",
+      "parentBulletText": "erläutern die Regulation des Blutzuckerspiegels durch Hormone und stellen einen Zusammenhang zwischen Lebensgewohnheiten sowie Veranlagung und dem Auftreten von Diabetes her, indem sie erklären, welche Faktoren die Regulation des Blutzuckerspiegels beeinflussen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.5",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.2"
+      ],
+      "rawSourceText": "erläutern die Regulation des Blutzuckerspiegels durch Hormone und stellen einen Zusammenhang zwischen Lebensgewohnheiten sowie Veranlagung und dem Auftreten von Diabetes her, indem sie erklären, welche Faktoren die Regulation des Blutzuckerspiegels beeinflussen.",
+      "rawSourceSpan": "B8.2.5",
+      "rawParentBulletText": "erläutern die Regulation des Blutzuckerspiegels durch Hormone und stellen einen Zusammenhang zwischen Lebensgewohnheiten sowie Veranlagung und dem Auftreten von Diabetes her, indem sie erklären, welche Faktoren die Regulation des Blutzuckerspiegels beeinflussen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "8b2bc52e-c75a-52f8-8d6e-c889098b1b63",
+          "passageId": "by-bio:B8.2",
+          "topicCode": "B8.2",
+          "sourceSpan": "B8.2.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.5",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.2"
+      ],
+      "mergedSourceSpans": [
+        "B8.2.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.5"
+      ]
+    },
+    {
+      "id": "65529a29-8e40-5c29-ab13-43c5e9d91fe0",
+      "passageId": "by-bio:B8.2",
+      "topicCode": "B8.2",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "erklären das Auftreten körperlicher Symptome bei der Stressreaktion durch das Zusammenspiel v...",
+      "description": "erklären das Auftreten körperlicher Symptome bei der Stressreaktion durch das Zusammenspiel von Nervensystem und hormonellen Faktoren und nutzen ihre Kenntnisse für die individuelle Stressbewältigung.",
+      "sourceText": "erklären das Auftreten körperlicher Symptome bei der Stressreaktion durch das Zusammenspiel von Nervensystem und hormonellen Faktoren und nutzen ihre Kenntnisse für die individuelle Stressbewältigung.",
+      "sourceSpan": "B8.2.6",
+      "parentBulletText": "erklären das Auftreten körperlicher Symptome bei der Stressreaktion durch das Zusammenspiel von Nervensystem und hormonellen Faktoren und nutzen ihre Kenntnisse für die individuelle Stressbewältigung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.6",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.2"
+      ],
+      "rawSourceText": "erklären das Auftreten körperlicher Symptome bei der Stressreaktion durch das Zusammenspiel von Nervensystem und hormonellen Faktoren und nutzen ihre Kenntnisse für die individuelle Stressbewältigung.",
+      "rawSourceSpan": "B8.2.6",
+      "rawParentBulletText": "erklären das Auftreten körperlicher Symptome bei der Stressreaktion durch das Zusammenspiel von Nervensystem und hormonellen Faktoren und nutzen ihre Kenntnisse für die individuelle Stressbewältigung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "65529a29-8e40-5c29-ab13-43c5e9d91fe0",
+          "passageId": "by-bio:B8.2",
+          "topicCode": "B8.2",
+          "sourceSpan": "B8.2.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.6",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.2"
+      ],
+      "mergedSourceSpans": [
+        "B8.2.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.6"
+      ]
+    },
+    {
+      "id": "0236413c-a800-5cc7-94d8-071e45ed8948",
+      "passageId": "by-bio:B8.2",
+      "topicCode": "B8.2",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "vergleichen die Informationsübertragung im Nervensystem mit der Informationsübertragung durch...",
+      "description": "vergleichen die Informationsübertragung im Nervensystem mit der Informationsübertragung durch Hormone.",
+      "sourceText": "vergleichen die Informationsübertragung im Nervensystem mit der Informationsübertragung durch Hormone.",
+      "sourceSpan": "B8.2.7",
+      "parentBulletText": "vergleichen die Informationsübertragung im Nervensystem mit der Informationsübertragung durch Hormone.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.7",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.2"
+      ],
+      "rawSourceText": "vergleichen die Informationsübertragung im Nervensystem mit der Informationsübertragung durch Hormone.",
+      "rawSourceSpan": "B8.2.7",
+      "rawParentBulletText": "vergleichen die Informationsübertragung im Nervensystem mit der Informationsübertragung durch Hormone.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "0236413c-a800-5cc7-94d8-071e45ed8948",
+          "passageId": "by-bio:B8.2",
+          "topicCode": "B8.2",
+          "sourceSpan": "B8.2.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.7",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.2"
+      ],
+      "mergedSourceSpans": [
+        "B8.2.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.2.7"
+      ]
+    },
+    {
+      "id": "5d142d10-554b-533a-9457-c8abe3b9cd7c",
+      "passageId": "by-bio:B8.3",
+      "topicCode": "B8.3",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "verständigen sich in medizinischen und gesellschaftlichen Kontexten sowie in Partnerschaften ...",
+      "description": "verständigen sich in medizinischen und gesellschaftlichen Kontexten sowie in Partnerschaften in geeigneter Sprache und respektvoll über Sexualität und begegnen medial vermittelter sexueller Belästigung und Gewalt sowie der unterschwelligen Bedrohung durch sexualisierten, abwertenden Sprachgebrauch angemessen.",
+      "sourceText": "verständigen sich in medizinischen und gesellschaftlichen Kontexten sowie in Partnerschaften in geeigneter Sprache und respektvoll über Sexualität und begegnen medial vermittelter sexueller Belästigung und Gewalt sowie der unterschwelligen Bedrohung durch sexualisierten, abwertenden Sprachgebrauch angemessen.",
+      "sourceSpan": "B8.3.1",
+      "parentBulletText": "verständigen sich in medizinischen und gesellschaftlichen Kontexten sowie in Partnerschaften in geeigneter Sprache und respektvoll über Sexualität und begegnen medial vermittelter sexueller Belästigung und Gewalt sowie der unterschwelligen Bedrohung durch sexualisierten, abwertenden Sprachgebrauch angemessen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.3"
+      ],
+      "rawSourceText": "verständigen sich in medizinischen und gesellschaftlichen Kontexten sowie in Partnerschaften in geeigneter Sprache und respektvoll über Sexualität und begegnen medial vermittelter sexueller Belästigung und Gewalt sowie der unterschwelligen Bedrohung durch sexualisierten, abwertenden Sprachgebrauch angemessen.",
+      "rawSourceSpan": "B8.3.1",
+      "rawParentBulletText": "verständigen sich in medizinischen und gesellschaftlichen Kontexten sowie in Partnerschaften in geeigneter Sprache und respektvoll über Sexualität und begegnen medial vermittelter sexueller Belästigung und Gewalt sowie der unterschwelligen Bedrohung durch sexualisierten, abwertenden Sprachgebrauch angemessen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "5d142d10-554b-533a-9457-c8abe3b9cd7c",
+          "passageId": "by-bio:B8.3",
+          "topicCode": "B8.3",
+          "sourceSpan": "B8.3.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.3"
+      ],
+      "mergedSourceSpans": [
+        "B8.3.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.1"
+      ]
+    },
+    {
+      "id": "6ceddf31-0bb9-5fac-a286-d635bbca600b",
+      "passageId": "by-bio:B8.3",
+      "topicCode": "B8.3",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "bewerten unterschiedliche Verhaltensweisen im Hinblick auf die sexuelle Selbstbestimmung, die...",
+      "description": "bewerten unterschiedliche Verhaltensweisen im Hinblick auf die sexuelle Selbstbestimmung, die Achtung von persönlicher Würde und freier Selbstentfaltung und stellen Rollen- und Körperbilder und die Sexualisierung von Alltagsthemen in den Medien infrage.",
+      "sourceText": "bewerten unterschiedliche Verhaltensweisen im Hinblick auf die sexuelle Selbstbestimmung, die Achtung von persönlicher Würde und freier Selbstentfaltung und stellen Rollen- und Körperbilder und die Sexualisierung von Alltagsthemen in den Medien infrage.",
+      "sourceSpan": "B8.3.2",
+      "parentBulletText": "bewerten unterschiedliche Verhaltensweisen im Hinblick auf die sexuelle Selbstbestimmung, die Achtung von persönlicher Würde und freier Selbstentfaltung und stellen Rollen- und Körperbilder und die Sexualisierung von Alltagsthemen in den Medien infrage.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.3"
+      ],
+      "rawSourceText": "bewerten unterschiedliche Verhaltensweisen im Hinblick auf die sexuelle Selbstbestimmung, die Achtung von persönlicher Würde und freier Selbstentfaltung und stellen Rollen- und Körperbilder und die Sexualisierung von Alltagsthemen in den Medien infrage.",
+      "rawSourceSpan": "B8.3.2",
+      "rawParentBulletText": "bewerten unterschiedliche Verhaltensweisen im Hinblick auf die sexuelle Selbstbestimmung, die Achtung von persönlicher Würde und freier Selbstentfaltung und stellen Rollen- und Körperbilder und die Sexualisierung von Alltagsthemen in den Medien infrage.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "6ceddf31-0bb9-5fac-a286-d635bbca600b",
+          "passageId": "by-bio:B8.3",
+          "topicCode": "B8.3",
+          "sourceSpan": "B8.3.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.3"
+      ],
+      "mergedSourceSpans": [
+        "B8.3.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.2"
+      ]
+    },
+    {
+      "id": "540b60bd-556d-55a8-8814-ad99ccc4ecd8",
+      "passageId": "by-bio:B8.3",
+      "topicCode": "B8.3",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "charakterisieren psychische und physische Veränderungen während der Pubertät als Teil eines b...",
+      "description": "charakterisieren psychische und physische Veränderungen während der Pubertät als Teil eines biologischen Entwicklungsprozesses, um diese Veränderungen dadurch bei sich und bei anderen besser annehmen und verstehen zu können. Dabei erkennen sie den Einfluss der Medien auf eigene Vorstellungen von Sexualität und Schönheit.",
+      "sourceText": "charakterisieren psychische und physische Veränderungen während der Pubertät als Teil eines biologischen Entwicklungsprozesses, um diese Veränderungen dadurch bei sich und bei anderen besser annehmen und verstehen zu können. Dabei erkennen sie den Einfluss der Medien auf eigene Vorstellungen von Sexualität und Schönheit.",
+      "sourceSpan": "B8.3.3",
+      "parentBulletText": "charakterisieren psychische und physische Veränderungen während der Pubertät als Teil eines biologischen Entwicklungsprozesses, um diese Veränderungen dadurch bei sich und bei anderen besser annehmen und verstehen zu können. Dabei erkennen sie den Einfluss der Medien auf eigene Vorstellungen von Sexualität und Schönheit.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.3"
+      ],
+      "rawSourceText": "charakterisieren psychische und physische Veränderungen während der Pubertät als Teil eines biologischen Entwicklungsprozesses, um diese Veränderungen dadurch bei sich und bei anderen besser annehmen und verstehen zu können. Dabei erkennen sie den Einfluss der Medien auf eigene Vorstellungen von Sexualität und Schönheit.",
+      "rawSourceSpan": "B8.3.3",
+      "rawParentBulletText": "charakterisieren psychische und physische Veränderungen während der Pubertät als Teil eines biologischen Entwicklungsprozesses, um diese Veränderungen dadurch bei sich und bei anderen besser annehmen und verstehen zu können. Dabei erkennen sie den Einfluss der Medien auf eigene Vorstellungen von Sexualität und Schönheit.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "540b60bd-556d-55a8-8814-ad99ccc4ecd8",
+          "passageId": "by-bio:B8.3",
+          "topicCode": "B8.3",
+          "sourceSpan": "B8.3.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.3"
+      ],
+      "mergedSourceSpans": [
+        "B8.3.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.3"
+      ]
+    },
+    {
+      "id": "5d2a6bed-9958-5753-8fb4-9703d5a15752",
+      "passageId": "by-bio:B8.3",
+      "topicCode": "B8.3",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "beschreiben den Menstruationszyklus und erklären dessen Steuerung durch das Zusammenspiel ver...",
+      "description": "beschreiben den Menstruationszyklus und erklären dessen Steuerung durch das Zusammenspiel verschiedener Hormone.",
+      "sourceText": "beschreiben den Menstruationszyklus und erklären dessen Steuerung durch das Zusammenspiel verschiedener Hormone.",
+      "sourceSpan": "B8.3.4",
+      "parentBulletText": "beschreiben den Menstruationszyklus und erklären dessen Steuerung durch das Zusammenspiel verschiedener Hormone.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.4",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.3"
+      ],
+      "rawSourceText": "beschreiben den Menstruationszyklus und erklären dessen Steuerung durch das Zusammenspiel verschiedener Hormone.",
+      "rawSourceSpan": "B8.3.4",
+      "rawParentBulletText": "beschreiben den Menstruationszyklus und erklären dessen Steuerung durch das Zusammenspiel verschiedener Hormone.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "5d2a6bed-9958-5753-8fb4-9703d5a15752",
+          "passageId": "by-bio:B8.3",
+          "topicCode": "B8.3",
+          "sourceSpan": "B8.3.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.4",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.3"
+      ],
+      "mergedSourceSpans": [
+        "B8.3.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.4"
+      ]
+    },
+    {
+      "id": "b89ae127-06b7-5752-a60a-c96d4c53db6e",
+      "passageId": "by-bio:B8.3",
+      "topicCode": "B8.3",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "bewerten verschiedene Verhaltensweisen im Vorfeld und während der Schwangerschaft im Hinblick...",
+      "description": "bewerten verschiedene Verhaltensweisen im Vorfeld und während der Schwangerschaft im Hinblick auf mögliche gesundheitliche Folgen für das Kind.",
+      "sourceText": "bewerten verschiedene Verhaltensweisen im Vorfeld und während der Schwangerschaft im Hinblick auf mögliche gesundheitliche Folgen für das Kind.",
+      "sourceSpan": "B8.3.5",
+      "parentBulletText": "bewerten verschiedene Verhaltensweisen im Vorfeld und während der Schwangerschaft im Hinblick auf mögliche gesundheitliche Folgen für das Kind.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.5",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.3"
+      ],
+      "rawSourceText": "bewerten verschiedene Verhaltensweisen im Vorfeld und während der Schwangerschaft im Hinblick auf mögliche gesundheitliche Folgen für das Kind.",
+      "rawSourceSpan": "B8.3.5",
+      "rawParentBulletText": "bewerten verschiedene Verhaltensweisen im Vorfeld und während der Schwangerschaft im Hinblick auf mögliche gesundheitliche Folgen für das Kind.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b89ae127-06b7-5752-a60a-c96d4c53db6e",
+          "passageId": "by-bio:B8.3",
+          "topicCode": "B8.3",
+          "sourceSpan": "B8.3.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.5",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.3"
+      ],
+      "mergedSourceSpans": [
+        "B8.3.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.5"
+      ]
+    },
+    {
+      "id": "24c2aaf9-e4b2-5b71-9449-7d954795ba6c",
+      "passageId": "by-bio:B8.3",
+      "topicCode": "B8.3",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "erklären die Wirkungsweise verschiedener Methoden der Empfängnisregulation, um deren Vor- und...",
+      "description": "erklären die Wirkungsweise verschiedener Methoden der Empfängnisregulation, um deren Vor- und Nachteile abzuwägen und so Familienplanung aktiv und verantwortlich gestalten zu können.",
+      "sourceText": "erklären die Wirkungsweise verschiedener Methoden der Empfängnisregulation, um deren Vor- und Nachteile abzuwägen und so Familienplanung aktiv und verantwortlich gestalten zu können.",
+      "sourceSpan": "B8.3.6",
+      "parentBulletText": "erklären die Wirkungsweise verschiedener Methoden der Empfängnisregulation, um deren Vor- und Nachteile abzuwägen und so Familienplanung aktiv und verantwortlich gestalten zu können.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.6",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.3"
+      ],
+      "rawSourceText": "erklären die Wirkungsweise verschiedener Methoden der Empfängnisregulation, um deren Vor- und Nachteile abzuwägen und so Familienplanung aktiv und verantwortlich gestalten zu können.",
+      "rawSourceSpan": "B8.3.6",
+      "rawParentBulletText": "erklären die Wirkungsweise verschiedener Methoden der Empfängnisregulation, um deren Vor- und Nachteile abzuwägen und so Familienplanung aktiv und verantwortlich gestalten zu können.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "24c2aaf9-e4b2-5b71-9449-7d954795ba6c",
+          "passageId": "by-bio:B8.3",
+          "topicCode": "B8.3",
+          "sourceSpan": "B8.3.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.6",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.3"
+      ],
+      "mergedSourceSpans": [
+        "B8.3.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.6"
+      ]
+    },
+    {
+      "id": "b0a2fbf6-bf74-5e9f-8ca1-39ae90ffe0b8",
+      "passageId": "by-bio:B8.3",
+      "topicCode": "B8.3",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "nutzen Wissen zu sexuell übertragbaren Erkrankungen und deren Übertragungswegen, um sich und ...",
+      "description": "nutzen Wissen zu sexuell übertragbaren Erkrankungen und deren Übertragungswegen, um sich und andere vor einer Infektion zu schützen.",
+      "sourceText": "nutzen Wissen zu sexuell übertragbaren Erkrankungen und deren Übertragungswegen, um sich und andere vor einer Infektion zu schützen.",
+      "sourceSpan": "B8.3.7",
+      "parentBulletText": "nutzen Wissen zu sexuell übertragbaren Erkrankungen und deren Übertragungswegen, um sich und andere vor einer Infektion zu schützen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.7",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.3"
+      ],
+      "rawSourceText": "nutzen Wissen zu sexuell übertragbaren Erkrankungen und deren Übertragungswegen, um sich und andere vor einer Infektion zu schützen.",
+      "rawSourceSpan": "B8.3.7",
+      "rawParentBulletText": "nutzen Wissen zu sexuell übertragbaren Erkrankungen und deren Übertragungswegen, um sich und andere vor einer Infektion zu schützen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b0a2fbf6-bf74-5e9f-8ca1-39ae90ffe0b8",
+          "passageId": "by-bio:B8.3",
+          "topicCode": "B8.3",
+          "sourceSpan": "B8.3.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.7",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.3"
+      ],
+      "mergedSourceSpans": [
+        "B8.3.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.3.7"
+      ]
+    },
+    {
+      "id": "ed0a0007-5c26-5a6c-954b-9840ee344563",
+      "passageId": "by-bio:B8.4",
+      "topicCode": "B8.4",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "beobachten und vergleichen einfache Verhaltensweisen auch mithilfe von Attrappenversuchen, um...",
+      "description": "beobachten und vergleichen einfache Verhaltensweisen auch mithilfe von Attrappenversuchen, um sie als Ergebnis des Zusammenwirkens von inneren Faktoren und reaktionsauslösenden Reizen zu beschreiben.",
+      "sourceText": "beobachten und vergleichen einfache Verhaltensweisen auch mithilfe von Attrappenversuchen, um sie als Ergebnis des Zusammenwirkens von inneren Faktoren und reaktionsauslösenden Reizen zu beschreiben.",
+      "sourceSpan": "B8.4.1",
+      "parentBulletText": "beobachten und vergleichen einfache Verhaltensweisen auch mithilfe von Attrappenversuchen, um sie als Ergebnis des Zusammenwirkens von inneren Faktoren und reaktionsauslösenden Reizen zu beschreiben.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.4.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.4"
+      ],
+      "rawSourceText": "beobachten und vergleichen einfache Verhaltensweisen auch mithilfe von Attrappenversuchen, um sie als Ergebnis des Zusammenwirkens von inneren Faktoren und reaktionsauslösenden Reizen zu beschreiben.",
+      "rawSourceSpan": "B8.4.1",
+      "rawParentBulletText": "beobachten und vergleichen einfache Verhaltensweisen auch mithilfe von Attrappenversuchen, um sie als Ergebnis des Zusammenwirkens von inneren Faktoren und reaktionsauslösenden Reizen zu beschreiben.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "ed0a0007-5c26-5a6c-954b-9840ee344563",
+          "passageId": "by-bio:B8.4",
+          "topicCode": "B8.4",
+          "sourceSpan": "B8.4.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.4.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.4"
+      ],
+      "mergedSourceSpans": [
+        "B8.4.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.4.1"
+      ]
+    },
+    {
+      "id": "dd94b698-5c06-5a28-966f-b0294fa78805",
+      "passageId": "by-bio:B8.4",
+      "topicCode": "B8.4",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "beurteilen auf der Grundlage von Daten aus Verhaltensbeobachtungen, ob eine Verhaltensweise v...",
+      "description": "beurteilen auf der Grundlage von Daten aus Verhaltensbeobachtungen, ob eine Verhaltensweise v. a. auf genetisch bedingten oder erworbenen Anteilen beruht.",
+      "sourceText": "beurteilen auf der Grundlage von Daten aus Verhaltensbeobachtungen, ob eine Verhaltensweise v. a. auf genetisch bedingten oder erworbenen Anteilen beruht.",
+      "sourceSpan": "B8.4.2",
+      "parentBulletText": "beurteilen auf der Grundlage von Daten aus Verhaltensbeobachtungen, ob eine Verhaltensweise v. a. auf genetisch bedingten oder erworbenen Anteilen beruht.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.4.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.4"
+      ],
+      "rawSourceText": "beurteilen auf der Grundlage von Daten aus Verhaltensbeobachtungen, ob eine Verhaltensweise v. a. auf genetisch bedingten oder erworbenen Anteilen beruht.",
+      "rawSourceSpan": "B8.4.2",
+      "rawParentBulletText": "beurteilen auf der Grundlage von Daten aus Verhaltensbeobachtungen, ob eine Verhaltensweise v. a. auf genetisch bedingten oder erworbenen Anteilen beruht.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "dd94b698-5c06-5a28-966f-b0294fa78805",
+          "passageId": "by-bio:B8.4",
+          "topicCode": "B8.4",
+          "sourceSpan": "B8.4.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.4.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.4"
+      ],
+      "mergedSourceSpans": [
+        "B8.4.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.4.2"
+      ]
+    },
+    {
+      "id": "f2c5e33a-178f-54e1-9f8c-5d1a4910870a",
+      "passageId": "by-bio:B8.4",
+      "topicCode": "B8.4",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "planen Experimente zur Konditionierung, um die Beeinflussbarkeit von Verhaltensweisen durch U...",
+      "description": "planen Experimente zur Konditionierung, um die Beeinflussbarkeit von Verhaltensweisen durch Umwelteinflüsse zu ermitteln, und grenzen ggf. die Lernfähigkeit des Menschen von der anderer Lebewesen ab.",
+      "sourceText": "planen Experimente zur Konditionierung, um die Beeinflussbarkeit von Verhaltensweisen durch Umwelteinflüsse zu ermitteln, und grenzen ggf. die Lernfähigkeit des Menschen von der anderer Lebewesen ab.",
+      "sourceSpan": "B8.4.3",
+      "parentBulletText": "planen Experimente zur Konditionierung, um die Beeinflussbarkeit von Verhaltensweisen durch Umwelteinflüsse zu ermitteln, und grenzen ggf. die Lernfähigkeit des Menschen von der anderer Lebewesen ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.4.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.4"
+      ],
+      "rawSourceText": "planen Experimente zur Konditionierung, um die Beeinflussbarkeit von Verhaltensweisen durch Umwelteinflüsse zu ermitteln, und grenzen ggf. die Lernfähigkeit des Menschen von der anderer Lebewesen ab.",
+      "rawSourceSpan": "B8.4.3",
+      "rawParentBulletText": "planen Experimente zur Konditionierung, um die Beeinflussbarkeit von Verhaltensweisen durch Umwelteinflüsse zu ermitteln, und grenzen ggf. die Lernfähigkeit des Menschen von der anderer Lebewesen ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f2c5e33a-178f-54e1-9f8c-5d1a4910870a",
+          "passageId": "by-bio:B8.4",
+          "topicCode": "B8.4",
+          "sourceSpan": "B8.4.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.4.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.4"
+      ],
+      "mergedSourceSpans": [
+        "B8.4.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.4.3"
+      ]
+    },
+    {
+      "id": "039a2c9c-f2f8-5f1e-b20e-21d6a503546a",
+      "passageId": "by-bio:B8.5",
+      "topicCode": "B8.5",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "erläutern die Grenze zwischen Genuss und Sucht, um sich eigener Suchtrisiken bewusst zu werden.",
+      "description": "erläutern die Grenze zwischen Genuss und Sucht, um sich eigener Suchtrisiken bewusst zu werden.",
+      "sourceText": "erläutern die Grenze zwischen Genuss und Sucht, um sich eigener Suchtrisiken bewusst zu werden.",
+      "sourceSpan": "B8.5.1",
+      "parentBulletText": "erläutern die Grenze zwischen Genuss und Sucht, um sich eigener Suchtrisiken bewusst zu werden.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.5.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.5"
+      ],
+      "rawSourceText": "erläutern die Grenze zwischen Genuss und Sucht, um sich eigener Suchtrisiken bewusst zu werden.",
+      "rawSourceSpan": "B8.5.1",
+      "rawParentBulletText": "erläutern die Grenze zwischen Genuss und Sucht, um sich eigener Suchtrisiken bewusst zu werden.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "039a2c9c-f2f8-5f1e-b20e-21d6a503546a",
+          "passageId": "by-bio:B8.5",
+          "topicCode": "B8.5",
+          "sourceSpan": "B8.5.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.5.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.5"
+      ],
+      "mergedSourceSpans": [
+        "B8.5.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.5.1"
+      ]
+    },
+    {
+      "id": "e2600c5b-3f63-5b03-be78-50d01912e0d0",
+      "passageId": "by-bio:B8.5",
+      "topicCode": "B8.5",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "erklären mithilfe von Modellen die Entstehung von Suchtverhalten, beschreiben Folgen für Betr...",
+      "description": "erklären mithilfe von Modellen die Entstehung von Suchtverhalten, beschreiben Folgen für Betroffene und sind dadurch für die Gefahren einer Sucht sensibilisiert.",
+      "sourceText": "erklären mithilfe von Modellen die Entstehung von Suchtverhalten, beschreiben Folgen für Betroffene und sind dadurch für die Gefahren einer Sucht sensibilisiert.",
+      "sourceSpan": "B8.5.2",
+      "parentBulletText": "erklären mithilfe von Modellen die Entstehung von Suchtverhalten, beschreiben Folgen für Betroffene und sind dadurch für die Gefahren einer Sucht sensibilisiert.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.5.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.5"
+      ],
+      "rawSourceText": "erklären mithilfe von Modellen die Entstehung von Suchtverhalten, beschreiben Folgen für Betroffene und sind dadurch für die Gefahren einer Sucht sensibilisiert.",
+      "rawSourceSpan": "B8.5.2",
+      "rawParentBulletText": "erklären mithilfe von Modellen die Entstehung von Suchtverhalten, beschreiben Folgen für Betroffene und sind dadurch für die Gefahren einer Sucht sensibilisiert.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "e2600c5b-3f63-5b03-be78-50d01912e0d0",
+          "passageId": "by-bio:B8.5",
+          "topicCode": "B8.5",
+          "sourceSpan": "B8.5.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.5.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.5"
+      ],
+      "mergedSourceSpans": [
+        "B8.5.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.5.2"
+      ]
+    },
+    {
+      "id": "33ee5392-408e-5a7e-a764-8b95b66ecb79",
+      "passageId": "by-bio:B8.5",
+      "topicCode": "B8.5",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "erklären die Bedeutung von Lebenskompetenzen für eine starke Persönlichkeit, die die Anforder...",
+      "description": "erklären die Bedeutung von Lebenskompetenzen für eine starke Persönlichkeit, die die Anforderungen des Alltags bewältigen kann und ihre Zufriedenheit nicht von bestimmten Verhaltensweisen oder Substanzen abhängig macht, um Strategien für die eigene Persönlichkeitsentwicklung ableiten zu können.",
+      "sourceText": "erklären die Bedeutung von Lebenskompetenzen für eine starke Persönlichkeit, die die Anforderungen des Alltags bewältigen kann und ihre Zufriedenheit nicht von bestimmten Verhaltensweisen oder Substanzen abhängig macht, um Strategien für die eigene Persönlichkeitsentwicklung ableiten zu können.",
+      "sourceSpan": "B8.5.3",
+      "parentBulletText": "erklären die Bedeutung von Lebenskompetenzen für eine starke Persönlichkeit, die die Anforderungen des Alltags bewältigen kann und ihre Zufriedenheit nicht von bestimmten Verhaltensweisen oder Substanzen abhängig macht, um Strategien für die eigene Persönlichkeitsentwicklung ableiten zu können.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.5.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.5"
+      ],
+      "rawSourceText": "erklären die Bedeutung von Lebenskompetenzen für eine starke Persönlichkeit, die die Anforderungen des Alltags bewältigen kann und ihre Zufriedenheit nicht von bestimmten Verhaltensweisen oder Substanzen abhängig macht, um Strategien für die eigene Persönlichkeitsentwicklung ableiten zu können.",
+      "rawSourceSpan": "B8.5.3",
+      "rawParentBulletText": "erklären die Bedeutung von Lebenskompetenzen für eine starke Persönlichkeit, die die Anforderungen des Alltags bewältigen kann und ihre Zufriedenheit nicht von bestimmten Verhaltensweisen oder Substanzen abhängig macht, um Strategien für die eigene Persönlichkeitsentwicklung ableiten zu können.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "33ee5392-408e-5a7e-a764-8b95b66ecb79",
+          "passageId": "by-bio:B8.5",
+          "topicCode": "B8.5",
+          "sourceSpan": "B8.5.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.5.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.5"
+      ],
+      "mergedSourceSpans": [
+        "B8.5.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.5.3"
+      ]
+    },
+    {
+      "id": "d275b9f4-09ed-5b32-951c-df550720204d",
+      "passageId": "by-bio:B8.6",
+      "topicCode": "B8.6",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "charakterisieren die Veränderung eines ortsnahen Ökosystems im Lauf der Zeit, um die Entwickl...",
+      "description": "charakterisieren die Veränderung eines ortsnahen Ökosystems im Lauf der Zeit, um die Entwicklung dieses Ökosystems unter dem Einfluss des Menschen von einer natürlichen Entwicklung zu unterscheiden.",
+      "sourceText": "charakterisieren die Veränderung eines ortsnahen Ökosystems im Lauf der Zeit, um die Entwicklung dieses Ökosystems unter dem Einfluss des Menschen von einer natürlichen Entwicklung zu unterscheiden.",
+      "sourceSpan": "B8.6.1",
+      "parentBulletText": "charakterisieren die Veränderung eines ortsnahen Ökosystems im Lauf der Zeit, um die Entwicklung dieses Ökosystems unter dem Einfluss des Menschen von einer natürlichen Entwicklung zu unterscheiden.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.6.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.6"
+      ],
+      "rawSourceText": "charakterisieren die Veränderung eines ortsnahen Ökosystems im Lauf der Zeit, um die Entwicklung dieses Ökosystems unter dem Einfluss des Menschen von einer natürlichen Entwicklung zu unterscheiden.",
+      "rawSourceSpan": "B8.6.1",
+      "rawParentBulletText": "charakterisieren die Veränderung eines ortsnahen Ökosystems im Lauf der Zeit, um die Entwicklung dieses Ökosystems unter dem Einfluss des Menschen von einer natürlichen Entwicklung zu unterscheiden.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "d275b9f4-09ed-5b32-951c-df550720204d",
+          "passageId": "by-bio:B8.6",
+          "topicCode": "B8.6",
+          "sourceSpan": "B8.6.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.6.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.6"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.6"
+      ],
+      "mergedSourceSpans": [
+        "B8.6.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.6.1"
+      ]
+    },
+    {
+      "id": "d51e6243-8b61-5bb5-b9e8-99456895d22a",
+      "passageId": "by-bio:B8.6",
+      "topicCode": "B8.6",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "beschreiben Eingriffe des Menschen in die Natur, erörtern Handlungsoptionen unter dem Aspekt ...",
+      "description": "beschreiben Eingriffe des Menschen in die Natur, erörtern Handlungsoptionen unter dem Aspekt einer nachhaltigen Entwicklung und treffen so begründete Entscheidungen für oder gegen diese Eingriffe.",
+      "sourceText": "beschreiben Eingriffe des Menschen in die Natur, erörtern Handlungsoptionen unter dem Aspekt einer nachhaltigen Entwicklung und treffen so begründete Entscheidungen für oder gegen diese Eingriffe.",
+      "sourceSpan": "B8.6.2",
+      "parentBulletText": "beschreiben Eingriffe des Menschen in die Natur, erörtern Handlungsoptionen unter dem Aspekt einer nachhaltigen Entwicklung und treffen so begründete Entscheidungen für oder gegen diese Eingriffe.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.6.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.6"
+      ],
+      "rawSourceText": "beschreiben Eingriffe des Menschen in die Natur, erörtern Handlungsoptionen unter dem Aspekt einer nachhaltigen Entwicklung und treffen so begründete Entscheidungen für oder gegen diese Eingriffe.",
+      "rawSourceSpan": "B8.6.2",
+      "rawParentBulletText": "beschreiben Eingriffe des Menschen in die Natur, erörtern Handlungsoptionen unter dem Aspekt einer nachhaltigen Entwicklung und treffen so begründete Entscheidungen für oder gegen diese Eingriffe.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "d51e6243-8b61-5bb5-b9e8-99456895d22a",
+          "passageId": "by-bio:B8.6",
+          "topicCode": "B8.6",
+          "sourceSpan": "B8.6.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.6.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.6"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.6"
+      ],
+      "mergedSourceSpans": [
+        "B8.6.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.6.2"
+      ]
+    },
+    {
+      "id": "a161e6be-c302-513e-ba6b-ae217ed84a78",
+      "passageId": "by-bio:B8.6",
+      "topicCode": "B8.6",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "bewerten die Beeinflussung globaler Stoffströme unter dem Aspekt der nachhaltigen Entwicklung...",
+      "description": "bewerten die Beeinflussung globaler Stoffströme unter dem Aspekt der nachhaltigen Entwicklung und beschreiben politische und persönliche Möglichkeiten, Einfluss auf diese Systeme zu nehmen.",
+      "sourceText": "bewerten die Beeinflussung globaler Stoffströme unter dem Aspekt der nachhaltigen Entwicklung und beschreiben politische und persönliche Möglichkeiten, Einfluss auf diese Systeme zu nehmen.",
+      "sourceSpan": "B8.6.3",
+      "parentBulletText": "bewerten die Beeinflussung globaler Stoffströme unter dem Aspekt der nachhaltigen Entwicklung und beschreiben politische und persönliche Möglichkeiten, Einfluss auf diese Systeme zu nehmen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.6.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B8.6"
+      ],
+      "rawSourceText": "bewerten die Beeinflussung globaler Stoffströme unter dem Aspekt der nachhaltigen Entwicklung und beschreiben politische und persönliche Möglichkeiten, Einfluss auf diese Systeme zu nehmen.",
+      "rawSourceSpan": "B8.6.3",
+      "rawParentBulletText": "bewerten die Beeinflussung globaler Stoffströme unter dem Aspekt der nachhaltigen Entwicklung und beschreiben politische und persönliche Möglichkeiten, Einfluss auf diese Systeme zu nehmen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "a161e6be-c302-513e-ba6b-ae217ed84a78",
+          "passageId": "by-bio:B8.6",
+          "topicCode": "B8.6",
+          "sourceSpan": "B8.6.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B8.6.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B8.6"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B8.6"
+      ],
+      "mergedSourceSpans": [
+        "B8.6.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B8.6.3"
+      ]
+    },
+    {
+      "id": "f4bbc76c-c071-5370-8596-0a2f94a82569",
+      "passageId": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "leiten ausgehend von für sie vorstrukturierten Alltags- und Naturphänomenen biologische Frage...",
+      "description": "leiten ausgehend von für sie vorstrukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zur Beantwortung dieser Fragestellungen vermehrt auch aus quantitativer Sicht.",
+      "sourceText": "leiten ausgehend von für sie vorstrukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zur Beantwortung dieser Fragestellungen vermehrt auch aus quantitativer Sicht.",
+      "sourceSpan": "B9.1.1",
+      "parentBulletText": "leiten ausgehend von für sie vorstrukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zur Beantwortung dieser Fragestellungen vermehrt auch aus quantitativer Sicht.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.1"
+      ],
+      "rawSourceText": "leiten ausgehend von für sie vorstrukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zur Beantwortung dieser Fragestellungen vermehrt auch aus quantitativer Sicht.",
+      "rawSourceSpan": "B9.1.1",
+      "rawParentBulletText": "leiten ausgehend von für sie vorstrukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zur Beantwortung dieser Fragestellungen vermehrt auch aus quantitativer Sicht.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f4bbc76c-c071-5370-8596-0a2f94a82569",
+          "passageId": "by-bio:B9.1",
+          "topicCode": "B9.1",
+          "sourceSpan": "B9.1.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.1"
+      ],
+      "mergedSourceSpans": [
+        "B9.1.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.1"
+      ]
+    },
+    {
+      "id": "9a1f283e-03c8-5f29-81b5-c4306f4972a4",
+      "passageId": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "führen einfache selbstgeplante oder komplexe angeleitete naturwissenschaftliche Untersuchunge...",
+      "description": "führen einfache selbstgeplante oder komplexe angeleitete naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten bei bekannten Sachverhalten selbständig und bei unbekannten mit Hilfestellung (ggf. auch mit digitalen Hilfsmitteln) vor.",
+      "sourceText": "führen einfache selbstgeplante oder komplexe angeleitete naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten bei bekannten Sachverhalten selbständig und bei unbekannten mit Hilfestellung (ggf. auch mit digitalen Hilfsmitteln) vor.",
+      "sourceSpan": "B9.1.2",
+      "parentBulletText": "führen einfache selbstgeplante oder komplexe angeleitete naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten bei bekannten Sachverhalten selbständig und bei unbekannten mit Hilfestellung (ggf. auch mit digitalen Hilfsmitteln) vor.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.1"
+      ],
+      "rawSourceText": "führen einfache selbstgeplante oder komplexe angeleitete naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten bei bekannten Sachverhalten selbständig und bei unbekannten mit Hilfestellung (ggf. auch mit digitalen Hilfsmitteln) vor.",
+      "rawSourceSpan": "B9.1.2",
+      "rawParentBulletText": "führen einfache selbstgeplante oder komplexe angeleitete naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten bei bekannten Sachverhalten selbständig und bei unbekannten mit Hilfestellung (ggf. auch mit digitalen Hilfsmitteln) vor.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "9a1f283e-03c8-5f29-81b5-c4306f4972a4",
+          "passageId": "by-bio:B9.1",
+          "topicCode": "B9.1",
+          "sourceSpan": "B9.1.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.1"
+      ],
+      "mergedSourceSpans": [
+        "B9.1.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.2"
+      ]
+    },
+    {
+      "id": "1b2d5534-d17e-574c-982a-194934ddc6c7",
+      "passageId": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von...",
+      "description": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren überwiegend selbständig ihre Beobachtungen, werten sie aus und veranschaulichen sie.",
+      "sourceText": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren überwiegend selbständig ihre Beobachtungen, werten sie aus und veranschaulichen sie.",
+      "sourceSpan": "B9.1.3",
+      "parentBulletText": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren überwiegend selbständig ihre Beobachtungen, werten sie aus und veranschaulichen sie.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.1"
+      ],
+      "rawSourceText": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren überwiegend selbständig ihre Beobachtungen, werten sie aus und veranschaulichen sie.",
+      "rawSourceSpan": "B9.1.3",
+      "rawParentBulletText": "beobachten Lebewesen und ihre Lebenserscheinungen auch in der natürlichen Umgebung anhand von vorgegebenen und eigenen Kriterien. Sie dokumentieren überwiegend selbständig ihre Beobachtungen, werten sie aus und veranschaulichen sie.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "1b2d5534-d17e-574c-982a-194934ddc6c7",
+          "passageId": "by-bio:B9.1",
+          "topicCode": "B9.1",
+          "sourceSpan": "B9.1.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.1"
+      ],
+      "mergedSourceSpans": [
+        "B9.1.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.3"
+      ]
+    },
+    {
+      "id": "ea1d4041-df5d-55e4-8286-3898c3063826",
+      "passageId": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "verwenden ein Lichtmikroskop oder Binokular, um Präparate zu betrachten, und erstellen selbst...",
+      "description": "verwenden ein Lichtmikroskop oder Binokular, um Präparate zu betrachten, und erstellen selbständig beschriftete Zeichnungen der betrachteten biologischen Strukturen.",
+      "sourceText": "verwenden ein Lichtmikroskop oder Binokular, um Präparate zu betrachten, und erstellen selbständig beschriftete Zeichnungen der betrachteten biologischen Strukturen.",
+      "sourceSpan": "B9.1.4",
+      "parentBulletText": "verwenden ein Lichtmikroskop oder Binokular, um Präparate zu betrachten, und erstellen selbständig beschriftete Zeichnungen der betrachteten biologischen Strukturen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.4",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.1"
+      ],
+      "rawSourceText": "verwenden ein Lichtmikroskop oder Binokular, um Präparate zu betrachten, und erstellen selbständig beschriftete Zeichnungen der betrachteten biologischen Strukturen.",
+      "rawSourceSpan": "B9.1.4",
+      "rawParentBulletText": "verwenden ein Lichtmikroskop oder Binokular, um Präparate zu betrachten, und erstellen selbständig beschriftete Zeichnungen der betrachteten biologischen Strukturen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "ea1d4041-df5d-55e4-8286-3898c3063826",
+          "passageId": "by-bio:B9.1",
+          "topicCode": "B9.1",
+          "sourceSpan": "B9.1.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.4",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.1"
+      ],
+      "mergedSourceSpans": [
+        "B9.1.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.4"
+      ]
+    },
+    {
+      "id": "0cf1cee3-5715-597d-8108-65f47d9624b6",
+      "passageId": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "vergleichen Lebewesen und deren Merkmale kriteriengeleitet, um Rückschlüsse auf die Ursachen ...",
+      "description": "vergleichen Lebewesen und deren Merkmale kriteriengeleitet, um Rückschlüsse auf die Ursachen von Ähnlichkeiten zu ziehen.",
+      "sourceText": "vergleichen Lebewesen und deren Merkmale kriteriengeleitet, um Rückschlüsse auf die Ursachen von Ähnlichkeiten zu ziehen.",
+      "sourceSpan": "B9.1.5",
+      "parentBulletText": "vergleichen Lebewesen und deren Merkmale kriteriengeleitet, um Rückschlüsse auf die Ursachen von Ähnlichkeiten zu ziehen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.5",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.1"
+      ],
+      "rawSourceText": "vergleichen Lebewesen und deren Merkmale kriteriengeleitet, um Rückschlüsse auf die Ursachen von Ähnlichkeiten zu ziehen.",
+      "rawSourceSpan": "B9.1.5",
+      "rawParentBulletText": "vergleichen Lebewesen und deren Merkmale kriteriengeleitet, um Rückschlüsse auf die Ursachen von Ähnlichkeiten zu ziehen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "0cf1cee3-5715-597d-8108-65f47d9624b6",
+          "passageId": "by-bio:B9.1",
+          "topicCode": "B9.1",
+          "sourceSpan": "B9.1.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.5",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.1"
+      ],
+      "mergedSourceSpans": [
+        "B9.1.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.5"
+      ]
+    },
+    {
+      "id": "cc6b48b2-27c7-55aa-addd-123e31080217",
+      "passageId": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "systematisieren u. a. Insekten mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch...",
+      "description": "systematisieren u. a. Insekten mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk) und sind sich dadurch der Artenvielfalt der Wirbellosen bewusst.",
+      "sourceText": "systematisieren u. a. Insekten mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk) und sind sich dadurch der Artenvielfalt der Wirbellosen bewusst.",
+      "sourceSpan": "B9.1.6",
+      "parentBulletText": "systematisieren u. a. Insekten mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk) und sind sich dadurch der Artenvielfalt der Wirbellosen bewusst.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.6",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.1"
+      ],
+      "rawSourceText": "systematisieren u. a. Insekten mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk) und sind sich dadurch der Artenvielfalt der Wirbellosen bewusst.",
+      "rawSourceSpan": "B9.1.6",
+      "rawParentBulletText": "systematisieren u. a. Insekten mithilfe ausgewählter Bestimmungshilfen (z. B. Bestimmungsbuch, digitales Nachschlagewerk) und sind sich dadurch der Artenvielfalt der Wirbellosen bewusst.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "cc6b48b2-27c7-55aa-addd-123e31080217",
+          "passageId": "by-bio:B9.1",
+          "topicCode": "B9.1",
+          "sourceSpan": "B9.1.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.6",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.1"
+      ],
+      "mergedSourceSpans": [
+        "B9.1.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.6"
+      ]
+    },
+    {
+      "id": "55e67047-03c8-5551-a360-d8f91ef65c7b",
+      "passageId": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "interpretieren erhobene oder recherchierte Daten und schätzen deren Gültigkeit ein. Sie benen...",
+      "description": "interpretieren erhobene oder recherchierte Daten und schätzen deren Gültigkeit ein. Sie benennen mögliche Fehlerquellen und leiten Maßnahmen zur Fehlervermeidung ab.",
+      "sourceText": "interpretieren erhobene oder recherchierte Daten und schätzen deren Gültigkeit ein. Sie benennen mögliche Fehlerquellen und leiten Maßnahmen zur Fehlervermeidung ab.",
+      "sourceSpan": "B9.1.7",
+      "parentBulletText": "interpretieren erhobene oder recherchierte Daten und schätzen deren Gültigkeit ein. Sie benennen mögliche Fehlerquellen und leiten Maßnahmen zur Fehlervermeidung ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.7",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.1"
+      ],
+      "rawSourceText": "interpretieren erhobene oder recherchierte Daten und schätzen deren Gültigkeit ein. Sie benennen mögliche Fehlerquellen und leiten Maßnahmen zur Fehlervermeidung ab.",
+      "rawSourceSpan": "B9.1.7",
+      "rawParentBulletText": "interpretieren erhobene oder recherchierte Daten und schätzen deren Gültigkeit ein. Sie benennen mögliche Fehlerquellen und leiten Maßnahmen zur Fehlervermeidung ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "55e67047-03c8-5551-a360-d8f91ef65c7b",
+          "passageId": "by-bio:B9.1",
+          "topicCode": "B9.1",
+          "sourceSpan": "B9.1.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.7",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.1"
+      ],
+      "mergedSourceSpans": [
+        "B9.1.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.7"
+      ]
+    },
+    {
+      "id": "a4c628d9-cf4b-5a6f-80a6-32512acd9004",
+      "passageId": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "beschreiben ausgewählte Eigenschaften naturwissenschaftlichen Wissens und leiten daraus Aussa...",
+      "description": "beschreiben ausgewählte Eigenschaften naturwissenschaftlichen Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab (z. B. Evolutionsforschung).",
+      "sourceText": "beschreiben ausgewählte Eigenschaften naturwissenschaftlichen Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab (z. B. Evolutionsforschung).",
+      "sourceSpan": "B9.1.8",
+      "parentBulletText": "beschreiben ausgewählte Eigenschaften naturwissenschaftlichen Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab (z. B. Evolutionsforschung).",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.8",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.1"
+      ],
+      "rawSourceText": "beschreiben ausgewählte Eigenschaften naturwissenschaftlichen Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab (z. B. Evolutionsforschung).",
+      "rawSourceSpan": "B9.1.8",
+      "rawParentBulletText": "beschreiben ausgewählte Eigenschaften naturwissenschaftlichen Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab (z. B. Evolutionsforschung).",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "a4c628d9-cf4b-5a6f-80a6-32512acd9004",
+          "passageId": "by-bio:B9.1",
+          "topicCode": "B9.1",
+          "sourceSpan": "B9.1.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.8",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.1"
+      ],
+      "mergedSourceSpans": [
+        "B9.1.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.8"
+      ]
+    },
+    {
+      "id": "39e911cd-891b-5aa3-af27-bf5d3053d6ff",
+      "passageId": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "bulletIndex": 9,
+      "aspectIndex": 1,
+      "title": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Kohlenstoffatomkreislauf, DNA-Re...",
+      "description": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Kohlenstoffatomkreislauf, DNA-Replikation) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken, Schwächen und Grenzen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten.",
+      "sourceText": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Kohlenstoffatomkreislauf, DNA-Replikation) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken, Schwächen und Grenzen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten.",
+      "sourceSpan": "B9.1.9",
+      "parentBulletText": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Kohlenstoffatomkreislauf, DNA-Replikation) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken, Schwächen und Grenzen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.9",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.1"
+      ],
+      "rawSourceText": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Kohlenstoffatomkreislauf, DNA-Replikation) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken, Schwächen und Grenzen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten.",
+      "rawSourceSpan": "B9.1.9",
+      "rawParentBulletText": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Kohlenstoffatomkreislauf, DNA-Replikation) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken, Schwächen und Grenzen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "39e911cd-891b-5aa3-af27-bf5d3053d6ff",
+          "passageId": "by-bio:B9.1",
+          "topicCode": "B9.1",
+          "sourceSpan": "B9.1.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.9",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.1"
+      ],
+      "mergedSourceSpans": [
+        "B9.1.9"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.9"
+      ]
+    },
+    {
+      "id": "211c8f83-7a8b-5ba0-b794-69bdad821ba5",
+      "passageId": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "bulletIndex": 10,
+      "aspectIndex": 1,
+      "title": "beantworten biologische Fragestellungen, indem sie vorgegebene und selbst recherchierte, auch...",
+      "description": "beantworten biologische Fragestellungen, indem sie vorgegebene und selbst recherchierte, auch digitale Quellen situations- und adressatengerecht auswerten.",
+      "sourceText": "beantworten biologische Fragestellungen, indem sie vorgegebene und selbst recherchierte, auch digitale Quellen situations- und adressatengerecht auswerten.",
+      "sourceSpan": "B9.1.10",
+      "parentBulletText": "beantworten biologische Fragestellungen, indem sie vorgegebene und selbst recherchierte, auch digitale Quellen situations- und adressatengerecht auswerten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.10",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.1"
+      ],
+      "rawSourceText": "beantworten biologische Fragestellungen, indem sie vorgegebene und selbst recherchierte, auch digitale Quellen situations- und adressatengerecht auswerten.",
+      "rawSourceSpan": "B9.1.10",
+      "rawParentBulletText": "beantworten biologische Fragestellungen, indem sie vorgegebene und selbst recherchierte, auch digitale Quellen situations- und adressatengerecht auswerten.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "211c8f83-7a8b-5ba0-b794-69bdad821ba5",
+          "passageId": "by-bio:B9.1",
+          "topicCode": "B9.1",
+          "sourceSpan": "B9.1.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.10",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.1"
+      ],
+      "mergedSourceSpans": [
+        "B9.1.10"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.10"
+      ]
+    },
+    {
+      "id": "9a0c77f1-b6ae-5c8f-a894-1a3634c3a512",
+      "passageId": "by-bio:B9.1",
+      "topicCode": "B9.1",
+      "bulletIndex": 11,
+      "aspectIndex": 1,
+      "title": "bewerten selbständig biologische Sachverhalte und Folgen menschlichen Handelns, indem sie Pro...",
+      "description": "bewerten selbständig biologische Sachverhalte und Folgen menschlichen Handelns, indem sie Pro- und Kontra-Argumente formulieren und diese abwägen, um Handlungsoptionen zu entwickeln. Dabei berücksichtigen sie auch die Notwendigkeit des Einbezugs vielfältiger Gesichtspunkte bei der Urteilsfindung.",
+      "sourceText": "bewerten selbständig biologische Sachverhalte und Folgen menschlichen Handelns, indem sie Pro- und Kontra-Argumente formulieren und diese abwägen, um Handlungsoptionen zu entwickeln. Dabei berücksichtigen sie auch die Notwendigkeit des Einbezugs vielfältiger Gesichtspunkte bei der Urteilsfindung.",
+      "sourceSpan": "B9.1.11",
+      "parentBulletText": "bewerten selbständig biologische Sachverhalte und Folgen menschlichen Handelns, indem sie Pro- und Kontra-Argumente formulieren und diese abwägen, um Handlungsoptionen zu entwickeln. Dabei berücksichtigen sie auch die Notwendigkeit des Einbezugs vielfältiger Gesichtspunkte bei der Urteilsfindung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.11",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.1"
+      ],
+      "rawSourceText": "bewerten selbständig biologische Sachverhalte und Folgen menschlichen Handelns, indem sie Pro- und Kontra-Argumente formulieren und diese abwägen, um Handlungsoptionen zu entwickeln. Dabei berücksichtigen sie auch die Notwendigkeit des Einbezugs vielfältiger Gesichtspunkte bei der Urteilsfindung.",
+      "rawSourceSpan": "B9.1.11",
+      "rawParentBulletText": "bewerten selbständig biologische Sachverhalte und Folgen menschlichen Handelns, indem sie Pro- und Kontra-Argumente formulieren und diese abwägen, um Handlungsoptionen zu entwickeln. Dabei berücksichtigen sie auch die Notwendigkeit des Einbezugs vielfältiger Gesichtspunkte bei der Urteilsfindung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "9a0c77f1-b6ae-5c8f-a894-1a3634c3a512",
+          "passageId": "by-bio:B9.1",
+          "topicCode": "B9.1",
+          "sourceSpan": "B9.1.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.11",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.1"
+      ],
+      "mergedSourceSpans": [
+        "B9.1.11"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.1.11"
+      ]
+    },
+    {
+      "id": "dc5044f4-bf54-5642-8201-49dcf8dce9e1",
+      "passageId": "by-bio:B9.2",
+      "topicCode": "B9.2",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "erklären die biotechnologische Nutzbarkeit von Mikroorganismen, indem sie deren Besonderheite...",
+      "description": "erklären die biotechnologische Nutzbarkeit von Mikroorganismen, indem sie deren Besonderheiten im Grundbauplan, bei der Fortpflanzung und im Stoffwechsel beschreiben.",
+      "sourceText": "erklären die biotechnologische Nutzbarkeit von Mikroorganismen, indem sie deren Besonderheiten im Grundbauplan, bei der Fortpflanzung und im Stoffwechsel beschreiben.",
+      "sourceSpan": "B9.2.1",
+      "parentBulletText": "erklären die biotechnologische Nutzbarkeit von Mikroorganismen, indem sie deren Besonderheiten im Grundbauplan, bei der Fortpflanzung und im Stoffwechsel beschreiben.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.2.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.2"
+      ],
+      "rawSourceText": "erklären die biotechnologische Nutzbarkeit von Mikroorganismen, indem sie deren Besonderheiten im Grundbauplan, bei der Fortpflanzung und im Stoffwechsel beschreiben.",
+      "rawSourceSpan": "B9.2.1",
+      "rawParentBulletText": "erklären die biotechnologische Nutzbarkeit von Mikroorganismen, indem sie deren Besonderheiten im Grundbauplan, bei der Fortpflanzung und im Stoffwechsel beschreiben.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "dc5044f4-bf54-5642-8201-49dcf8dce9e1",
+          "passageId": "by-bio:B9.2",
+          "topicCode": "B9.2",
+          "sourceSpan": "B9.2.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.2.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.2"
+      ],
+      "mergedSourceSpans": [
+        "B9.2.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.2.1"
+      ]
+    },
+    {
+      "id": "b564e60e-832b-55bd-b01d-9607a1e8a2a2",
+      "passageId": "by-bio:B9.2",
+      "topicCode": "B9.2",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "erklären die Bedeutung von Mikroorganismen beim Lebensmittelverderb anhand des Stoffwechsels,...",
+      "description": "erklären die Bedeutung von Mikroorganismen beim Lebensmittelverderb anhand des Stoffwechsels, der Fortpflanzung und der Ausbreitung von Mikroorganismen und leiten daraus Verhaltensweisen zur Lebensmittelhygiene ab.",
+      "sourceText": "erklären die Bedeutung von Mikroorganismen beim Lebensmittelverderb anhand des Stoffwechsels, der Fortpflanzung und der Ausbreitung von Mikroorganismen und leiten daraus Verhaltensweisen zur Lebensmittelhygiene ab.",
+      "sourceSpan": "B9.2.2",
+      "parentBulletText": "erklären die Bedeutung von Mikroorganismen beim Lebensmittelverderb anhand des Stoffwechsels, der Fortpflanzung und der Ausbreitung von Mikroorganismen und leiten daraus Verhaltensweisen zur Lebensmittelhygiene ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.2.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.2"
+      ],
+      "rawSourceText": "erklären die Bedeutung von Mikroorganismen beim Lebensmittelverderb anhand des Stoffwechsels, der Fortpflanzung und der Ausbreitung von Mikroorganismen und leiten daraus Verhaltensweisen zur Lebensmittelhygiene ab.",
+      "rawSourceSpan": "B9.2.2",
+      "rawParentBulletText": "erklären die Bedeutung von Mikroorganismen beim Lebensmittelverderb anhand des Stoffwechsels, der Fortpflanzung und der Ausbreitung von Mikroorganismen und leiten daraus Verhaltensweisen zur Lebensmittelhygiene ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b564e60e-832b-55bd-b01d-9607a1e8a2a2",
+          "passageId": "by-bio:B9.2",
+          "topicCode": "B9.2",
+          "sourceSpan": "B9.2.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.2.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.2"
+      ],
+      "mergedSourceSpans": [
+        "B9.2.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.2.2"
+      ]
+    },
+    {
+      "id": "f0f89514-0f46-5f3d-9a2b-c75352d5a8ba",
+      "passageId": "by-bio:B9.2",
+      "topicCode": "B9.2",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "erklären die Wirkungsweise verschiedener Konservierungsmethoden und vergleichen die Auswirkun...",
+      "description": "erklären die Wirkungsweise verschiedener Konservierungsmethoden und vergleichen die Auswirkung dieser Methoden auf die Lebensmittelqualität.",
+      "sourceText": "erklären die Wirkungsweise verschiedener Konservierungsmethoden und vergleichen die Auswirkung dieser Methoden auf die Lebensmittelqualität.",
+      "sourceSpan": "B9.2.3",
+      "parentBulletText": "erklären die Wirkungsweise verschiedener Konservierungsmethoden und vergleichen die Auswirkung dieser Methoden auf die Lebensmittelqualität.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.2.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.2"
+      ],
+      "rawSourceText": "erklären die Wirkungsweise verschiedener Konservierungsmethoden und vergleichen die Auswirkung dieser Methoden auf die Lebensmittelqualität.",
+      "rawSourceSpan": "B9.2.3",
+      "rawParentBulletText": "erklären die Wirkungsweise verschiedener Konservierungsmethoden und vergleichen die Auswirkung dieser Methoden auf die Lebensmittelqualität.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f0f89514-0f46-5f3d-9a2b-c75352d5a8ba",
+          "passageId": "by-bio:B9.2",
+          "topicCode": "B9.2",
+          "sourceSpan": "B9.2.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.2.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.2"
+      ],
+      "mergedSourceSpans": [
+        "B9.2.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.2.3"
+      ]
+    },
+    {
+      "id": "caa62aba-fb03-5b28-8df1-d09624168990",
+      "passageId": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "erklären verschiedene Funktionen von Proteinen im Organismus anhand ihrer strukturellen Vielf...",
+      "description": "erklären verschiedene Funktionen von Proteinen im Organismus anhand ihrer strukturellen Vielfalt.",
+      "sourceText": "erklären verschiedene Funktionen von Proteinen im Organismus anhand ihrer strukturellen Vielfalt.",
+      "sourceSpan": "B9.3.1",
+      "parentBulletText": "erklären verschiedene Funktionen von Proteinen im Organismus anhand ihrer strukturellen Vielfalt.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.3"
+      ],
+      "rawSourceText": "erklären verschiedene Funktionen von Proteinen im Organismus anhand ihrer strukturellen Vielfalt.",
+      "rawSourceSpan": "B9.3.1",
+      "rawParentBulletText": "erklären verschiedene Funktionen von Proteinen im Organismus anhand ihrer strukturellen Vielfalt.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "caa62aba-fb03-5b28-8df1-d09624168990",
+          "passageId": "by-bio:B9.3",
+          "topicCode": "B9.3",
+          "sourceSpan": "B9.3.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.3"
+      ],
+      "mergedSourceSpans": [
+        "B9.3.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.1"
+      ]
+    },
+    {
+      "id": "e4f857b8-85da-58e5-9fb4-b4f05048d3b5",
+      "passageId": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "beschreiben ein Modell der DNA und erklären anhand dieses Modells die Zusammenhänge zwischen ...",
+      "description": "beschreiben ein Modell der DNA und erklären anhand dieses Modells die Zusammenhänge zwischen ihrer Struktur und ihrer Funktion als Informationsspeicher.",
+      "sourceText": "beschreiben ein Modell der DNA und erklären anhand dieses Modells die Zusammenhänge zwischen ihrer Struktur und ihrer Funktion als Informationsspeicher.",
+      "sourceSpan": "B9.3.2",
+      "parentBulletText": "beschreiben ein Modell der DNA und erklären anhand dieses Modells die Zusammenhänge zwischen ihrer Struktur und ihrer Funktion als Informationsspeicher.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.3"
+      ],
+      "rawSourceText": "beschreiben ein Modell der DNA und erklären anhand dieses Modells die Zusammenhänge zwischen ihrer Struktur und ihrer Funktion als Informationsspeicher.",
+      "rawSourceSpan": "B9.3.2",
+      "rawParentBulletText": "beschreiben ein Modell der DNA und erklären anhand dieses Modells die Zusammenhänge zwischen ihrer Struktur und ihrer Funktion als Informationsspeicher.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "e4f857b8-85da-58e5-9fb4-b4f05048d3b5",
+          "passageId": "by-bio:B9.3",
+          "topicCode": "B9.3",
+          "sourceSpan": "B9.3.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.3"
+      ],
+      "mergedSourceSpans": [
+        "B9.3.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.2"
+      ]
+    },
+    {
+      "id": "a6ad1554-558e-51e4-9d05-aa9b38ebfa40",
+      "passageId": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "erklären das Prinzip der Bildung von Proteinen durch die Proteinbiosynthese und die Rolle der...",
+      "description": "erklären das Prinzip der Bildung von Proteinen durch die Proteinbiosynthese und die Rolle der Proteine bei der Merkmalsausbildung.",
+      "sourceText": "erklären das Prinzip der Bildung von Proteinen durch die Proteinbiosynthese und die Rolle der Proteine bei der Merkmalsausbildung.",
+      "sourceSpan": "B9.3.3",
+      "parentBulletText": "erklären das Prinzip der Bildung von Proteinen durch die Proteinbiosynthese und die Rolle der Proteine bei der Merkmalsausbildung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.3"
+      ],
+      "rawSourceText": "erklären das Prinzip der Bildung von Proteinen durch die Proteinbiosynthese und die Rolle der Proteine bei der Merkmalsausbildung.",
+      "rawSourceSpan": "B9.3.3",
+      "rawParentBulletText": "erklären das Prinzip der Bildung von Proteinen durch die Proteinbiosynthese und die Rolle der Proteine bei der Merkmalsausbildung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "a6ad1554-558e-51e4-9d05-aa9b38ebfa40",
+          "passageId": "by-bio:B9.3",
+          "topicCode": "B9.3",
+          "sourceSpan": "B9.3.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.3"
+      ],
+      "mergedSourceSpans": [
+        "B9.3.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.3"
+      ]
+    },
+    {
+      "id": "673d3825-e43d-585c-9ee7-58bb143fd382",
+      "passageId": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "vergleichen die Organisation des genetischen Materials bei Pro- und Eukaryoten.",
+      "description": "vergleichen die Organisation des genetischen Materials bei Pro- und Eukaryoten.",
+      "sourceText": "vergleichen die Organisation des genetischen Materials bei Pro- und Eukaryoten.",
+      "sourceSpan": "B9.3.4",
+      "parentBulletText": "vergleichen die Organisation des genetischen Materials bei Pro- und Eukaryoten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.4",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.3"
+      ],
+      "rawSourceText": "vergleichen die Organisation des genetischen Materials bei Pro- und Eukaryoten.",
+      "rawSourceSpan": "B9.3.4",
+      "rawParentBulletText": "vergleichen die Organisation des genetischen Materials bei Pro- und Eukaryoten.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "673d3825-e43d-585c-9ee7-58bb143fd382",
+          "passageId": "by-bio:B9.3",
+          "topicCode": "B9.3",
+          "sourceSpan": "B9.3.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.4",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.3"
+      ],
+      "mergedSourceSpans": [
+        "B9.3.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.4"
+      ]
+    },
+    {
+      "id": "b9b18077-88f5-57ed-981e-2f7e2512af4c",
+      "passageId": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "erklären die Bedeutung der Replikation von DNA und stellen den Ablauf mithilfe eines einfache...",
+      "description": "erklären die Bedeutung der Replikation von DNA und stellen den Ablauf mithilfe eines einfachen DNA-Modells dar.",
+      "sourceText": "erklären die Bedeutung der Replikation von DNA und stellen den Ablauf mithilfe eines einfachen DNA-Modells dar.",
+      "sourceSpan": "B9.3.5",
+      "parentBulletText": "erklären die Bedeutung der Replikation von DNA und stellen den Ablauf mithilfe eines einfachen DNA-Modells dar.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.5",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.3"
+      ],
+      "rawSourceText": "erklären die Bedeutung der Replikation von DNA und stellen den Ablauf mithilfe eines einfachen DNA-Modells dar.",
+      "rawSourceSpan": "B9.3.5",
+      "rawParentBulletText": "erklären die Bedeutung der Replikation von DNA und stellen den Ablauf mithilfe eines einfachen DNA-Modells dar.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b9b18077-88f5-57ed-981e-2f7e2512af4c",
+          "passageId": "by-bio:B9.3",
+          "topicCode": "B9.3",
+          "sourceSpan": "B9.3.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.5",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.3"
+      ],
+      "mergedSourceSpans": [
+        "B9.3.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.5"
+      ]
+    },
+    {
+      "id": "55793844-76b0-57d8-a3c1-e5db5fa2e370",
+      "passageId": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, ...",
+      "description": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Fortpflanzung.",
+      "sourceText": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Fortpflanzung.",
+      "sourceSpan": "B9.3.6",
+      "parentBulletText": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Fortpflanzung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.6",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.3"
+      ],
+      "rawSourceText": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Fortpflanzung.",
+      "rawSourceSpan": "B9.3.6",
+      "rawParentBulletText": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Fortpflanzung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "55793844-76b0-57d8-a3c1-e5db5fa2e370",
+          "passageId": "by-bio:B9.3",
+          "topicCode": "B9.3",
+          "sourceSpan": "B9.3.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.6",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.3"
+      ],
+      "mergedSourceSpans": [
+        "B9.3.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.6"
+      ]
+    },
+    {
+      "id": "e0bbe3b2-96d7-5e7a-b8c1-d649a084e355",
+      "passageId": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "beschreiben das Prinzip der Meiose zur Bildung von Keimzellen und erklären die Bedeutung dies...",
+      "description": "beschreiben das Prinzip der Meiose zur Bildung von Keimzellen und erklären die Bedeutung dieses Prozesses für die geschlechtliche Fortpflanzung und die genetische Vielfalt.",
+      "sourceText": "beschreiben das Prinzip der Meiose zur Bildung von Keimzellen und erklären die Bedeutung dieses Prozesses für die geschlechtliche Fortpflanzung und die genetische Vielfalt.",
+      "sourceSpan": "B9.3.7",
+      "parentBulletText": "beschreiben das Prinzip der Meiose zur Bildung von Keimzellen und erklären die Bedeutung dieses Prozesses für die geschlechtliche Fortpflanzung und die genetische Vielfalt.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.7",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.3"
+      ],
+      "rawSourceText": "beschreiben das Prinzip der Meiose zur Bildung von Keimzellen und erklären die Bedeutung dieses Prozesses für die geschlechtliche Fortpflanzung und die genetische Vielfalt.",
+      "rawSourceSpan": "B9.3.7",
+      "rawParentBulletText": "beschreiben das Prinzip der Meiose zur Bildung von Keimzellen und erklären die Bedeutung dieses Prozesses für die geschlechtliche Fortpflanzung und die genetische Vielfalt.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "e0bbe3b2-96d7-5e7a-b8c1-d649a084e355",
+          "passageId": "by-bio:B9.3",
+          "topicCode": "B9.3",
+          "sourceSpan": "B9.3.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.7",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.3"
+      ],
+      "mergedSourceSpans": [
+        "B9.3.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.7"
+      ]
+    },
+    {
+      "id": "706204f2-4768-56d3-984a-85e9ec6fc370",
+      "passageId": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "erklären Genommutationen beim Menschen als Folge von Fehlern bei der Meiose.",
+      "description": "erklären Genommutationen beim Menschen als Folge von Fehlern bei der Meiose.",
+      "sourceText": "erklären Genommutationen beim Menschen als Folge von Fehlern bei der Meiose.",
+      "sourceSpan": "B9.3.8",
+      "parentBulletText": "erklären Genommutationen beim Menschen als Folge von Fehlern bei der Meiose.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.8",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.3"
+      ],
+      "rawSourceText": "erklären Genommutationen beim Menschen als Folge von Fehlern bei der Meiose.",
+      "rawSourceSpan": "B9.3.8",
+      "rawParentBulletText": "erklären Genommutationen beim Menschen als Folge von Fehlern bei der Meiose.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "706204f2-4768-56d3-984a-85e9ec6fc370",
+          "passageId": "by-bio:B9.3",
+          "topicCode": "B9.3",
+          "sourceSpan": "B9.3.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.8",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.3"
+      ],
+      "mergedSourceSpans": [
+        "B9.3.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.8"
+      ]
+    },
+    {
+      "id": "a3e24e24-e489-57ad-88f1-64e85633225d",
+      "passageId": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "bulletIndex": 9,
+      "aspectIndex": 1,
+      "title": "unterscheiden im Kontext von Genommutationen zwischen einer Änderung des Phänotyps und einer ...",
+      "description": "unterscheiden im Kontext von Genommutationen zwischen einer Änderung des Phänotyps und einer Krankheit.",
+      "sourceText": "unterscheiden im Kontext von Genommutationen zwischen einer Änderung des Phänotyps und einer Krankheit.",
+      "sourceSpan": "B9.3.9",
+      "parentBulletText": "unterscheiden im Kontext von Genommutationen zwischen einer Änderung des Phänotyps und einer Krankheit.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.9",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.3"
+      ],
+      "rawSourceText": "unterscheiden im Kontext von Genommutationen zwischen einer Änderung des Phänotyps und einer Krankheit.",
+      "rawSourceSpan": "B9.3.9",
+      "rawParentBulletText": "unterscheiden im Kontext von Genommutationen zwischen einer Änderung des Phänotyps und einer Krankheit.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "a3e24e24-e489-57ad-88f1-64e85633225d",
+          "passageId": "by-bio:B9.3",
+          "topicCode": "B9.3",
+          "sourceSpan": "B9.3.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.9",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.3"
+      ],
+      "mergedSourceSpans": [
+        "B9.3.9"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.9"
+      ]
+    },
+    {
+      "id": "2802979c-6270-521c-87e0-1ed9360d6bea",
+      "passageId": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "bulletIndex": 10,
+      "aspectIndex": 1,
+      "title": "bewerten medizinische, soziale und ethische Aspekte der reproduktionsmedizinischen Diagnostik...",
+      "description": "bewerten medizinische, soziale und ethische Aspekte der reproduktionsmedizinischen Diagnostik, um an gesellschaftlichen Diskussionen aktiv teilnehmen zu können.",
+      "sourceText": "bewerten medizinische, soziale und ethische Aspekte der reproduktionsmedizinischen Diagnostik, um an gesellschaftlichen Diskussionen aktiv teilnehmen zu können.",
+      "sourceSpan": "B9.3.10",
+      "parentBulletText": "bewerten medizinische, soziale und ethische Aspekte der reproduktionsmedizinischen Diagnostik, um an gesellschaftlichen Diskussionen aktiv teilnehmen zu können.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.10",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.3"
+      ],
+      "rawSourceText": "bewerten medizinische, soziale und ethische Aspekte der reproduktionsmedizinischen Diagnostik, um an gesellschaftlichen Diskussionen aktiv teilnehmen zu können.",
+      "rawSourceSpan": "B9.3.10",
+      "rawParentBulletText": "bewerten medizinische, soziale und ethische Aspekte der reproduktionsmedizinischen Diagnostik, um an gesellschaftlichen Diskussionen aktiv teilnehmen zu können.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "2802979c-6270-521c-87e0-1ed9360d6bea",
+          "passageId": "by-bio:B9.3",
+          "topicCode": "B9.3",
+          "sourceSpan": "B9.3.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.10",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.3"
+      ],
+      "mergedSourceSpans": [
+        "B9.3.10"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.10"
+      ]
+    },
+    {
+      "id": "1ad96d9d-03d9-565f-94b2-94f6ed17c523",
+      "passageId": "by-bio:B9.3",
+      "topicCode": "B9.3",
+      "bulletIndex": 11,
+      "aspectIndex": 1,
+      "title": "erläutern die prinzipielle Verfahrensweise zur technischen Neukombination von Erbinformatione...",
+      "description": "erläutern die prinzipielle Verfahrensweise zur technischen Neukombination von Erbinformationen und bewerten durch sie geschaffene Möglichkeiten unter medizinischen, gesellschaftlichen und ethischen Aspekten.",
+      "sourceText": "erläutern die prinzipielle Verfahrensweise zur technischen Neukombination von Erbinformationen und bewerten durch sie geschaffene Möglichkeiten unter medizinischen, gesellschaftlichen und ethischen Aspekten.",
+      "sourceSpan": "B9.3.11",
+      "parentBulletText": "erläutern die prinzipielle Verfahrensweise zur technischen Neukombination von Erbinformationen und bewerten durch sie geschaffene Möglichkeiten unter medizinischen, gesellschaftlichen und ethischen Aspekten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.11",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.3"
+      ],
+      "rawSourceText": "erläutern die prinzipielle Verfahrensweise zur technischen Neukombination von Erbinformationen und bewerten durch sie geschaffene Möglichkeiten unter medizinischen, gesellschaftlichen und ethischen Aspekten.",
+      "rawSourceSpan": "B9.3.11",
+      "rawParentBulletText": "erläutern die prinzipielle Verfahrensweise zur technischen Neukombination von Erbinformationen und bewerten durch sie geschaffene Möglichkeiten unter medizinischen, gesellschaftlichen und ethischen Aspekten.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "1ad96d9d-03d9-565f-94b2-94f6ed17c523",
+          "passageId": "by-bio:B9.3",
+          "topicCode": "B9.3",
+          "sourceSpan": "B9.3.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.11",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.3"
+      ],
+      "mergedSourceSpans": [
+        "B9.3.11"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.3.11"
+      ]
+    },
+    {
+      "id": "b17074cd-317a-512a-a4d8-6fbd5d037dd4",
+      "passageId": "by-bio:B9.4",
+      "topicCode": "B9.4",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "beschreiben die Stammesgeschichte der Lebewesen als fortlaufendes Evolutionsgeschehen, das mi...",
+      "description": "beschreiben die Stammesgeschichte der Lebewesen als fortlaufendes Evolutionsgeschehen, das mithilfe von naturwissenschaftlichen Befunden belegt werden kann.",
+      "sourceText": "beschreiben die Stammesgeschichte der Lebewesen als fortlaufendes Evolutionsgeschehen, das mithilfe von naturwissenschaftlichen Befunden belegt werden kann.",
+      "sourceSpan": "B9.4.1",
+      "parentBulletText": "beschreiben die Stammesgeschichte der Lebewesen als fortlaufendes Evolutionsgeschehen, das mithilfe von naturwissenschaftlichen Befunden belegt werden kann.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.4"
+      ],
+      "rawSourceText": "beschreiben die Stammesgeschichte der Lebewesen als fortlaufendes Evolutionsgeschehen, das mithilfe von naturwissenschaftlichen Befunden belegt werden kann.",
+      "rawSourceSpan": "B9.4.1",
+      "rawParentBulletText": "beschreiben die Stammesgeschichte der Lebewesen als fortlaufendes Evolutionsgeschehen, das mithilfe von naturwissenschaftlichen Befunden belegt werden kann.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b17074cd-317a-512a-a4d8-6fbd5d037dd4",
+          "passageId": "by-bio:B9.4",
+          "topicCode": "B9.4",
+          "sourceSpan": "B9.4.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.4"
+      ],
+      "mergedSourceSpans": [
+        "B9.4.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.1"
+      ]
+    },
+    {
+      "id": "efe8409f-0ba6-58e4-80ae-3967c4e9f4be",
+      "passageId": "by-bio:B9.4",
+      "topicCode": "B9.4",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "erklären die Entstehung einer heute lebenden Art als evolutionären Prozess, indem sie deren s...",
+      "description": "erklären die Entstehung einer heute lebenden Art als evolutionären Prozess, indem sie deren stammesgeschichtliche Entwicklung auf die Wirkung der Evolutionsfaktoren zurückführen.",
+      "sourceText": "erklären die Entstehung einer heute lebenden Art als evolutionären Prozess, indem sie deren stammesgeschichtliche Entwicklung auf die Wirkung der Evolutionsfaktoren zurückführen.",
+      "sourceSpan": "B9.4.2",
+      "parentBulletText": "erklären die Entstehung einer heute lebenden Art als evolutionären Prozess, indem sie deren stammesgeschichtliche Entwicklung auf die Wirkung der Evolutionsfaktoren zurückführen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.4"
+      ],
+      "rawSourceText": "erklären die Entstehung einer heute lebenden Art als evolutionären Prozess, indem sie deren stammesgeschichtliche Entwicklung auf die Wirkung der Evolutionsfaktoren zurückführen.",
+      "rawSourceSpan": "B9.4.2",
+      "rawParentBulletText": "erklären die Entstehung einer heute lebenden Art als evolutionären Prozess, indem sie deren stammesgeschichtliche Entwicklung auf die Wirkung der Evolutionsfaktoren zurückführen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "efe8409f-0ba6-58e4-80ae-3967c4e9f4be",
+          "passageId": "by-bio:B9.4",
+          "topicCode": "B9.4",
+          "sourceSpan": "B9.4.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.4"
+      ],
+      "mergedSourceSpans": [
+        "B9.4.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.2"
+      ]
+    },
+    {
+      "id": "dc172e4b-d8df-5b79-85ca-1116c2b64019",
+      "passageId": "by-bio:B9.4",
+      "topicCode": "B9.4",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "erklären Angepasstheiten an die jeweiligen biotischen und abiotischen Umweltfaktoren als Sele...",
+      "description": "erklären Angepasstheiten an die jeweiligen biotischen und abiotischen Umweltfaktoren als Selektionsvorteil.",
+      "sourceText": "erklären Angepasstheiten an die jeweiligen biotischen und abiotischen Umweltfaktoren als Selektionsvorteil.",
+      "sourceSpan": "B9.4.3",
+      "parentBulletText": "erklären Angepasstheiten an die jeweiligen biotischen und abiotischen Umweltfaktoren als Selektionsvorteil.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.4"
+      ],
+      "rawSourceText": "erklären Angepasstheiten an die jeweiligen biotischen und abiotischen Umweltfaktoren als Selektionsvorteil.",
+      "rawSourceSpan": "B9.4.3",
+      "rawParentBulletText": "erklären Angepasstheiten an die jeweiligen biotischen und abiotischen Umweltfaktoren als Selektionsvorteil.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "dc172e4b-d8df-5b79-85ca-1116c2b64019",
+          "passageId": "by-bio:B9.4",
+          "topicCode": "B9.4",
+          "sourceSpan": "B9.4.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.4"
+      ],
+      "mergedSourceSpans": [
+        "B9.4.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.3"
+      ]
+    },
+    {
+      "id": "2310bc26-c562-59d5-a45e-343d6b031c94",
+      "passageId": "by-bio:B9.4",
+      "topicCode": "B9.4",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "erklären die Bedeutung der geographischen Isolation für die Entstehung der biologischen Vielf...",
+      "description": "erklären die Bedeutung der geographischen Isolation für die Entstehung der biologischen Vielfalt.",
+      "sourceText": "erklären die Bedeutung der geographischen Isolation für die Entstehung der biologischen Vielfalt.",
+      "sourceSpan": "B9.4.4",
+      "parentBulletText": "erklären die Bedeutung der geographischen Isolation für die Entstehung der biologischen Vielfalt.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.4",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.4"
+      ],
+      "rawSourceText": "erklären die Bedeutung der geographischen Isolation für die Entstehung der biologischen Vielfalt.",
+      "rawSourceSpan": "B9.4.4",
+      "rawParentBulletText": "erklären die Bedeutung der geographischen Isolation für die Entstehung der biologischen Vielfalt.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "2310bc26-c562-59d5-a45e-343d6b031c94",
+          "passageId": "by-bio:B9.4",
+          "topicCode": "B9.4",
+          "sourceSpan": "B9.4.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.4",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.4"
+      ],
+      "mergedSourceSpans": [
+        "B9.4.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.4.4"
+      ]
+    },
+    {
+      "id": "b43f3efe-487c-5210-aad4-6e3eb1468e91",
+      "passageId": "by-bio:B9.5",
+      "topicCode": "B9.5",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "vergleichen das Skelett und den Bewegungsapparat von Insekten mit denen von Wirbeltieren und ...",
+      "description": "vergleichen das Skelett und den Bewegungsapparat von Insekten mit denen von Wirbeltieren und ggf. mit denen einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceText": "vergleichen das Skelett und den Bewegungsapparat von Insekten mit denen von Wirbeltieren und ggf. mit denen einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceSpan": "B9.5.1",
+      "parentBulletText": "vergleichen das Skelett und den Bewegungsapparat von Insekten mit denen von Wirbeltieren und ggf. mit denen einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.5"
+      ],
+      "rawSourceText": "vergleichen das Skelett und den Bewegungsapparat von Insekten mit denen von Wirbeltieren und ggf. mit denen einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "rawSourceSpan": "B9.5.1",
+      "rawParentBulletText": "vergleichen das Skelett und den Bewegungsapparat von Insekten mit denen von Wirbeltieren und ggf. mit denen einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b43f3efe-487c-5210-aad4-6e3eb1468e91",
+          "passageId": "by-bio:B9.5",
+          "topicCode": "B9.5",
+          "sourceSpan": "B9.5.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.5"
+      ],
+      "mergedSourceSpans": [
+        "B9.5.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.1"
+      ]
+    },
+    {
+      "id": "298c2060-c761-5029-9090-91b2292a679c",
+      "passageId": "by-bio:B9.5",
+      "topicCode": "B9.5",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "vergleichen die Angepasstheit der aktiven Bewegung bei Insekten an verschiedene Lebensräume.",
+      "description": "vergleichen die Angepasstheit der aktiven Bewegung bei Insekten an verschiedene Lebensräume.",
+      "sourceText": "vergleichen die Angepasstheit der aktiven Bewegung bei Insekten an verschiedene Lebensräume.",
+      "sourceSpan": "B9.5.2",
+      "parentBulletText": "vergleichen die Angepasstheit der aktiven Bewegung bei Insekten an verschiedene Lebensräume.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.5"
+      ],
+      "rawSourceText": "vergleichen die Angepasstheit der aktiven Bewegung bei Insekten an verschiedene Lebensräume.",
+      "rawSourceSpan": "B9.5.2",
+      "rawParentBulletText": "vergleichen die Angepasstheit der aktiven Bewegung bei Insekten an verschiedene Lebensräume.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "298c2060-c761-5029-9090-91b2292a679c",
+          "passageId": "by-bio:B9.5",
+          "topicCode": "B9.5",
+          "sourceSpan": "B9.5.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.5"
+      ],
+      "mergedSourceSpans": [
+        "B9.5.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.2"
+      ]
+    },
+    {
+      "id": "49770c26-6652-584b-80f5-625465cfa897",
+      "passageId": "by-bio:B9.5",
+      "topicCode": "B9.5",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "vergleichen Vertreter der Insekten mit Wirbeltieren und ggf. Vertretern einer weiteren Gruppe...",
+      "description": "vergleichen Vertreter der Insekten mit Wirbeltieren und ggf. Vertretern einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten zum Stofftransport und -austausch. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceText": "vergleichen Vertreter der Insekten mit Wirbeltieren und ggf. Vertretern einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten zum Stofftransport und -austausch. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceSpan": "B9.5.3",
+      "parentBulletText": "vergleichen Vertreter der Insekten mit Wirbeltieren und ggf. Vertretern einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten zum Stofftransport und -austausch. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.5"
+      ],
+      "rawSourceText": "vergleichen Vertreter der Insekten mit Wirbeltieren und ggf. Vertretern einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten zum Stofftransport und -austausch. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "rawSourceSpan": "B9.5.3",
+      "rawParentBulletText": "vergleichen Vertreter der Insekten mit Wirbeltieren und ggf. Vertretern einer weiteren Gruppe der Wirbellosen hinsichtlich ihrer Angepasstheiten zum Stofftransport und -austausch. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "49770c26-6652-584b-80f5-625465cfa897",
+          "passageId": "by-bio:B9.5",
+          "topicCode": "B9.5",
+          "sourceSpan": "B9.5.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.5"
+      ],
+      "mergedSourceSpans": [
+        "B9.5.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.3"
+      ]
+    },
+    {
+      "id": "bea8c52c-bdba-5ae1-97a7-87b9af9fe8f8",
+      "passageId": "by-bio:B9.5",
+      "topicCode": "B9.5",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "vergleichen die Angepasstheiten der Mundwerkzeuge bei Insekten an verschiedene Nahrungsquelle...",
+      "description": "vergleichen die Angepasstheiten der Mundwerkzeuge bei Insekten an verschiedene Nahrungsquellen und schätzen die Auswirkungen dieser Nutzung unterschiedlicher Nahrungsquellen auf den Menschen ab.",
+      "sourceText": "vergleichen die Angepasstheiten der Mundwerkzeuge bei Insekten an verschiedene Nahrungsquellen und schätzen die Auswirkungen dieser Nutzung unterschiedlicher Nahrungsquellen auf den Menschen ab.",
+      "sourceSpan": "B9.5.4",
+      "parentBulletText": "vergleichen die Angepasstheiten der Mundwerkzeuge bei Insekten an verschiedene Nahrungsquellen und schätzen die Auswirkungen dieser Nutzung unterschiedlicher Nahrungsquellen auf den Menschen ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.4",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.5"
+      ],
+      "rawSourceText": "vergleichen die Angepasstheiten der Mundwerkzeuge bei Insekten an verschiedene Nahrungsquellen und schätzen die Auswirkungen dieser Nutzung unterschiedlicher Nahrungsquellen auf den Menschen ab.",
+      "rawSourceSpan": "B9.5.4",
+      "rawParentBulletText": "vergleichen die Angepasstheiten der Mundwerkzeuge bei Insekten an verschiedene Nahrungsquellen und schätzen die Auswirkungen dieser Nutzung unterschiedlicher Nahrungsquellen auf den Menschen ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "bea8c52c-bdba-5ae1-97a7-87b9af9fe8f8",
+          "passageId": "by-bio:B9.5",
+          "topicCode": "B9.5",
+          "sourceSpan": "B9.5.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.4",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.5"
+      ],
+      "mergedSourceSpans": [
+        "B9.5.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.4"
+      ]
+    },
+    {
+      "id": "6fe6a4af-3d6a-5afa-85fe-ae2b2202e42e",
+      "passageId": "by-bio:B9.5",
+      "topicCode": "B9.5",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "vergleichen Vertreter der Insekten untereinander, mit Vertretern der Wirbeltiere und ggf. mit...",
+      "description": "vergleichen Vertreter der Insekten untereinander, mit Vertretern der Wirbeltiere und ggf. mit Vertretern weiterer Gruppen der Wirbellosen hinsichtlich ihrer Fortpflanzung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceText": "vergleichen Vertreter der Insekten untereinander, mit Vertretern der Wirbeltiere und ggf. mit Vertretern weiterer Gruppen der Wirbellosen hinsichtlich ihrer Fortpflanzung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceSpan": "B9.5.5",
+      "parentBulletText": "vergleichen Vertreter der Insekten untereinander, mit Vertretern der Wirbeltiere und ggf. mit Vertretern weiterer Gruppen der Wirbellosen hinsichtlich ihrer Fortpflanzung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.5",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.5"
+      ],
+      "rawSourceText": "vergleichen Vertreter der Insekten untereinander, mit Vertretern der Wirbeltiere und ggf. mit Vertretern weiterer Gruppen der Wirbellosen hinsichtlich ihrer Fortpflanzung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "rawSourceSpan": "B9.5.5",
+      "rawParentBulletText": "vergleichen Vertreter der Insekten untereinander, mit Vertretern der Wirbeltiere und ggf. mit Vertretern weiterer Gruppen der Wirbellosen hinsichtlich ihrer Fortpflanzung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "6fe6a4af-3d6a-5afa-85fe-ae2b2202e42e",
+          "passageId": "by-bio:B9.5",
+          "topicCode": "B9.5",
+          "sourceSpan": "B9.5.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.5",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.5"
+      ],
+      "mergedSourceSpans": [
+        "B9.5.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.5"
+      ]
+    },
+    {
+      "id": "7be0e13a-2a59-5463-b44d-a9233a48aad0",
+      "passageId": "by-bio:B9.5",
+      "topicCode": "B9.5",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "vergleichen Vertreter der Insekten untereinander und mit Vertretern der Wirbeltiere hinsichtl...",
+      "description": "vergleichen Vertreter der Insekten untereinander und mit Vertretern der Wirbeltiere hinsichtlich ihrer Individualentwicklung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceText": "vergleichen Vertreter der Insekten untereinander und mit Vertretern der Wirbeltiere hinsichtlich ihrer Individualentwicklung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceSpan": "B9.5.6",
+      "parentBulletText": "vergleichen Vertreter der Insekten untereinander und mit Vertretern der Wirbeltiere hinsichtlich ihrer Individualentwicklung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.6",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.5"
+      ],
+      "rawSourceText": "vergleichen Vertreter der Insekten untereinander und mit Vertretern der Wirbeltiere hinsichtlich ihrer Individualentwicklung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "rawSourceSpan": "B9.5.6",
+      "rawParentBulletText": "vergleichen Vertreter der Insekten untereinander und mit Vertretern der Wirbeltiere hinsichtlich ihrer Individualentwicklung. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "7be0e13a-2a59-5463-b44d-a9233a48aad0",
+          "passageId": "by-bio:B9.5",
+          "topicCode": "B9.5",
+          "sourceSpan": "B9.5.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.6",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.5"
+      ],
+      "mergedSourceSpans": [
+        "B9.5.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.6"
+      ]
+    },
+    {
+      "id": "3a0d3bc3-598d-54a2-8932-73a600c3e166",
+      "passageId": "by-bio:B9.5",
+      "topicCode": "B9.5",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "vergleichen das Nervensystem von Insekten mit dem von Wirbeltieren und ggf. dem Nervensystem ...",
+      "description": "vergleichen das Nervensystem von Insekten mit dem von Wirbeltieren und ggf. dem Nervensystem von Vertretern einer weiteren Gruppe der Wirbellosen. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceText": "vergleichen das Nervensystem von Insekten mit dem von Wirbeltieren und ggf. dem Nervensystem von Vertretern einer weiteren Gruppe der Wirbellosen. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceSpan": "B9.5.7",
+      "parentBulletText": "vergleichen das Nervensystem von Insekten mit dem von Wirbeltieren und ggf. dem Nervensystem von Vertretern einer weiteren Gruppe der Wirbellosen. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.7",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.5"
+      ],
+      "rawSourceText": "vergleichen das Nervensystem von Insekten mit dem von Wirbeltieren und ggf. dem Nervensystem von Vertretern einer weiteren Gruppe der Wirbellosen. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "rawSourceSpan": "B9.5.7",
+      "rawParentBulletText": "vergleichen das Nervensystem von Insekten mit dem von Wirbeltieren und ggf. dem Nervensystem von Vertretern einer weiteren Gruppe der Wirbellosen. Dabei identifizieren sie typische Merkmale der jeweiligen Gruppen und beschreiben die beobachtete Vielfalt unter dem Blickwinkel einer evolutionären Angepasstheit.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "3a0d3bc3-598d-54a2-8932-73a600c3e166",
+          "passageId": "by-bio:B9.5",
+          "topicCode": "B9.5",
+          "sourceSpan": "B9.5.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.7",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.5"
+      ],
+      "mergedSourceSpans": [
+        "B9.5.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.7"
+      ]
+    },
+    {
+      "id": "7a28147c-b531-563c-845d-b397997c6639",
+      "passageId": "by-bio:B9.5",
+      "topicCode": "B9.5",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "vergleichen Vertreter der Insekten mit Wirbeltieren hinsichtlich ihrer Sinnesorgane und Sinne...",
+      "description": "vergleichen Vertreter der Insekten mit Wirbeltieren hinsichtlich ihrer Sinnesorgane und Sinnesleistungen.",
+      "sourceText": "vergleichen Vertreter der Insekten mit Wirbeltieren hinsichtlich ihrer Sinnesorgane und Sinnesleistungen.",
+      "sourceSpan": "B9.5.8",
+      "parentBulletText": "vergleichen Vertreter der Insekten mit Wirbeltieren hinsichtlich ihrer Sinnesorgane und Sinnesleistungen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.8",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.5"
+      ],
+      "rawSourceText": "vergleichen Vertreter der Insekten mit Wirbeltieren hinsichtlich ihrer Sinnesorgane und Sinnesleistungen.",
+      "rawSourceSpan": "B9.5.8",
+      "rawParentBulletText": "vergleichen Vertreter der Insekten mit Wirbeltieren hinsichtlich ihrer Sinnesorgane und Sinnesleistungen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "7a28147c-b531-563c-845d-b397997c6639",
+          "passageId": "by-bio:B9.5",
+          "topicCode": "B9.5",
+          "sourceSpan": "B9.5.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.8",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.5"
+      ],
+      "mergedSourceSpans": [
+        "B9.5.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.8"
+      ]
+    },
+    {
+      "id": "0ddc9d8b-c3d5-5df9-bbd3-96b26de53470",
+      "passageId": "by-bio:B9.5",
+      "topicCode": "B9.5",
+      "bulletIndex": 9,
+      "aspectIndex": 1,
+      "title": "erklären die Bedeutung verschiedener Signale zur inner- und zwischenartlichen Kommunikation b...",
+      "description": "erklären die Bedeutung verschiedener Signale zur inner- und zwischenartlichen Kommunikation bei Insekten.",
+      "sourceText": "erklären die Bedeutung verschiedener Signale zur inner- und zwischenartlichen Kommunikation bei Insekten.",
+      "sourceSpan": "B9.5.9",
+      "parentBulletText": "erklären die Bedeutung verschiedener Signale zur inner- und zwischenartlichen Kommunikation bei Insekten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.9",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.5"
+      ],
+      "rawSourceText": "erklären die Bedeutung verschiedener Signale zur inner- und zwischenartlichen Kommunikation bei Insekten.",
+      "rawSourceSpan": "B9.5.9",
+      "rawParentBulletText": "erklären die Bedeutung verschiedener Signale zur inner- und zwischenartlichen Kommunikation bei Insekten.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "0ddc9d8b-c3d5-5df9-bbd3-96b26de53470",
+          "passageId": "by-bio:B9.5",
+          "topicCode": "B9.5",
+          "sourceSpan": "B9.5.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.9",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.5"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.5"
+      ],
+      "mergedSourceSpans": [
+        "B9.5.9"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.5.9"
+      ]
+    },
+    {
+      "id": "e1b4d7fa-ea04-544f-a04f-630865810b71",
+      "passageId": "by-bio:B9.6",
+      "topicCode": "B9.6",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "untersuchen Boden, protokollieren die Ergebnisse ggf. mithilfe digitaler Medien und erkunden ...",
+      "description": "untersuchen Boden, protokollieren die Ergebnisse ggf. mithilfe digitaler Medien und erkunden so das Biotop und die Biozönose des Bodens.",
+      "sourceText": "untersuchen Boden, protokollieren die Ergebnisse ggf. mithilfe digitaler Medien und erkunden so das Biotop und die Biozönose des Bodens.",
+      "sourceSpan": "B9.6.1",
+      "parentBulletText": "untersuchen Boden, protokollieren die Ergebnisse ggf. mithilfe digitaler Medien und erkunden so das Biotop und die Biozönose des Bodens.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.6"
+      ],
+      "rawSourceText": "untersuchen Boden, protokollieren die Ergebnisse ggf. mithilfe digitaler Medien und erkunden so das Biotop und die Biozönose des Bodens.",
+      "rawSourceSpan": "B9.6.1",
+      "rawParentBulletText": "untersuchen Boden, protokollieren die Ergebnisse ggf. mithilfe digitaler Medien und erkunden so das Biotop und die Biozönose des Bodens.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "e1b4d7fa-ea04-544f-a04f-630865810b71",
+          "passageId": "by-bio:B9.6",
+          "topicCode": "B9.6",
+          "sourceSpan": "B9.6.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.6"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.6"
+      ],
+      "mergedSourceSpans": [
+        "B9.6.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.1"
+      ]
+    },
+    {
+      "id": "1107a269-d9dd-5cac-9ab5-fe7086d7a3e3",
+      "passageId": "by-bio:B9.6",
+      "topicCode": "B9.6",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "stellen den Stoff- und Energiefluss innerhalb der Biozönose des Bodens dar und beschreiben di...",
+      "description": "stellen den Stoff- und Energiefluss innerhalb der Biozönose des Bodens dar und beschreiben die Humusbildung und Mineralisierung als zeitliche Veränderung.",
+      "sourceText": "stellen den Stoff- und Energiefluss innerhalb der Biozönose des Bodens dar und beschreiben die Humusbildung und Mineralisierung als zeitliche Veränderung.",
+      "sourceSpan": "B9.6.2",
+      "parentBulletText": "stellen den Stoff- und Energiefluss innerhalb der Biozönose des Bodens dar und beschreiben die Humusbildung und Mineralisierung als zeitliche Veränderung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.6"
+      ],
+      "rawSourceText": "stellen den Stoff- und Energiefluss innerhalb der Biozönose des Bodens dar und beschreiben die Humusbildung und Mineralisierung als zeitliche Veränderung.",
+      "rawSourceSpan": "B9.6.2",
+      "rawParentBulletText": "stellen den Stoff- und Energiefluss innerhalb der Biozönose des Bodens dar und beschreiben die Humusbildung und Mineralisierung als zeitliche Veränderung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "1107a269-d9dd-5cac-9ab5-fe7086d7a3e3",
+          "passageId": "by-bio:B9.6",
+          "topicCode": "B9.6",
+          "sourceSpan": "B9.6.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.6"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.6"
+      ],
+      "mergedSourceSpans": [
+        "B9.6.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.2"
+      ]
+    },
+    {
+      "id": "6a34dc00-ba46-565f-93c4-5748f5bd2fc9",
+      "passageId": "by-bio:B9.6",
+      "topicCode": "B9.6",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "stellen einen einfachen Kohlenstoffatomkreislauf als Wechselwirkungen zwischen Organismen und...",
+      "description": "stellen einen einfachen Kohlenstoffatomkreislauf als Wechselwirkungen zwischen Organismen und zwischen Organismen und unbelebter Materie dar.",
+      "sourceText": "stellen einen einfachen Kohlenstoffatomkreislauf als Wechselwirkungen zwischen Organismen und zwischen Organismen und unbelebter Materie dar.",
+      "sourceSpan": "B9.6.3",
+      "parentBulletText": "stellen einen einfachen Kohlenstoffatomkreislauf als Wechselwirkungen zwischen Organismen und zwischen Organismen und unbelebter Materie dar.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.6"
+      ],
+      "rawSourceText": "stellen einen einfachen Kohlenstoffatomkreislauf als Wechselwirkungen zwischen Organismen und zwischen Organismen und unbelebter Materie dar.",
+      "rawSourceSpan": "B9.6.3",
+      "rawParentBulletText": "stellen einen einfachen Kohlenstoffatomkreislauf als Wechselwirkungen zwischen Organismen und zwischen Organismen und unbelebter Materie dar.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "6a34dc00-ba46-565f-93c4-5748f5bd2fc9",
+          "passageId": "by-bio:B9.6",
+          "topicCode": "B9.6",
+          "sourceSpan": "B9.6.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.6"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.6"
+      ],
+      "mergedSourceSpans": [
+        "B9.6.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.3"
+      ]
+    },
+    {
+      "id": "0afc5a61-e1cf-5b36-8d3c-aa41e19a0de5",
+      "passageId": "by-bio:B9.6",
+      "topicCode": "B9.6",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "beurteilen die Bedeutung des Bodens für eine nachhaltige Produktion von Lebensmitteln, charak...",
+      "description": "beurteilen die Bedeutung des Bodens für eine nachhaltige Produktion von Lebensmitteln, charakterisieren Gefahren für dieses Ökosystem durch die komplexe Verkettung menschlicher Einflüsse und sind sich dabei der Folgen für die Menschen bewusst.",
+      "sourceText": "beurteilen die Bedeutung des Bodens für eine nachhaltige Produktion von Lebensmitteln, charakterisieren Gefahren für dieses Ökosystem durch die komplexe Verkettung menschlicher Einflüsse und sind sich dabei der Folgen für die Menschen bewusst.",
+      "sourceSpan": "B9.6.4",
+      "parentBulletText": "beurteilen die Bedeutung des Bodens für eine nachhaltige Produktion von Lebensmitteln, charakterisieren Gefahren für dieses Ökosystem durch die komplexe Verkettung menschlicher Einflüsse und sind sich dabei der Folgen für die Menschen bewusst.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.4",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B9.6"
+      ],
+      "rawSourceText": "beurteilen die Bedeutung des Bodens für eine nachhaltige Produktion von Lebensmitteln, charakterisieren Gefahren für dieses Ökosystem durch die komplexe Verkettung menschlicher Einflüsse und sind sich dabei der Folgen für die Menschen bewusst.",
+      "rawSourceSpan": "B9.6.4",
+      "rawParentBulletText": "beurteilen die Bedeutung des Bodens für eine nachhaltige Produktion von Lebensmitteln, charakterisieren Gefahren für dieses Ökosystem durch die komplexe Verkettung menschlicher Einflüsse und sind sich dabei der Folgen für die Menschen bewusst.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "0afc5a61-e1cf-5b36-8d3c-aa41e19a0de5",
+          "passageId": "by-bio:B9.6",
+          "topicCode": "B9.6",
+          "sourceSpan": "B9.6.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.4",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B9.6"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B9.6"
+      ],
+      "mergedSourceSpans": [
+        "B9.6.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B9.6.4"
+      ]
+    },
+    {
+      "id": "08e4882b-46a2-5e58-b1bd-b9e95995dd87",
+      "passageId": "by-bio:B10.1",
+      "topicCode": "B10.1",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "leiten aus komplex strukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab...",
+      "description": "leiten aus komplex strukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren qualitativer und quantitativer Beantwortung.",
+      "sourceText": "leiten aus komplex strukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren qualitativer und quantitativer Beantwortung.",
+      "sourceSpan": "B10.1.1",
+      "parentBulletText": "leiten aus komplex strukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren qualitativer und quantitativer Beantwortung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.1"
+      ],
+      "rawSourceText": "leiten aus komplex strukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren qualitativer und quantitativer Beantwortung.",
+      "rawSourceSpan": "B10.1.1",
+      "rawParentBulletText": "leiten aus komplex strukturierten Alltags- und Naturphänomenen biologische Fragestellungen ab und planen hypothesengeleitet z. B. Beobachtungen und Experimente zu deren qualitativer und quantitativer Beantwortung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "08e4882b-46a2-5e58-b1bd-b9e95995dd87",
+          "passageId": "by-bio:B10.1",
+          "topicCode": "B10.1",
+          "sourceSpan": "B10.1.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.1"
+      ],
+      "mergedSourceSpans": [
+        "B10.1.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.1"
+      ]
+    },
+    {
+      "id": "cd4d29ab-121e-5b5e-8db2-1cce371cd93c",
+      "passageId": "by-bio:B10.1",
+      "topicCode": "B10.1",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "führen u. a. selbstgeplante naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die...",
+      "description": "führen u. a. selbstgeplante naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten (auch mit digitalen Hilfsmitteln) selbständig vor.",
+      "sourceText": "führen u. a. selbstgeplante naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten (auch mit digitalen Hilfsmitteln) selbständig vor.",
+      "sourceSpan": "B10.1.2",
+      "parentBulletText": "führen u. a. selbstgeplante naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten (auch mit digitalen Hilfsmitteln) selbständig vor.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.1"
+      ],
+      "rawSourceText": "führen u. a. selbstgeplante naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten (auch mit digitalen Hilfsmitteln) selbständig vor.",
+      "rawSourceSpan": "B10.1.2",
+      "rawParentBulletText": "führen u. a. selbstgeplante naturwissenschaftliche Untersuchungen durch. Dabei nehmen sie die Dokumentation, Auswertung und Veranschaulichung der erhobenen Daten (auch mit digitalen Hilfsmitteln) selbständig vor.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "cd4d29ab-121e-5b5e-8db2-1cce371cd93c",
+          "passageId": "by-bio:B10.1",
+          "topicCode": "B10.1",
+          "sourceSpan": "B10.1.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.1"
+      ],
+      "mergedSourceSpans": [
+        "B10.1.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.2"
+      ]
+    },
+    {
+      "id": "c7a6f8a0-04af-59c5-bc49-b9b428a816aa",
+      "passageId": "by-bio:B10.1",
+      "topicCode": "B10.1",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "beurteilen die Gültigkeit von erhobenen oder recherchierten Daten und finden in diesen Daten ...",
+      "description": "beurteilen die Gültigkeit von erhobenen oder recherchierten Daten und finden in diesen Daten Trends, Strukturen und Beziehungen.",
+      "sourceText": "beurteilen die Gültigkeit von erhobenen oder recherchierten Daten und finden in diesen Daten Trends, Strukturen und Beziehungen.",
+      "sourceSpan": "B10.1.3",
+      "parentBulletText": "beurteilen die Gültigkeit von erhobenen oder recherchierten Daten und finden in diesen Daten Trends, Strukturen und Beziehungen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.1"
+      ],
+      "rawSourceText": "beurteilen die Gültigkeit von erhobenen oder recherchierten Daten und finden in diesen Daten Trends, Strukturen und Beziehungen.",
+      "rawSourceSpan": "B10.1.3",
+      "rawParentBulletText": "beurteilen die Gültigkeit von erhobenen oder recherchierten Daten und finden in diesen Daten Trends, Strukturen und Beziehungen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "c7a6f8a0-04af-59c5-bc49-b9b428a816aa",
+          "passageId": "by-bio:B10.1",
+          "topicCode": "B10.1",
+          "sourceSpan": "B10.1.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.1"
+      ],
+      "mergedSourceSpans": [
+        "B10.1.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.3"
+      ]
+    },
+    {
+      "id": "c8154bd2-306a-5875-8609-cf35ec63a901",
+      "passageId": "by-bio:B10.1",
+      "topicCode": "B10.1",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "beschreiben Grenzen des im Rahmen eines naturwissenschaftlichen Erkenntniswegs generierten Wi...",
+      "description": "beschreiben Grenzen des im Rahmen eines naturwissenschaftlichen Erkenntniswegs generierten Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab.",
+      "sourceText": "beschreiben Grenzen des im Rahmen eines naturwissenschaftlichen Erkenntniswegs generierten Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab.",
+      "sourceSpan": "B10.1.4",
+      "parentBulletText": "beschreiben Grenzen des im Rahmen eines naturwissenschaftlichen Erkenntniswegs generierten Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.4",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.1"
+      ],
+      "rawSourceText": "beschreiben Grenzen des im Rahmen eines naturwissenschaftlichen Erkenntniswegs generierten Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab.",
+      "rawSourceSpan": "B10.1.4",
+      "rawParentBulletText": "beschreiben Grenzen des im Rahmen eines naturwissenschaftlichen Erkenntniswegs generierten Wissens und leiten daraus Aussagen zur Gültigkeit dieses Wissens ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "c8154bd2-306a-5875-8609-cf35ec63a901",
+          "passageId": "by-bio:B10.1",
+          "topicCode": "B10.1",
+          "sourceSpan": "B10.1.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.4",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.1"
+      ],
+      "mergedSourceSpans": [
+        "B10.1.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.4"
+      ]
+    },
+    {
+      "id": "d0cf0ae9-8943-5c29-9708-b394592d214c",
+      "passageId": "by-bio:B10.1",
+      "topicCode": "B10.1",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Enzymatik) mithilfe von Modellen...",
+      "description": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Enzymatik) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken und Schwächen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten und weiterzuentwickeln.",
+      "sourceText": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Enzymatik) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken und Schwächen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten und weiterzuentwickeln.",
+      "sourceSpan": "B10.1.5",
+      "parentBulletText": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Enzymatik) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken und Schwächen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten und weiterzuentwickeln.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.5",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.1"
+      ],
+      "rawSourceText": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Enzymatik) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken und Schwächen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten und weiterzuentwickeln.",
+      "rawSourceSpan": "B10.1.5",
+      "rawParentBulletText": "beschreiben Wechselwirkungen und Stoffwechselprozesse (z. B. Enzymatik) mithilfe von Modellen. Sie entwickeln zu einem Sachverhalt alternative Modelle. Dabei erkennen sie Stärken und Schwächen einzelner Modelle und leiten daraus die Notwendigkeit ab, Modelle kritisch zu betrachten und weiterzuentwickeln.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "d0cf0ae9-8943-5c29-9708-b394592d214c",
+          "passageId": "by-bio:B10.1",
+          "topicCode": "B10.1",
+          "sourceSpan": "B10.1.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.5",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.1"
+      ],
+      "mergedSourceSpans": [
+        "B10.1.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.5"
+      ]
+    },
+    {
+      "id": "42123cb1-f0a6-5787-b95e-43a86388d3d2",
+      "passageId": "by-bio:B10.1",
+      "topicCode": "B10.1",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "unterscheiden zwischen alltags- und fachsprachlichen Texten. Sie wählen mediale Informationsq...",
+      "description": "unterscheiden zwischen alltags- und fachsprachlichen Texten. Sie wählen mediale Informationsquellen begründet aus und entnehmen gezielt Inhalte zur adressaten- und situationsgerechten Beantwortung biologischer Fragestellungen.",
+      "sourceText": "unterscheiden zwischen alltags- und fachsprachlichen Texten. Sie wählen mediale Informationsquellen begründet aus und entnehmen gezielt Inhalte zur adressaten- und situationsgerechten Beantwortung biologischer Fragestellungen.",
+      "sourceSpan": "B10.1.6",
+      "parentBulletText": "unterscheiden zwischen alltags- und fachsprachlichen Texten. Sie wählen mediale Informationsquellen begründet aus und entnehmen gezielt Inhalte zur adressaten- und situationsgerechten Beantwortung biologischer Fragestellungen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.6",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.1"
+      ],
+      "rawSourceText": "unterscheiden zwischen alltags- und fachsprachlichen Texten. Sie wählen mediale Informationsquellen begründet aus und entnehmen gezielt Inhalte zur adressaten- und situationsgerechten Beantwortung biologischer Fragestellungen.",
+      "rawSourceSpan": "B10.1.6",
+      "rawParentBulletText": "unterscheiden zwischen alltags- und fachsprachlichen Texten. Sie wählen mediale Informationsquellen begründet aus und entnehmen gezielt Inhalte zur adressaten- und situationsgerechten Beantwortung biologischer Fragestellungen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "42123cb1-f0a6-5787-b95e-43a86388d3d2",
+          "passageId": "by-bio:B10.1",
+          "topicCode": "B10.1",
+          "sourceSpan": "B10.1.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.6",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.1"
+      ],
+      "mergedSourceSpans": [
+        "B10.1.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.6"
+      ]
+    },
+    {
+      "id": "f2c82a1a-6e62-5150-ad3f-ae42bc79f42b",
+      "passageId": "by-bio:B10.1",
+      "topicCode": "B10.1",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "formulieren unter Nutzung fachwissenschaftlicher Erkenntnisse der Biologie systematisch und b...",
+      "description": "formulieren unter Nutzung fachwissenschaftlicher Erkenntnisse der Biologie systematisch und begründet Handlungsoptionen, wenden dabei Entscheidungsstrategien an und reflektieren über getroffene Entscheidungen.",
+      "sourceText": "formulieren unter Nutzung fachwissenschaftlicher Erkenntnisse der Biologie systematisch und begründet Handlungsoptionen, wenden dabei Entscheidungsstrategien an und reflektieren über getroffene Entscheidungen.",
+      "sourceSpan": "B10.1.7",
+      "parentBulletText": "formulieren unter Nutzung fachwissenschaftlicher Erkenntnisse der Biologie systematisch und begründet Handlungsoptionen, wenden dabei Entscheidungsstrategien an und reflektieren über getroffene Entscheidungen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.7",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.1"
+      ],
+      "rawSourceText": "formulieren unter Nutzung fachwissenschaftlicher Erkenntnisse der Biologie systematisch und begründet Handlungsoptionen, wenden dabei Entscheidungsstrategien an und reflektieren über getroffene Entscheidungen.",
+      "rawSourceSpan": "B10.1.7",
+      "rawParentBulletText": "formulieren unter Nutzung fachwissenschaftlicher Erkenntnisse der Biologie systematisch und begründet Handlungsoptionen, wenden dabei Entscheidungsstrategien an und reflektieren über getroffene Entscheidungen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f2c82a1a-6e62-5150-ad3f-ae42bc79f42b",
+          "passageId": "by-bio:B10.1",
+          "topicCode": "B10.1",
+          "sourceSpan": "B10.1.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.7",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.1"
+      ],
+      "mergedSourceSpans": [
+        "B10.1.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.7"
+      ]
+    },
+    {
+      "id": "94d9d6c7-bbda-5ddc-b755-5c0c2baa8ec3",
+      "passageId": "by-bio:B10.1",
+      "topicCode": "B10.1",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "beurteilen die Folgen von Maßnahmen und Verhaltensweisen für die eigene Gesundheit und die Ge...",
+      "description": "beurteilen die Folgen von Maßnahmen und Verhaltensweisen für die eigene Gesundheit und die Gesundheit anderer, um auch unter Einbezug gesellschaftlicher Perspektiven bewusste wertorientierte Entscheidungen für die Gesunderhaltung treffen zu können (z. B. Impfungen).",
+      "sourceText": "beurteilen die Folgen von Maßnahmen und Verhaltensweisen für die eigene Gesundheit und die Gesundheit anderer, um auch unter Einbezug gesellschaftlicher Perspektiven bewusste wertorientierte Entscheidungen für die Gesunderhaltung treffen zu können (z. B. Impfungen).",
+      "sourceSpan": "B10.1.8",
+      "parentBulletText": "beurteilen die Folgen von Maßnahmen und Verhaltensweisen für die eigene Gesundheit und die Gesundheit anderer, um auch unter Einbezug gesellschaftlicher Perspektiven bewusste wertorientierte Entscheidungen für die Gesunderhaltung treffen zu können (z. B. Impfungen).",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.8",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.1"
+      ],
+      "rawSourceText": "beurteilen die Folgen von Maßnahmen und Verhaltensweisen für die eigene Gesundheit und die Gesundheit anderer, um auch unter Einbezug gesellschaftlicher Perspektiven bewusste wertorientierte Entscheidungen für die Gesunderhaltung treffen zu können (z. B. Impfungen).",
+      "rawSourceSpan": "B10.1.8",
+      "rawParentBulletText": "beurteilen die Folgen von Maßnahmen und Verhaltensweisen für die eigene Gesundheit und die Gesundheit anderer, um auch unter Einbezug gesellschaftlicher Perspektiven bewusste wertorientierte Entscheidungen für die Gesunderhaltung treffen zu können (z. B. Impfungen).",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "94d9d6c7-bbda-5ddc-b755-5c0c2baa8ec3",
+          "passageId": "by-bio:B10.1",
+          "topicCode": "B10.1",
+          "sourceSpan": "B10.1.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.8",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.1"
+      ],
+      "mergedSourceSpans": [
+        "B10.1.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.1.8"
+      ]
+    },
+    {
+      "id": "31582972-78fe-53b8-82e2-6c239087140a",
+      "passageId": "by-bio:B10.2",
+      "topicCode": "B10.2",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "beschreiben Wechselbeziehungen zwischen dem Menschen und anderen Lebewesen, die auf und im me...",
+      "description": "beschreiben Wechselbeziehungen zwischen dem Menschen und anderen Lebewesen, die auf und im menschlichen Körper leben, um Maßnahmen und Verhaltensweisen für eine gesundheitsbewusste Lebensführung abzuleiten.",
+      "sourceText": "beschreiben Wechselbeziehungen zwischen dem Menschen und anderen Lebewesen, die auf und im menschlichen Körper leben, um Maßnahmen und Verhaltensweisen für eine gesundheitsbewusste Lebensführung abzuleiten.",
+      "sourceSpan": "B10.2.1",
+      "parentBulletText": "beschreiben Wechselbeziehungen zwischen dem Menschen und anderen Lebewesen, die auf und im menschlichen Körper leben, um Maßnahmen und Verhaltensweisen für eine gesundheitsbewusste Lebensführung abzuleiten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.2"
+      ],
+      "rawSourceText": "beschreiben Wechselbeziehungen zwischen dem Menschen und anderen Lebewesen, die auf und im menschlichen Körper leben, um Maßnahmen und Verhaltensweisen für eine gesundheitsbewusste Lebensführung abzuleiten.",
+      "rawSourceSpan": "B10.2.1",
+      "rawParentBulletText": "beschreiben Wechselbeziehungen zwischen dem Menschen und anderen Lebewesen, die auf und im menschlichen Körper leben, um Maßnahmen und Verhaltensweisen für eine gesundheitsbewusste Lebensführung abzuleiten.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "31582972-78fe-53b8-82e2-6c239087140a",
+          "passageId": "by-bio:B10.2",
+          "topicCode": "B10.2",
+          "sourceSpan": "B10.2.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.2"
+      ],
+      "mergedSourceSpans": [
+        "B10.2.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.1"
+      ]
+    },
+    {
+      "id": "04fcb49f-b677-56c9-bcdd-7808efa9c7c8",
+      "passageId": "by-bio:B10.2",
+      "topicCode": "B10.2",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "unterscheiden bakterielle und virale Infektionen, beschreiben an ausgewählten Beispielen dere...",
+      "description": "unterscheiden bakterielle und virale Infektionen, beschreiben an ausgewählten Beispielen deren Verlauf und beurteilen Möglichkeiten und Grenzen des Infektionsschutzes und der Therapie.",
+      "sourceText": "unterscheiden bakterielle und virale Infektionen, beschreiben an ausgewählten Beispielen deren Verlauf und beurteilen Möglichkeiten und Grenzen des Infektionsschutzes und der Therapie.",
+      "sourceSpan": "B10.2.2",
+      "parentBulletText": "unterscheiden bakterielle und virale Infektionen, beschreiben an ausgewählten Beispielen deren Verlauf und beurteilen Möglichkeiten und Grenzen des Infektionsschutzes und der Therapie.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.2"
+      ],
+      "rawSourceText": "unterscheiden bakterielle und virale Infektionen, beschreiben an ausgewählten Beispielen deren Verlauf und beurteilen Möglichkeiten und Grenzen des Infektionsschutzes und der Therapie.",
+      "rawSourceSpan": "B10.2.2",
+      "rawParentBulletText": "unterscheiden bakterielle und virale Infektionen, beschreiben an ausgewählten Beispielen deren Verlauf und beurteilen Möglichkeiten und Grenzen des Infektionsschutzes und der Therapie.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "04fcb49f-b677-56c9-bcdd-7808efa9c7c8",
+          "passageId": "by-bio:B10.2",
+          "topicCode": "B10.2",
+          "sourceSpan": "B10.2.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.2"
+      ],
+      "mergedSourceSpans": [
+        "B10.2.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.2"
+      ]
+    },
+    {
+      "id": "9ffecbe5-ed7b-5a1b-9a59-5e6b5a23a165",
+      "passageId": "by-bio:B10.2",
+      "topicCode": "B10.2",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "erläutern körpereigene unspezifische sowie spezifische Abwehrmechanismen zum Schutz vor Paras...",
+      "description": "erläutern körpereigene unspezifische sowie spezifische Abwehrmechanismen zum Schutz vor Parasiten und Krankheitserregern und beschreiben Allergien als Fehlreaktionen des Immunsystems.",
+      "sourceText": "erläutern körpereigene unspezifische sowie spezifische Abwehrmechanismen zum Schutz vor Parasiten und Krankheitserregern und beschreiben Allergien als Fehlreaktionen des Immunsystems.",
+      "sourceSpan": "B10.2.3",
+      "parentBulletText": "erläutern körpereigene unspezifische sowie spezifische Abwehrmechanismen zum Schutz vor Parasiten und Krankheitserregern und beschreiben Allergien als Fehlreaktionen des Immunsystems.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.2"
+      ],
+      "rawSourceText": "erläutern körpereigene unspezifische sowie spezifische Abwehrmechanismen zum Schutz vor Parasiten und Krankheitserregern und beschreiben Allergien als Fehlreaktionen des Immunsystems.",
+      "rawSourceSpan": "B10.2.3",
+      "rawParentBulletText": "erläutern körpereigene unspezifische sowie spezifische Abwehrmechanismen zum Schutz vor Parasiten und Krankheitserregern und beschreiben Allergien als Fehlreaktionen des Immunsystems.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "9ffecbe5-ed7b-5a1b-9a59-5e6b5a23a165",
+          "passageId": "by-bio:B10.2",
+          "topicCode": "B10.2",
+          "sourceSpan": "B10.2.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.2"
+      ],
+      "mergedSourceSpans": [
+        "B10.2.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.3"
+      ]
+    },
+    {
+      "id": "57c704e7-0ed0-50f5-8e9f-2043bfe0ccc3",
+      "passageId": "by-bio:B10.2",
+      "topicCode": "B10.2",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "erläutern das Prinzip der aktiven und passiven Immunisierung sowie die Notwendigkeit von vorb...",
+      "description": "erläutern das Prinzip der aktiven und passiven Immunisierung sowie die Notwendigkeit von vorbeugenden Schutzimpfungen, um in entsprechenden Lebenssituationen sachgerecht handeln zu können.",
+      "sourceText": "erläutern das Prinzip der aktiven und passiven Immunisierung sowie die Notwendigkeit von vorbeugenden Schutzimpfungen, um in entsprechenden Lebenssituationen sachgerecht handeln zu können.",
+      "sourceSpan": "B10.2.4",
+      "parentBulletText": "erläutern das Prinzip der aktiven und passiven Immunisierung sowie die Notwendigkeit von vorbeugenden Schutzimpfungen, um in entsprechenden Lebenssituationen sachgerecht handeln zu können.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.4",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.2"
+      ],
+      "rawSourceText": "erläutern das Prinzip der aktiven und passiven Immunisierung sowie die Notwendigkeit von vorbeugenden Schutzimpfungen, um in entsprechenden Lebenssituationen sachgerecht handeln zu können.",
+      "rawSourceSpan": "B10.2.4",
+      "rawParentBulletText": "erläutern das Prinzip der aktiven und passiven Immunisierung sowie die Notwendigkeit von vorbeugenden Schutzimpfungen, um in entsprechenden Lebenssituationen sachgerecht handeln zu können.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "57c704e7-0ed0-50f5-8e9f-2043bfe0ccc3",
+          "passageId": "by-bio:B10.2",
+          "topicCode": "B10.2",
+          "sourceSpan": "B10.2.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.4",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.2"
+      ],
+      "mergedSourceSpans": [
+        "B10.2.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.4"
+      ]
+    },
+    {
+      "id": "eddfa569-9406-57be-ada7-d9b737c0675e",
+      "passageId": "by-bio:B10.2",
+      "topicCode": "B10.2",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "beurteilen am Beispiel des Einsatzes von Antibiotika die Auswirkungen eines Eingriffes in die...",
+      "description": "beurteilen am Beispiel des Einsatzes von Antibiotika die Auswirkungen eines Eingriffes in die Biozönose des Ökosystems Mensch und erläutern die Risiken einer nichtsachgemäßen Verwendung.",
+      "sourceText": "beurteilen am Beispiel des Einsatzes von Antibiotika die Auswirkungen eines Eingriffes in die Biozönose des Ökosystems Mensch und erläutern die Risiken einer nichtsachgemäßen Verwendung.",
+      "sourceSpan": "B10.2.5",
+      "parentBulletText": "beurteilen am Beispiel des Einsatzes von Antibiotika die Auswirkungen eines Eingriffes in die Biozönose des Ökosystems Mensch und erläutern die Risiken einer nichtsachgemäßen Verwendung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.5",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.2"
+      ],
+      "rawSourceText": "beurteilen am Beispiel des Einsatzes von Antibiotika die Auswirkungen eines Eingriffes in die Biozönose des Ökosystems Mensch und erläutern die Risiken einer nichtsachgemäßen Verwendung.",
+      "rawSourceSpan": "B10.2.5",
+      "rawParentBulletText": "beurteilen am Beispiel des Einsatzes von Antibiotika die Auswirkungen eines Eingriffes in die Biozönose des Ökosystems Mensch und erläutern die Risiken einer nichtsachgemäßen Verwendung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "eddfa569-9406-57be-ada7-d9b737c0675e",
+          "passageId": "by-bio:B10.2",
+          "topicCode": "B10.2",
+          "sourceSpan": "B10.2.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.5",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.2"
+      ],
+      "mergedSourceSpans": [
+        "B10.2.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.2.5"
+      ]
+    },
+    {
+      "id": "d8d1e189-9d47-5e5c-9f9f-450a357c8ffb",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "beschreiben den Menschen als offenes System, der für die Aufrechterhaltung seines Stoffwechse...",
+      "description": "beschreiben den Menschen als offenes System, der für die Aufrechterhaltung seines Stoffwechsels und damit für sein Überleben Energieträger und Baustoffe zu sich nehmen muss.",
+      "sourceText": "beschreiben den Menschen als offenes System, der für die Aufrechterhaltung seines Stoffwechsels und damit für sein Überleben Energieträger und Baustoffe zu sich nehmen muss.",
+      "sourceSpan": "B10.3.1",
+      "parentBulletText": "beschreiben den Menschen als offenes System, der für die Aufrechterhaltung seines Stoffwechsels und damit für sein Überleben Energieträger und Baustoffe zu sich nehmen muss.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "beschreiben den Menschen als offenes System, der für die Aufrechterhaltung seines Stoffwechsels und damit für sein Überleben Energieträger und Baustoffe zu sich nehmen muss.",
+      "rawSourceSpan": "B10.3.1",
+      "rawParentBulletText": "beschreiben den Menschen als offenes System, der für die Aufrechterhaltung seines Stoffwechsels und damit für sein Überleben Energieträger und Baustoffe zu sich nehmen muss.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "d8d1e189-9d47-5e5c-9f9f-450a357c8ffb",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.1"
+      ]
+    },
+    {
+      "id": "5a48b62b-a6b8-5a82-ab80-d43003960cd0",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "vergleichen ausgewählte Inhaltsstoffe von Nahrungsmitteln anhand des molekularen Baus, um sie...",
+      "description": "vergleichen ausgewählte Inhaltsstoffe von Nahrungsmitteln anhand des molekularen Baus, um sie den Makronährstoffgruppen (Kohlenhydrate, Fette, Proteine) zuzuordnen.",
+      "sourceText": "vergleichen ausgewählte Inhaltsstoffe von Nahrungsmitteln anhand des molekularen Baus, um sie den Makronährstoffgruppen (Kohlenhydrate, Fette, Proteine) zuzuordnen.",
+      "sourceSpan": "B10.3.2",
+      "parentBulletText": "vergleichen ausgewählte Inhaltsstoffe von Nahrungsmitteln anhand des molekularen Baus, um sie den Makronährstoffgruppen (Kohlenhydrate, Fette, Proteine) zuzuordnen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "vergleichen ausgewählte Inhaltsstoffe von Nahrungsmitteln anhand des molekularen Baus, um sie den Makronährstoffgruppen (Kohlenhydrate, Fette, Proteine) zuzuordnen.",
+      "rawSourceSpan": "B10.3.2",
+      "rawParentBulletText": "vergleichen ausgewählte Inhaltsstoffe von Nahrungsmitteln anhand des molekularen Baus, um sie den Makronährstoffgruppen (Kohlenhydrate, Fette, Proteine) zuzuordnen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "5a48b62b-a6b8-5a82-ab80-d43003960cd0",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.2"
+      ]
+    },
+    {
+      "id": "71c526b6-8c6d-50d9-9d1d-529e5e7e3f21",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "leiten aus der Bedeutung von Makronährstoffen und Mikronährstoffen (Vitamine und Mineralsalze...",
+      "description": "leiten aus der Bedeutung von Makronährstoffen und Mikronährstoffen (Vitamine und Mineralsalze) für den Körper und der Zusammensetzung von Nahrungsmitteln ein den Lebensumständen angepasstes, ausgewogenes Ernährungskonzept ab.",
+      "sourceText": "leiten aus der Bedeutung von Makronährstoffen und Mikronährstoffen (Vitamine und Mineralsalze) für den Körper und der Zusammensetzung von Nahrungsmitteln ein den Lebensumständen angepasstes, ausgewogenes Ernährungskonzept ab.",
+      "sourceSpan": "B10.3.3",
+      "parentBulletText": "leiten aus der Bedeutung von Makronährstoffen und Mikronährstoffen (Vitamine und Mineralsalze) für den Körper und der Zusammensetzung von Nahrungsmitteln ein den Lebensumständen angepasstes, ausgewogenes Ernährungskonzept ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "leiten aus der Bedeutung von Makronährstoffen und Mikronährstoffen (Vitamine und Mineralsalze) für den Körper und der Zusammensetzung von Nahrungsmitteln ein den Lebensumständen angepasstes, ausgewogenes Ernährungskonzept ab.",
+      "rawSourceSpan": "B10.3.3",
+      "rawParentBulletText": "leiten aus der Bedeutung von Makronährstoffen und Mikronährstoffen (Vitamine und Mineralsalze) für den Körper und der Zusammensetzung von Nahrungsmitteln ein den Lebensumständen angepasstes, ausgewogenes Ernährungskonzept ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "71c526b6-8c6d-50d9-9d1d-529e5e7e3f21",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.3"
+      ]
+    },
+    {
+      "id": "bd5adfd4-8da0-5872-9152-0be6cbdba487",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "erläutern am Beispiel der Verdauung die allgemeine Wirkungsweise von Enzymen auf der Stoff- u...",
+      "description": "erläutern am Beispiel der Verdauung die allgemeine Wirkungsweise von Enzymen auf der Stoff- und der Teilchenebene, indem sie das Energiekonzept und das Schlüssel-Schloss-Modell auf enzymkatalysierte Reaktionen anwenden.",
+      "sourceText": "erläutern am Beispiel der Verdauung die allgemeine Wirkungsweise von Enzymen auf der Stoff- und der Teilchenebene, indem sie das Energiekonzept und das Schlüssel-Schloss-Modell auf enzymkatalysierte Reaktionen anwenden.",
+      "sourceSpan": "B10.3.4",
+      "parentBulletText": "erläutern am Beispiel der Verdauung die allgemeine Wirkungsweise von Enzymen auf der Stoff- und der Teilchenebene, indem sie das Energiekonzept und das Schlüssel-Schloss-Modell auf enzymkatalysierte Reaktionen anwenden.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.4",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "erläutern am Beispiel der Verdauung die allgemeine Wirkungsweise von Enzymen auf der Stoff- und der Teilchenebene, indem sie das Energiekonzept und das Schlüssel-Schloss-Modell auf enzymkatalysierte Reaktionen anwenden.",
+      "rawSourceSpan": "B10.3.4",
+      "rawParentBulletText": "erläutern am Beispiel der Verdauung die allgemeine Wirkungsweise von Enzymen auf der Stoff- und der Teilchenebene, indem sie das Energiekonzept und das Schlüssel-Schloss-Modell auf enzymkatalysierte Reaktionen anwenden.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "bd5adfd4-8da0-5872-9152-0be6cbdba487",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.4",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.4"
+      ]
+    },
+    {
+      "id": "d211a55b-11e7-5596-89ac-2021cb49cc97",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "erläutern die Enzymausstattung des Menschen als Angepasstheit, indem sie die Beeinflussung de...",
+      "description": "erläutern die Enzymausstattung des Menschen als Angepasstheit, indem sie die Beeinflussung der Enzymaktivität durch Außenfaktoren beschreiben.",
+      "sourceText": "erläutern die Enzymausstattung des Menschen als Angepasstheit, indem sie die Beeinflussung der Enzymaktivität durch Außenfaktoren beschreiben.",
+      "sourceSpan": "B10.3.5",
+      "parentBulletText": "erläutern die Enzymausstattung des Menschen als Angepasstheit, indem sie die Beeinflussung der Enzymaktivität durch Außenfaktoren beschreiben.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.5",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "erläutern die Enzymausstattung des Menschen als Angepasstheit, indem sie die Beeinflussung der Enzymaktivität durch Außenfaktoren beschreiben.",
+      "rawSourceSpan": "B10.3.5",
+      "rawParentBulletText": "erläutern die Enzymausstattung des Menschen als Angepasstheit, indem sie die Beeinflussung der Enzymaktivität durch Außenfaktoren beschreiben.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "d211a55b-11e7-5596-89ac-2021cb49cc97",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.5",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.5"
+      ]
+    },
+    {
+      "id": "3696816f-4126-5fc3-a2ca-a84927b7ff6c",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "erklären das Zusammenwirken der Bestandteile des Verdauungssystems beim Transport des Nahrung...",
+      "description": "erklären das Zusammenwirken der Bestandteile des Verdauungssystems beim Transport des Nahrungsbreis und beim stufenweisen enzymatischen Abbau von Kohlenhydraten, Fetten und Proteinen zu resorbierbaren Teilchen.",
+      "sourceText": "erklären das Zusammenwirken der Bestandteile des Verdauungssystems beim Transport des Nahrungsbreis und beim stufenweisen enzymatischen Abbau von Kohlenhydraten, Fetten und Proteinen zu resorbierbaren Teilchen.",
+      "sourceSpan": "B10.3.6",
+      "parentBulletText": "erklären das Zusammenwirken der Bestandteile des Verdauungssystems beim Transport des Nahrungsbreis und beim stufenweisen enzymatischen Abbau von Kohlenhydraten, Fetten und Proteinen zu resorbierbaren Teilchen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.6",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "erklären das Zusammenwirken der Bestandteile des Verdauungssystems beim Transport des Nahrungsbreis und beim stufenweisen enzymatischen Abbau von Kohlenhydraten, Fetten und Proteinen zu resorbierbaren Teilchen.",
+      "rawSourceSpan": "B10.3.6",
+      "rawParentBulletText": "erklären das Zusammenwirken der Bestandteile des Verdauungssystems beim Transport des Nahrungsbreis und beim stufenweisen enzymatischen Abbau von Kohlenhydraten, Fetten und Proteinen zu resorbierbaren Teilchen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "3696816f-4126-5fc3-a2ca-a84927b7ff6c",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.6",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.6"
+      ]
+    },
+    {
+      "id": "637df96d-52aa-52ee-8a6b-db2748122e5e",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "beschreiben den Aufbau der Dünndarmwand, um mithilfe des Struktur-Funktions-Konzepts die Reso...",
+      "description": "beschreiben den Aufbau der Dünndarmwand, um mithilfe des Struktur-Funktions-Konzepts die Resorption zu erläutern.",
+      "sourceText": "beschreiben den Aufbau der Dünndarmwand, um mithilfe des Struktur-Funktions-Konzepts die Resorption zu erläutern.",
+      "sourceSpan": "B10.3.7",
+      "parentBulletText": "beschreiben den Aufbau der Dünndarmwand, um mithilfe des Struktur-Funktions-Konzepts die Resorption zu erläutern.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.7",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "beschreiben den Aufbau der Dünndarmwand, um mithilfe des Struktur-Funktions-Konzepts die Resorption zu erläutern.",
+      "rawSourceSpan": "B10.3.7",
+      "rawParentBulletText": "beschreiben den Aufbau der Dünndarmwand, um mithilfe des Struktur-Funktions-Konzepts die Resorption zu erläutern.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "637df96d-52aa-52ee-8a6b-db2748122e5e",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.7",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.7"
+      ]
+    },
+    {
+      "id": "a53d4b2b-5d39-5b7c-98a6-3287f5b024f1",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "erklären den Gasaustausch durch Diffusion mithilfe des Struktur-Funktions-Konzepts.",
+      "description": "erklären den Gasaustausch durch Diffusion mithilfe des Struktur-Funktions-Konzepts.",
+      "sourceText": "erklären den Gasaustausch durch Diffusion mithilfe des Struktur-Funktions-Konzepts.",
+      "sourceSpan": "B10.3.8",
+      "parentBulletText": "erklären den Gasaustausch durch Diffusion mithilfe des Struktur-Funktions-Konzepts.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.8",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "erklären den Gasaustausch durch Diffusion mithilfe des Struktur-Funktions-Konzepts.",
+      "rawSourceSpan": "B10.3.8",
+      "rawParentBulletText": "erklären den Gasaustausch durch Diffusion mithilfe des Struktur-Funktions-Konzepts.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "a53d4b2b-5d39-5b7c-98a6-3287f5b024f1",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.8",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.8"
+      ]
+    },
+    {
+      "id": "efcf0167-7143-59a2-91b3-f0fbbc2153e4",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 9,
+      "aspectIndex": 1,
+      "title": "erläutern die Funktion des Herz-Kreislauf-Systems als Transportsystem zwischen der Umgebung u...",
+      "description": "erläutern die Funktion des Herz-Kreislauf-Systems als Transportsystem zwischen der Umgebung und allen Zellen des menschlichen Körpers bei der Stoffaufnahme und ‐abgabe.",
+      "sourceText": "erläutern die Funktion des Herz-Kreislauf-Systems als Transportsystem zwischen der Umgebung und allen Zellen des menschlichen Körpers bei der Stoffaufnahme und ‐abgabe.",
+      "sourceSpan": "B10.3.9",
+      "parentBulletText": "erläutern die Funktion des Herz-Kreislauf-Systems als Transportsystem zwischen der Umgebung und allen Zellen des menschlichen Körpers bei der Stoffaufnahme und ‐abgabe.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.9",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "erläutern die Funktion des Herz-Kreislauf-Systems als Transportsystem zwischen der Umgebung und allen Zellen des menschlichen Körpers bei der Stoffaufnahme und ‐abgabe.",
+      "rawSourceSpan": "B10.3.9",
+      "rawParentBulletText": "erläutern die Funktion des Herz-Kreislauf-Systems als Transportsystem zwischen der Umgebung und allen Zellen des menschlichen Körpers bei der Stoffaufnahme und ‐abgabe.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "efcf0167-7143-59a2-91b3-f0fbbc2153e4",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.9",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.9"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.9"
+      ]
+    },
+    {
+      "id": "013209a3-9dd2-5fb2-9347-c7f21572bd99",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 10,
+      "aspectIndex": 1,
+      "title": "erklären die Bedeutung einer aktiven Gesundheitsvorsorge zur Vermeidung von Schädigungen und ...",
+      "description": "erklären die Bedeutung einer aktiven Gesundheitsvorsorge zur Vermeidung von Schädigungen und Erkrankungen der Lunge und des Herz-Kreislauf-Systems und erläutern medizinische Möglichkeiten ihrer Behandlung.",
+      "sourceText": "erklären die Bedeutung einer aktiven Gesundheitsvorsorge zur Vermeidung von Schädigungen und Erkrankungen der Lunge und des Herz-Kreislauf-Systems und erläutern medizinische Möglichkeiten ihrer Behandlung.",
+      "sourceSpan": "B10.3.10",
+      "parentBulletText": "erklären die Bedeutung einer aktiven Gesundheitsvorsorge zur Vermeidung von Schädigungen und Erkrankungen der Lunge und des Herz-Kreislauf-Systems und erläutern medizinische Möglichkeiten ihrer Behandlung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.10",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "erklären die Bedeutung einer aktiven Gesundheitsvorsorge zur Vermeidung von Schädigungen und Erkrankungen der Lunge und des Herz-Kreislauf-Systems und erläutern medizinische Möglichkeiten ihrer Behandlung.",
+      "rawSourceSpan": "B10.3.10",
+      "rawParentBulletText": "erklären die Bedeutung einer aktiven Gesundheitsvorsorge zur Vermeidung von Schädigungen und Erkrankungen der Lunge und des Herz-Kreislauf-Systems und erläutern medizinische Möglichkeiten ihrer Behandlung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "013209a3-9dd2-5fb2-9347-c7f21572bd99",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.10",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.10"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.10"
+      ]
+    },
+    {
+      "id": "2aa63a1f-2267-50c6-9fe6-1ade7ec30b50",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 11,
+      "aspectIndex": 1,
+      "title": "beschreiben den Glucoseabbau als exotherme Redoxreaktion, in deren Verlauf die abgegebene Ene...",
+      "description": "beschreiben den Glucoseabbau als exotherme Redoxreaktion, in deren Verlauf die abgegebene Energie im Energieträger ATP gespeichert wird, und erläutern die Notwendigkeit dieses mobilen und universellen Energieträgers.",
+      "sourceText": "beschreiben den Glucoseabbau als exotherme Redoxreaktion, in deren Verlauf die abgegebene Energie im Energieträger ATP gespeichert wird, und erläutern die Notwendigkeit dieses mobilen und universellen Energieträgers.",
+      "sourceSpan": "B10.3.11",
+      "parentBulletText": "beschreiben den Glucoseabbau als exotherme Redoxreaktion, in deren Verlauf die abgegebene Energie im Energieträger ATP gespeichert wird, und erläutern die Notwendigkeit dieses mobilen und universellen Energieträgers.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.11",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "beschreiben den Glucoseabbau als exotherme Redoxreaktion, in deren Verlauf die abgegebene Energie im Energieträger ATP gespeichert wird, und erläutern die Notwendigkeit dieses mobilen und universellen Energieträgers.",
+      "rawSourceSpan": "B10.3.11",
+      "rawParentBulletText": "beschreiben den Glucoseabbau als exotherme Redoxreaktion, in deren Verlauf die abgegebene Energie im Energieträger ATP gespeichert wird, und erläutern die Notwendigkeit dieses mobilen und universellen Energieträgers.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "2aa63a1f-2267-50c6-9fe6-1ade7ec30b50",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.11",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.11"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.11"
+      ]
+    },
+    {
+      "id": "93d6d931-debc-5f17-9e41-baafe529dcf4",
+      "passageId": "by-bio:B10.3",
+      "topicCode": "B10.3",
+      "bulletIndex": 12,
+      "aspectIndex": 1,
+      "title": "vergleichen die Stoff- und Energiebilanz des aeroben und anaeroben Abbaus von Glucose in mens...",
+      "description": "vergleichen die Stoff- und Energiebilanz des aeroben und anaeroben Abbaus von Glucose in menschlichen Zellen, um die Bedeutung beider Stoffwechselwege für den menschlichen Organismus zu erläutern.",
+      "sourceText": "vergleichen die Stoff- und Energiebilanz des aeroben und anaeroben Abbaus von Glucose in menschlichen Zellen, um die Bedeutung beider Stoffwechselwege für den menschlichen Organismus zu erläutern.",
+      "sourceSpan": "B10.3.12",
+      "parentBulletText": "vergleichen die Stoff- und Energiebilanz des aeroben und anaeroben Abbaus von Glucose in menschlichen Zellen, um die Bedeutung beider Stoffwechselwege für den menschlichen Organismus zu erläutern.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.12",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.3"
+      ],
+      "rawSourceText": "vergleichen die Stoff- und Energiebilanz des aeroben und anaeroben Abbaus von Glucose in menschlichen Zellen, um die Bedeutung beider Stoffwechselwege für den menschlichen Organismus zu erläutern.",
+      "rawSourceSpan": "B10.3.12",
+      "rawParentBulletText": "vergleichen die Stoff- und Energiebilanz des aeroben und anaeroben Abbaus von Glucose in menschlichen Zellen, um die Bedeutung beider Stoffwechselwege für den menschlichen Organismus zu erläutern.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "93d6d931-debc-5f17-9e41-baafe529dcf4",
+          "passageId": "by-bio:B10.3",
+          "topicCode": "B10.3",
+          "sourceSpan": "B10.3.12",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.12",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.3"
+      ],
+      "mergedSourceSpans": [
+        "B10.3.12"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.3.12"
+      ]
+    },
+    {
+      "id": "b957227d-cd28-5d10-8de4-9a487b70a3ec",
+      "passageId": "by-bio:B10.4",
+      "topicCode": "B10.4",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "skizzieren den Verlauf der Geschichte des Lebens, um zu verdeutlichen, dass der moderne Mensc...",
+      "description": "skizzieren den Verlauf der Geschichte des Lebens, um zu verdeutlichen, dass der moderne Mensch eine erdgeschichtlich junge Art ist.",
+      "sourceText": "skizzieren den Verlauf der Geschichte des Lebens, um zu verdeutlichen, dass der moderne Mensch eine erdgeschichtlich junge Art ist.",
+      "sourceSpan": "B10.4.1",
+      "parentBulletText": "skizzieren den Verlauf der Geschichte des Lebens, um zu verdeutlichen, dass der moderne Mensch eine erdgeschichtlich junge Art ist.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.4.1",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.4"
+      ],
+      "rawSourceText": "skizzieren den Verlauf der Geschichte des Lebens, um zu verdeutlichen, dass der moderne Mensch eine erdgeschichtlich junge Art ist.",
+      "rawSourceSpan": "B10.4.1",
+      "rawParentBulletText": "skizzieren den Verlauf der Geschichte des Lebens, um zu verdeutlichen, dass der moderne Mensch eine erdgeschichtlich junge Art ist.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b957227d-cd28-5d10-8de4-9a487b70a3ec",
+          "passageId": "by-bio:B10.4",
+          "topicCode": "B10.4",
+          "sourceSpan": "B10.4.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.4.1",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.4"
+      ],
+      "mergedSourceSpans": [
+        "B10.4.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.4.1"
+      ]
+    },
+    {
+      "id": "bb2200a1-389f-5ce4-ad80-5c599c9cd59e",
+      "passageId": "by-bio:B10.4",
+      "topicCode": "B10.4",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "ordnen den modernen Menschen (Homo sapiens) unter Berücksichtigung anatomischer und molekular...",
+      "description": "ordnen den modernen Menschen (Homo sapiens) unter Berücksichtigung anatomischer und molekularbiologischer Merkmale in das natürliche System ein.",
+      "sourceText": "ordnen den modernen Menschen (Homo sapiens) unter Berücksichtigung anatomischer und molekularbiologischer Merkmale in das natürliche System ein.",
+      "sourceSpan": "B10.4.2",
+      "parentBulletText": "ordnen den modernen Menschen (Homo sapiens) unter Berücksichtigung anatomischer und molekularbiologischer Merkmale in das natürliche System ein.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.4.2",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.4"
+      ],
+      "rawSourceText": "ordnen den modernen Menschen (Homo sapiens) unter Berücksichtigung anatomischer und molekularbiologischer Merkmale in das natürliche System ein.",
+      "rawSourceSpan": "B10.4.2",
+      "rawParentBulletText": "ordnen den modernen Menschen (Homo sapiens) unter Berücksichtigung anatomischer und molekularbiologischer Merkmale in das natürliche System ein.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "bb2200a1-389f-5ce4-ad80-5c599c9cd59e",
+          "passageId": "by-bio:B10.4",
+          "topicCode": "B10.4",
+          "sourceSpan": "B10.4.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.4.2",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.4"
+      ],
+      "mergedSourceSpans": [
+        "B10.4.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.4.2"
+      ]
+    },
+    {
+      "id": "791145f3-650f-5e1a-84f7-2619aceb6a6a",
+      "passageId": "by-bio:B10.4",
+      "topicCode": "B10.4",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "leiten aus Merkmalen fossiler Funde Hypothesen zur biologischen Evolution des modernen Mensch...",
+      "description": "leiten aus Merkmalen fossiler Funde Hypothesen zur biologischen Evolution des modernen Menschen ab, um die zeitliche Reihenfolge eines Evolutionsprozesses zu rekonstruieren, und analysieren die Bedeutung der kulturellen Evolution für den heutigen Menschen in seiner Umwelt.",
+      "sourceText": "leiten aus Merkmalen fossiler Funde Hypothesen zur biologischen Evolution des modernen Menschen ab, um die zeitliche Reihenfolge eines Evolutionsprozesses zu rekonstruieren, und analysieren die Bedeutung der kulturellen Evolution für den heutigen Menschen in seiner Umwelt.",
+      "sourceSpan": "B10.4.3",
+      "parentBulletText": "leiten aus Merkmalen fossiler Funde Hypothesen zur biologischen Evolution des modernen Menschen ab, um die zeitliche Reihenfolge eines Evolutionsprozesses zu rekonstruieren, und analysieren die Bedeutung der kulturellen Evolution für den heutigen Menschen in seiner Umwelt.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.4.3",
+      "courseLevel": "unspecified",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:unspecified",
+        "jurisdiction:DE-BY",
+        "stage:SekI",
+        "topic:B10.4"
+      ],
+      "rawSourceText": "leiten aus Merkmalen fossiler Funde Hypothesen zur biologischen Evolution des modernen Menschen ab, um die zeitliche Reihenfolge eines Evolutionsprozesses zu rekonstruieren, und analysieren die Bedeutung der kulturellen Evolution für den heutigen Menschen in seiner Umwelt.",
+      "rawSourceSpan": "B10.4.3",
+      "rawParentBulletText": "leiten aus Merkmalen fossiler Funde Hypothesen zur biologischen Evolution des modernen Menschen ab, um die zeitliche Reihenfolge eines Evolutionsprozesses zu rekonstruieren, und analysieren die Bedeutung der kulturellen Evolution für den heutigen Menschen in seiner Umwelt.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "791145f3-650f-5e1a-84f7-2619aceb6a6a",
+          "passageId": "by-bio:B10.4",
+          "topicCode": "B10.4",
+          "sourceSpan": "B10.4.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B10.4.3",
+          "courseLevel": "unspecified",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekI",
+            "courseLevel:unspecified",
+            "topic:B10.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B10.4"
+      ],
+      "mergedSourceSpans": [
+        "B10.4.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B10.4.3"
+      ]
+    },
+    {
+      "id": "93208e54-7814-5738-b753-e30df89dcd5d",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "beschreiben und erläutern biologische Sachverhalte, Phänomene und Anwendungen der Biologie sa...",
+      "description": "beschreiben und erläutern biologische Sachverhalte, Phänomene und Anwendungen der Biologie sachgerecht. Zur Strukturierung und Erschließung nutzen sie Basiskonzepte und binden fachübergreifende Aspekte ein.",
+      "sourceText": "beschreiben und erläutern biologische Sachverhalte, Phänomene und Anwendungen der Biologie sachgerecht. Zur Strukturierung und Erschließung nutzen sie Basiskonzepte und binden fachübergreifende Aspekte ein.",
+      "sourceSpan": "B12-EA.1.1",
+      "parentBulletText": "beschreiben und erläutern biologische Sachverhalte, Phänomene und Anwendungen der Biologie sachgerecht. Zur Strukturierung und Erschließung nutzen sie Basiskonzepte und binden fachübergreifende Aspekte ein.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.1",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "beschreiben und erläutern biologische Sachverhalte, Phänomene und Anwendungen der Biologie sachgerecht. Zur Strukturierung und Erschließung nutzen sie Basiskonzepte und binden fachübergreifende Aspekte ein.",
+      "rawSourceSpan": "B12-EA.1.1",
+      "rawParentBulletText": "beschreiben und erläutern biologische Sachverhalte, Phänomene und Anwendungen der Biologie sachgerecht. Zur Strukturierung und Erschließung nutzen sie Basiskonzepte und binden fachübergreifende Aspekte ein.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "93208e54-7814-5738-b753-e30df89dcd5d",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.1",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "4653a1c2-dd75-5c96-b805-34a6e1bfccf3",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.1",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "2fb49326-5081-58b2-8a26-ecdcdb446718",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.1",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "4598a52f-1f4e-5ed3-8a0a-0e97339b8aa6",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.1",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.1",
+        "B12-GA.1.1",
+        "B13-EA.1.1",
+        "B13-GA.1.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.1",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.1",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.1",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.1"
+      ]
+    },
+    {
+      "id": "c86da1fa-e9b1-53e1-8a71-ebeda357eb72",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "formulieren zu biologischen Phänomenen sowie Anwendungen der Biologie theoriegeleitet Hypothe...",
+      "description": "formulieren zu biologischen Phänomenen sowie Anwendungen der Biologie theoriegeleitet Hypothesen und Aussagen.",
+      "sourceText": "formulieren zu biologischen Phänomenen sowie Anwendungen der Biologie theoriegeleitet Hypothesen und Aussagen.",
+      "sourceSpan": "B12-EA.1.2",
+      "parentBulletText": "formulieren zu biologischen Phänomenen sowie Anwendungen der Biologie theoriegeleitet Hypothesen und Aussagen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.2",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "formulieren zu biologischen Phänomenen sowie Anwendungen der Biologie theoriegeleitet Hypothesen und Aussagen.",
+      "rawSourceSpan": "B12-EA.1.2",
+      "rawParentBulletText": "formulieren zu biologischen Phänomenen sowie Anwendungen der Biologie theoriegeleitet Hypothesen und Aussagen.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "c86da1fa-e9b1-53e1-8a71-ebeda357eb72",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.2",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "60480a4f-04e6-532b-b75d-dde597b3a74c",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.2",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "11347edf-6098-569c-8486-14df558c6195",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.2",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "71fb6948-b7fa-52a6-9030-d0d7fb5ad3f5",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.2",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.2",
+        "B12-GA.1.2",
+        "B13-EA.1.2",
+        "B13-GA.1.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.2",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.2",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.2",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.2"
+      ]
+    },
+    {
+      "id": "66dbee5c-ffd7-5ffc-bace-0898d13479b2",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "erschließen und erläutern mithilfe von Basiskonzepten strukturiert die Eigenschaften lebender...",
+      "description": "erschließen und erläutern mithilfe von Basiskonzepten strukturiert die Eigenschaften lebender Systeme unter qualitativen und quantitativen Aspekten. Dabei stellen sie Vernetzungen zwischen Systemebenen (Molekular- bis Biosphärenebene) her.",
+      "sourceText": "erschließen und erläutern mithilfe von Basiskonzepten strukturiert die Eigenschaften lebender Systeme unter qualitativen und quantitativen Aspekten. Dabei stellen sie Vernetzungen zwischen Systemebenen (Molekular- bis Biosphärenebene) her.",
+      "sourceSpan": "B12-EA.1.3",
+      "parentBulletText": "erschließen und erläutern mithilfe von Basiskonzepten strukturiert die Eigenschaften lebender Systeme unter qualitativen und quantitativen Aspekten. Dabei stellen sie Vernetzungen zwischen Systemebenen (Molekular- bis Biosphärenebene) her.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.3",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1"
+      ],
+      "rawSourceText": "erschließen und erläutern mithilfe von Basiskonzepten strukturiert die Eigenschaften lebender Systeme unter qualitativen und quantitativen Aspekten. Dabei stellen sie Vernetzungen zwischen Systemebenen (Molekular- bis Biosphärenebene) her.",
+      "rawSourceSpan": "B12-EA.1.3",
+      "rawParentBulletText": "erschließen und erläutern mithilfe von Basiskonzepten strukturiert die Eigenschaften lebender Systeme unter qualitativen und quantitativen Aspekten. Dabei stellen sie Vernetzungen zwischen Systemebenen (Molekular- bis Biosphärenebene) her.",
+      "duplicateSourceGoalCount": 2,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "66dbee5c-ffd7-5ffc-bace-0898d13479b2",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.3",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "024f887c-a586-5c2c-ba7a-a4a9e5498a5a",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.3",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "c898275e-33d6-55fd-8eb4-808a7dc89017",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.3",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.3",
+        "B12-GA.1.3",
+        "B13-EA.1.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.3",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.3",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.3"
+      ]
+    },
+    {
+      "id": "14c703b4-fcc6-5e15-8027-1696a3024ab6",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "erläutern Prozesse in und zwischen lebenden Systemen sowie zwischen lebenden Systemen und ihr...",
+      "description": "erläutern Prozesse in und zwischen lebenden Systemen sowie zwischen lebenden Systemen und ihrer Umwelt.",
+      "sourceText": "erläutern Prozesse in und zwischen lebenden Systemen sowie zwischen lebenden Systemen und ihrer Umwelt.",
+      "sourceSpan": "B12-EA.1.4",
+      "parentBulletText": "erläutern Prozesse in und zwischen lebenden Systemen sowie zwischen lebenden Systemen und ihrer Umwelt.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.4",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "erläutern Prozesse in und zwischen lebenden Systemen sowie zwischen lebenden Systemen und ihrer Umwelt.",
+      "rawSourceSpan": "B12-EA.1.4",
+      "rawParentBulletText": "erläutern Prozesse in und zwischen lebenden Systemen sowie zwischen lebenden Systemen und ihrer Umwelt.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "14c703b4-fcc6-5e15-8027-1696a3024ab6",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.4",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "79be130e-f79b-5293-a76e-c1b55fab6785",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.4",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "d71858a1-9fea-5cf3-9745-4f526afb8489",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.4",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "9d9d0baf-14fe-5b9b-aa93-b0e517607384",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.3",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.4",
+        "B12-GA.1.4",
+        "B13-EA.1.4",
+        "B13-GA.1.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.4",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.4",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.4",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.3"
+      ]
+    },
+    {
+      "id": "16b8c298-6574-5eb5-81d6-e6d68839ee68",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "erläutern die Entstehung und Bedeutung von Biodiversität sowie Gründe für deren Schutz und na...",
+      "description": "erläutern die Entstehung und Bedeutung von Biodiversität sowie Gründe für deren Schutz und nachhaltige Nutzung.",
+      "sourceText": "erläutern die Entstehung und Bedeutung von Biodiversität sowie Gründe für deren Schutz und nachhaltige Nutzung.",
+      "sourceSpan": "B12-EA.1.5",
+      "parentBulletText": "erläutern die Entstehung und Bedeutung von Biodiversität sowie Gründe für deren Schutz und nachhaltige Nutzung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.5",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "erläutern die Entstehung und Bedeutung von Biodiversität sowie Gründe für deren Schutz und nachhaltige Nutzung.",
+      "rawSourceSpan": "B12-EA.1.5",
+      "rawParentBulletText": "erläutern die Entstehung und Bedeutung von Biodiversität sowie Gründe für deren Schutz und nachhaltige Nutzung.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "16b8c298-6574-5eb5-81d6-e6d68839ee68",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.5",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "e2f8c37c-72b1-529f-b816-c7c65ced6c9b",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.5",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "8ab66725-7935-5d4b-abd1-1312d14d5109",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.5",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "b55634a8-b1e9-5699-94c4-56c15d562977",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.4",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.5",
+        "B12-GA.1.5",
+        "B13-EA.1.5",
+        "B13-GA.1.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.5",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.5",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.5",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.4"
+      ]
+    },
+    {
+      "id": "d128f994-616b-5bd7-a01a-ecf428ee54df",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "identifizieren und entwickeln ausgehend von Phänomenen und Beobachtungen Fragestellungen zu b...",
+      "description": "identifizieren und entwickeln ausgehend von Phänomenen und Beobachtungen Fragestellungen zu biologischen Sachverhalten und stellen theoriegeleitet Hypothesen zu ihrer Bearbeitung auf.",
+      "sourceText": "identifizieren und entwickeln ausgehend von Phänomenen und Beobachtungen Fragestellungen zu biologischen Sachverhalten und stellen theoriegeleitet Hypothesen zu ihrer Bearbeitung auf.",
+      "sourceSpan": "B12-EA.1.6",
+      "parentBulletText": "identifizieren und entwickeln ausgehend von Phänomenen und Beobachtungen Fragestellungen zu biologischen Sachverhalten und stellen theoriegeleitet Hypothesen zu ihrer Bearbeitung auf.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.6",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "identifizieren und entwickeln ausgehend von Phänomenen und Beobachtungen Fragestellungen zu biologischen Sachverhalten und stellen theoriegeleitet Hypothesen zu ihrer Bearbeitung auf.",
+      "rawSourceSpan": "B12-EA.1.6",
+      "rawParentBulletText": "identifizieren und entwickeln ausgehend von Phänomenen und Beobachtungen Fragestellungen zu biologischen Sachverhalten und stellen theoriegeleitet Hypothesen zu ihrer Bearbeitung auf.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "d128f994-616b-5bd7-a01a-ecf428ee54df",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.6",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "478c9c90-1a07-5111-8b16-31085243a7be",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.6",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "e24a4083-3ea5-5693-829c-59987d218bee",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.6",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "e25be74c-e045-570d-866e-b5f32817481d",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.5",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.6",
+        "B12-GA.1.6",
+        "B13-EA.1.6",
+        "B13-GA.1.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.6",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.6",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.6",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.5"
+      ]
+    },
+    {
+      "id": "28e9a9ec-76d4-57f8-a8b2-a14bfe2f0dc4",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "planen und führen hypothesengeleitete Beobachtungen, Vergleiche, Experimente und Modellierung...",
+      "description": "planen und führen hypothesengeleitete Beobachtungen, Vergleiche, Experimente und Modellierungen unter Berücksichtigung des jeweiligen Variablengefüges bzw. der Variablenkontrolle durch und protokollieren sie.",
+      "sourceText": "planen und führen hypothesengeleitete Beobachtungen, Vergleiche, Experimente und Modellierungen unter Berücksichtigung des jeweiligen Variablengefüges bzw. der Variablenkontrolle durch und protokollieren sie.",
+      "sourceSpan": "B12-EA.1.7",
+      "parentBulletText": "planen und führen hypothesengeleitete Beobachtungen, Vergleiche, Experimente und Modellierungen unter Berücksichtigung des jeweiligen Variablengefüges bzw. der Variablenkontrolle durch und protokollieren sie.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.7",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "planen und führen hypothesengeleitete Beobachtungen, Vergleiche, Experimente und Modellierungen unter Berücksichtigung des jeweiligen Variablengefüges bzw. der Variablenkontrolle durch und protokollieren sie.",
+      "rawSourceSpan": "B12-EA.1.7",
+      "rawParentBulletText": "planen und führen hypothesengeleitete Beobachtungen, Vergleiche, Experimente und Modellierungen unter Berücksichtigung des jeweiligen Variablengefüges bzw. der Variablenkontrolle durch und protokollieren sie.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "28e9a9ec-76d4-57f8-a8b2-a14bfe2f0dc4",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.7",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "cb9a4583-f41d-52da-924c-0507484ef66b",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.7",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "3fe61a0d-85f0-5971-bb7d-1b2ef0e3ce75",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.7",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "9cd8aeaf-0276-5a07-9208-643d58af38e1",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.6",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.7",
+        "B12-GA.1.7",
+        "B13-EA.1.7",
+        "B13-GA.1.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.7",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.7",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.7",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.6"
+      ]
+    },
+    {
+      "id": "258ad6b8-86fb-5300-b3b9-43626e1b6ab5",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "nehmen qualitative und quantitative Daten auch mithilfe digitaler Werkzeuge auf und werten si...",
+      "description": "nehmen qualitative und quantitative Daten auch mithilfe digitaler Werkzeuge auf und werten sie aus.",
+      "sourceText": "nehmen qualitative und quantitative Daten auch mithilfe digitaler Werkzeuge auf und werten sie aus.",
+      "sourceSpan": "B12-EA.1.8",
+      "parentBulletText": "nehmen qualitative und quantitative Daten auch mithilfe digitaler Werkzeuge auf und werten sie aus.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.8",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "nehmen qualitative und quantitative Daten auch mithilfe digitaler Werkzeuge auf und werten sie aus.",
+      "rawSourceSpan": "B12-EA.1.8",
+      "rawParentBulletText": "nehmen qualitative und quantitative Daten auch mithilfe digitaler Werkzeuge auf und werten sie aus.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "258ad6b8-86fb-5300-b3b9-43626e1b6ab5",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.8",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "1708f30d-1fdd-5c1c-9e6e-8d8a8b1bf590",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.8",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "072e18af-5a6c-5797-94a1-af5ef11b1598",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.8",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "3f344a8b-d533-5f38-b437-61f436674db3",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.7",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.8",
+        "B12-GA.1.8",
+        "B13-EA.1.8",
+        "B13-GA.1.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.8",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.8",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.8",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.7"
+      ]
+    },
+    {
+      "id": "6be93217-c8d5-5db7-bb9f-7fb4996c7f0c",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 9,
+      "aspectIndex": 1,
+      "title": "wenden Labor- und freilandbiologische Geräte und Techniken sachgerecht und unter Berücksichti...",
+      "description": "wenden Labor- und freilandbiologische Geräte und Techniken sachgerecht und unter Berücksichtigung der Sicherheitsbestimmungen an.",
+      "sourceText": "wenden Labor- und freilandbiologische Geräte und Techniken sachgerecht und unter Berücksichtigung der Sicherheitsbestimmungen an.",
+      "sourceSpan": "B12-EA.1.9",
+      "parentBulletText": "wenden Labor- und freilandbiologische Geräte und Techniken sachgerecht und unter Berücksichtigung der Sicherheitsbestimmungen an.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.9",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "wenden Labor- und freilandbiologische Geräte und Techniken sachgerecht und unter Berücksichtigung der Sicherheitsbestimmungen an.",
+      "rawSourceSpan": "B12-EA.1.9",
+      "rawParentBulletText": "wenden Labor- und freilandbiologische Geräte und Techniken sachgerecht und unter Berücksichtigung der Sicherheitsbestimmungen an.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "6be93217-c8d5-5db7-bb9f-7fb4996c7f0c",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.9",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "0cdfa5ef-8b11-5ac4-9272-1bc93a1de2f2",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.9",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "a69110c4-b7e3-51f9-a12f-22a7e1d5ef98",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.9",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "950467a5-894f-5764-8cbc-b44dbd51a011",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.8",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.9",
+        "B12-GA.1.9",
+        "B13-EA.1.9",
+        "B13-GA.1.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.9",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.9",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.9",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.8"
+      ]
+    },
+    {
+      "id": "5b33bfb3-b22f-52e0-a0d2-a5931dcbdbe6",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 10,
+      "aspectIndex": 1,
+      "title": "finden in erhobenen oder recherchierten Daten Strukturen, Beziehungen und Trends, erklären di...",
+      "description": "finden in erhobenen oder recherchierten Daten Strukturen, Beziehungen und Trends, erklären diese theoriebezogen und ziehen Schlussfolgerungen.",
+      "sourceText": "finden in erhobenen oder recherchierten Daten Strukturen, Beziehungen und Trends, erklären diese theoriebezogen und ziehen Schlussfolgerungen.",
+      "sourceSpan": "B12-EA.1.10",
+      "parentBulletText": "finden in erhobenen oder recherchierten Daten Strukturen, Beziehungen und Trends, erklären diese theoriebezogen und ziehen Schlussfolgerungen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.10",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "finden in erhobenen oder recherchierten Daten Strukturen, Beziehungen und Trends, erklären diese theoriebezogen und ziehen Schlussfolgerungen.",
+      "rawSourceSpan": "B12-EA.1.10",
+      "rawParentBulletText": "finden in erhobenen oder recherchierten Daten Strukturen, Beziehungen und Trends, erklären diese theoriebezogen und ziehen Schlussfolgerungen.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "5b33bfb3-b22f-52e0-a0d2-a5931dcbdbe6",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.10",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "b75c3538-7903-50f5-83cf-f9d54e7af797",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.10",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "55adf15f-9720-5eaa-9da7-436780b48e09",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.10",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "342278a0-c413-5618-940b-05137082d5b0",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.9",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.10",
+        "B12-GA.1.10",
+        "B13-EA.1.10",
+        "B13-GA.1.9"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.10",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.10",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.10",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.9"
+      ]
+    },
+    {
+      "id": "cacf5cc8-5dd2-56f0-aa7f-289b23c30f2a",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 11,
+      "aspectIndex": 1,
+      "title": "reflektieren die eigenen Ergebnisse und den eigenen Prozess der Erkenntnisgewinnung, indem si...",
+      "description": "reflektieren die eigenen Ergebnisse und den eigenen Prozess der Erkenntnisgewinnung, indem sie die Gültigkeit von Daten beurteilen, mögliche Fehlerquellen ermitteln sowie Möglichkeiten und Grenzen von Modellen diskutieren.",
+      "sourceText": "reflektieren die eigenen Ergebnisse und den eigenen Prozess der Erkenntnisgewinnung, indem sie die Gültigkeit von Daten beurteilen, mögliche Fehlerquellen ermitteln sowie Möglichkeiten und Grenzen von Modellen diskutieren.",
+      "sourceSpan": "B12-EA.1.11",
+      "parentBulletText": "reflektieren die eigenen Ergebnisse und den eigenen Prozess der Erkenntnisgewinnung, indem sie die Gültigkeit von Daten beurteilen, mögliche Fehlerquellen ermitteln sowie Möglichkeiten und Grenzen von Modellen diskutieren.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.11",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "reflektieren die eigenen Ergebnisse und den eigenen Prozess der Erkenntnisgewinnung, indem sie die Gültigkeit von Daten beurteilen, mögliche Fehlerquellen ermitteln sowie Möglichkeiten und Grenzen von Modellen diskutieren.",
+      "rawSourceSpan": "B12-EA.1.11",
+      "rawParentBulletText": "reflektieren die eigenen Ergebnisse und den eigenen Prozess der Erkenntnisgewinnung, indem sie die Gültigkeit von Daten beurteilen, mögliche Fehlerquellen ermitteln sowie Möglichkeiten und Grenzen von Modellen diskutieren.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "cacf5cc8-5dd2-56f0-aa7f-289b23c30f2a",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.11",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "4d2ea5fc-e373-5af7-bef9-3e04cf2a9125",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.11",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "1ce47060-051b-5392-bc76-cffb7297a060",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.11",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "c3869889-b25f-5daf-a968-8b7446cedf27",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.10",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.11",
+        "B12-GA.1.11",
+        "B13-EA.1.11",
+        "B13-GA.1.10"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.11",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.11",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.11",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.10"
+      ]
+    },
+    {
+      "id": "3258593f-0a53-52f4-b067-6c05f76937e0",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 12,
+      "aspectIndex": 1,
+      "title": "widerlegen oder stützen die Hypothese (Hypothesenrückbezug).",
+      "description": "widerlegen oder stützen die Hypothese (Hypothesenrückbezug).",
+      "sourceText": "widerlegen oder stützen die Hypothese (Hypothesenrückbezug).",
+      "sourceSpan": "B12-EA.1.12",
+      "parentBulletText": "widerlegen oder stützen die Hypothese (Hypothesenrückbezug).",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.12",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "widerlegen oder stützen die Hypothese (Hypothesenrückbezug).",
+      "rawSourceSpan": "B12-EA.1.12",
+      "rawParentBulletText": "widerlegen oder stützen die Hypothese (Hypothesenrückbezug).",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "3258593f-0a53-52f4-b067-6c05f76937e0",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.12",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.12",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "1be7cec0-77fa-5ff3-8881-633e04a38b50",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.12",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.12",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "a1b27513-0897-5e8f-935f-dfaae2a73420",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.12",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.12",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "16600adb-983f-547b-a9c9-332a4be8623f",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.11",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.12",
+        "B12-GA.1.12",
+        "B13-EA.1.12",
+        "B13-GA.1.11"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.12",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.12",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.12",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.11"
+      ]
+    },
+    {
+      "id": "d1acb51b-f547-567a-a0e6-2f24dd78bebb",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 13,
+      "aspectIndex": 1,
+      "title": "stellen bei der Interpretation von Untersuchungsbefunden fachübergreifende Bezüge her.",
+      "description": "stellen bei der Interpretation von Untersuchungsbefunden fachübergreifende Bezüge her.",
+      "sourceText": "stellen bei der Interpretation von Untersuchungsbefunden fachübergreifende Bezüge her.",
+      "sourceSpan": "B12-EA.1.13",
+      "parentBulletText": "stellen bei der Interpretation von Untersuchungsbefunden fachübergreifende Bezüge her.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.13",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "stellen bei der Interpretation von Untersuchungsbefunden fachübergreifende Bezüge her.",
+      "rawSourceSpan": "B12-EA.1.13",
+      "rawParentBulletText": "stellen bei der Interpretation von Untersuchungsbefunden fachübergreifende Bezüge her.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "d1acb51b-f547-567a-a0e6-2f24dd78bebb",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.13",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.13",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "9cd63e66-6698-5185-a151-9c6ec4b38e70",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.13",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.13",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "4471df1b-e0fd-5735-9174-67d0ce4196be",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.13",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.13",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "3e99ed4c-bf43-50b6-8bc1-e01552b89124",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.12",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.12",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.13",
+        "B12-GA.1.13",
+        "B13-EA.1.13",
+        "B13-GA.1.12"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.13",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.13",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.13",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.12"
+      ]
+    },
+    {
+      "id": "361dc7c8-154c-5919-abc7-34405877cfd1",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 14,
+      "aspectIndex": 1,
+      "title": "reflektieren Möglichkeiten und Grenzen des konkreten Erkenntnisgewinnungsprozesses sowie der ...",
+      "description": "reflektieren Möglichkeiten und Grenzen des konkreten Erkenntnisgewinnungsprozesses sowie der gewonnenen Erkenntnisse (z. B. Reproduzierbarkeit, Falsifizierbarkeit, Intersubjektivität, logische Konsistenz, Vorläufigkeit).",
+      "sourceText": "reflektieren Möglichkeiten und Grenzen des konkreten Erkenntnisgewinnungsprozesses sowie der gewonnenen Erkenntnisse (z. B. Reproduzierbarkeit, Falsifizierbarkeit, Intersubjektivität, logische Konsistenz, Vorläufigkeit).",
+      "sourceSpan": "B12-EA.1.14",
+      "parentBulletText": "reflektieren Möglichkeiten und Grenzen des konkreten Erkenntnisgewinnungsprozesses sowie der gewonnenen Erkenntnisse (z. B. Reproduzierbarkeit, Falsifizierbarkeit, Intersubjektivität, logische Konsistenz, Vorläufigkeit).",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.14",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "reflektieren Möglichkeiten und Grenzen des konkreten Erkenntnisgewinnungsprozesses sowie der gewonnenen Erkenntnisse (z. B. Reproduzierbarkeit, Falsifizierbarkeit, Intersubjektivität, logische Konsistenz, Vorläufigkeit).",
+      "rawSourceSpan": "B12-EA.1.14",
+      "rawParentBulletText": "reflektieren Möglichkeiten und Grenzen des konkreten Erkenntnisgewinnungsprozesses sowie der gewonnenen Erkenntnisse (z. B. Reproduzierbarkeit, Falsifizierbarkeit, Intersubjektivität, logische Konsistenz, Vorläufigkeit).",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "361dc7c8-154c-5919-abc7-34405877cfd1",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.14",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.14",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "17630cbb-52d1-569e-9de0-6d6ea2ea98c0",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.14",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.14",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "0102d776-a826-5fd7-887f-21cd7be2e028",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.14",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.14",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "96265c72-458c-59c0-8319-0b6d77fc4237",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.13",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.13",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.14",
+        "B12-GA.1.14",
+        "B13-EA.1.14",
+        "B13-GA.1.13"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.14",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.14",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.14",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.13"
+      ]
+    },
+    {
+      "id": "4d662fc7-15ce-5b6d-a5a1-287b48af2145",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 15,
+      "aspectIndex": 1,
+      "title": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieori...",
+      "description": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung), sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.",
+      "sourceText": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung), sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.",
+      "sourceSpan": "B12-EA.1.15",
+      "parentBulletText": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung), sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.15",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung), sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.",
+      "rawSourceSpan": "B12-EA.1.15",
+      "rawParentBulletText": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung), sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.",
+      "duplicateSourceGoalCount": 2,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "4d662fc7-15ce-5b6d-a5a1-287b48af2145",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.15",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.15",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "a5f0cabf-b69f-541e-acb0-2745de122144",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.15",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.15",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "4a38162c-0113-5a55-9243-43521ea938bb",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.14",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.14",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.15",
+        "B13-EA.1.15",
+        "B13-GA.1.14"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.15",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.15",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.14"
+      ]
+    },
+    {
+      "id": "8a1f3103-4b49-5daa-a0d8-58723438305a",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 16,
+      "aspectIndex": 1,
+      "title": "recherchieren zu biologischen Sachverhalten und anwendungsbezogenen Fragestellungen zielgeric...",
+      "description": "recherchieren zu biologischen Sachverhalten und anwendungsbezogenen Fragestellungen zielgerichtet in analogen und digitalen Medien. Sie wählen aus für ihre Zwecke passenden Quellen relevante und aussagekräftige Informationen und Daten aus. Dabei erschließen sie Informationen aus Darstellungsformen unterschiedlicher Komplexität.",
+      "sourceText": "recherchieren zu biologischen Sachverhalten und anwendungsbezogenen Fragestellungen zielgerichtet in analogen und digitalen Medien. Sie wählen aus für ihre Zwecke passenden Quellen relevante und aussagekräftige Informationen und Daten aus. Dabei erschließen sie Informationen aus Darstellungsformen unterschiedlicher Komplexität.",
+      "sourceSpan": "B12-EA.1.16",
+      "parentBulletText": "recherchieren zu biologischen Sachverhalten und anwendungsbezogenen Fragestellungen zielgerichtet in analogen und digitalen Medien. Sie wählen aus für ihre Zwecke passenden Quellen relevante und aussagekräftige Informationen und Daten aus. Dabei erschließen sie Informationen aus Darstellungsformen unterschiedlicher Komplexität.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.16",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "recherchieren zu biologischen Sachverhalten und anwendungsbezogenen Fragestellungen zielgerichtet in analogen und digitalen Medien. Sie wählen aus für ihre Zwecke passenden Quellen relevante und aussagekräftige Informationen und Daten aus. Dabei erschließen sie Informationen aus Darstellungsformen unterschiedlicher Komplexität.",
+      "rawSourceSpan": "B12-EA.1.16",
+      "rawParentBulletText": "recherchieren zu biologischen Sachverhalten und anwendungsbezogenen Fragestellungen zielgerichtet in analogen und digitalen Medien. Sie wählen aus für ihre Zwecke passenden Quellen relevante und aussagekräftige Informationen und Daten aus. Dabei erschließen sie Informationen aus Darstellungsformen unterschiedlicher Komplexität.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "8a1f3103-4b49-5daa-a0d8-58723438305a",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.16",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.16",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "40fc91f4-78f6-5e34-b2ec-d5a50d0c0167",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.16",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.16",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "d8ab56a9-d69e-55b1-9bd7-e2a03d647374",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.16",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.16",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "03b74b0e-b66f-53f5-a492-b3140259e84f",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.15",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.15",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.16",
+        "B12-GA.1.16",
+        "B13-EA.1.16",
+        "B13-GA.1.15"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.16",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.16",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.16",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.15"
+      ]
+    },
+    {
+      "id": "9f8601f9-64b9-5ea1-9ce1-7ecd54fa2f1c",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 17,
+      "aspectIndex": 1,
+      "title": "analysieren Herkunft, Qualität und Vertrauenswürdigkeit von verwendeten Quellen und Medien so...",
+      "description": "analysieren Herkunft, Qualität und Vertrauenswürdigkeit von verwendeten Quellen und Medien sowie darin enthaltene Darstellungsformen im Zusammenhang mit der Intention der Autorin/des Autors. Sie prüfen die Übereinstimmung verschiedener Quellen im Hinblick auf deren Aussagen.",
+      "sourceText": "analysieren Herkunft, Qualität und Vertrauenswürdigkeit von verwendeten Quellen und Medien sowie darin enthaltene Darstellungsformen im Zusammenhang mit der Intention der Autorin/des Autors. Sie prüfen die Übereinstimmung verschiedener Quellen im Hinblick auf deren Aussagen.",
+      "sourceSpan": "B12-EA.1.17",
+      "parentBulletText": "analysieren Herkunft, Qualität und Vertrauenswürdigkeit von verwendeten Quellen und Medien sowie darin enthaltene Darstellungsformen im Zusammenhang mit der Intention der Autorin/des Autors. Sie prüfen die Übereinstimmung verschiedener Quellen im Hinblick auf deren Aussagen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.17",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "analysieren Herkunft, Qualität und Vertrauenswürdigkeit von verwendeten Quellen und Medien sowie darin enthaltene Darstellungsformen im Zusammenhang mit der Intention der Autorin/des Autors. Sie prüfen die Übereinstimmung verschiedener Quellen im Hinblick auf deren Aussagen.",
+      "rawSourceSpan": "B12-EA.1.17",
+      "rawParentBulletText": "analysieren Herkunft, Qualität und Vertrauenswürdigkeit von verwendeten Quellen und Medien sowie darin enthaltene Darstellungsformen im Zusammenhang mit der Intention der Autorin/des Autors. Sie prüfen die Übereinstimmung verschiedener Quellen im Hinblick auf deren Aussagen.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "9f8601f9-64b9-5ea1-9ce1-7ecd54fa2f1c",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.17",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.17",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "e87c6aa8-4684-58c0-9ec0-52736554eaba",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.17",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.17",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "d3f6771c-f4c9-5802-89dc-45c9bd9c804a",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.17",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.17",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "6e7ff2bb-b6bb-5a33-aad9-ecc1a49f03e7",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.16",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.16",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.17",
+        "B12-GA.1.17",
+        "B13-EA.1.17",
+        "B13-GA.1.16"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.17",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.17",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.17",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.16"
+      ]
+    },
+    {
+      "id": "705566d5-ceab-5a71-a17b-5d740fa9dfa0",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 18,
+      "aspectIndex": 1,
+      "title": "strukturieren und interpretieren ausgewählte Informationen und leiten Schlussfolgerungen ab. ...",
+      "description": "strukturieren und interpretieren ausgewählte Informationen und leiten Schlussfolgerungen ab. Dazu nutzen sie geeignete Darstellungsformen und überführen diese ineinander.",
+      "sourceText": "strukturieren und interpretieren ausgewählte Informationen und leiten Schlussfolgerungen ab. Dazu nutzen sie geeignete Darstellungsformen und überführen diese ineinander.",
+      "sourceSpan": "B12-EA.1.18",
+      "parentBulletText": "strukturieren und interpretieren ausgewählte Informationen und leiten Schlussfolgerungen ab. Dazu nutzen sie geeignete Darstellungsformen und überführen diese ineinander.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.18",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "strukturieren und interpretieren ausgewählte Informationen und leiten Schlussfolgerungen ab. Dazu nutzen sie geeignete Darstellungsformen und überführen diese ineinander.",
+      "rawSourceSpan": "B12-EA.1.18",
+      "rawParentBulletText": "strukturieren und interpretieren ausgewählte Informationen und leiten Schlussfolgerungen ab. Dazu nutzen sie geeignete Darstellungsformen und überführen diese ineinander.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "705566d5-ceab-5a71-a17b-5d740fa9dfa0",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.18",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.18",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "81bea83f-4870-556f-97a9-1bfc2975c57e",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.18",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.18",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "843003fc-197e-59e4-833e-0700a886754a",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.18",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.18",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "d223dc00-8695-5b22-8153-b26f43a3c5c9",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.17",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.17",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.18",
+        "B12-GA.1.18",
+        "B13-EA.1.18",
+        "B13-GA.1.17"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.18",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.18",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.18",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.17"
+      ]
+    },
+    {
+      "id": "8963b296-06f3-523a-b9e9-e3d45c3a23a6",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 19,
+      "aspectIndex": 1,
+      "title": "unterscheiden zwischen Alltags- und Fachsprache sowie zwischen funktionalen und kausalen Erkl...",
+      "description": "unterscheiden zwischen Alltags- und Fachsprache sowie zwischen funktionalen und kausalen Erklärungen. Sie erklären Sachverhalte aus proximater und ultimater Sicht, ohne dabei finale Begründungen zu nutzen.",
+      "sourceText": "unterscheiden zwischen Alltags- und Fachsprache sowie zwischen funktionalen und kausalen Erklärungen. Sie erklären Sachverhalte aus proximater und ultimater Sicht, ohne dabei finale Begründungen zu nutzen.",
+      "sourceSpan": "B12-EA.1.19",
+      "parentBulletText": "unterscheiden zwischen Alltags- und Fachsprache sowie zwischen funktionalen und kausalen Erklärungen. Sie erklären Sachverhalte aus proximater und ultimater Sicht, ohne dabei finale Begründungen zu nutzen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.19",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "unterscheiden zwischen Alltags- und Fachsprache sowie zwischen funktionalen und kausalen Erklärungen. Sie erklären Sachverhalte aus proximater und ultimater Sicht, ohne dabei finale Begründungen zu nutzen.",
+      "rawSourceSpan": "B12-EA.1.19",
+      "rawParentBulletText": "unterscheiden zwischen Alltags- und Fachsprache sowie zwischen funktionalen und kausalen Erklärungen. Sie erklären Sachverhalte aus proximater und ultimater Sicht, ohne dabei finale Begründungen zu nutzen.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "8963b296-06f3-523a-b9e9-e3d45c3a23a6",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.19",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.19",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "3487947d-ad6d-5562-9846-555d27819ba7",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.19",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.19",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "f7432493-ce2c-5245-af21-e2333a17d644",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.19",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.19",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "ef93a985-c6a1-5403-b6fd-2aa4b34e31dc",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.18",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.18",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.19",
+        "B12-GA.1.19",
+        "B13-EA.1.19",
+        "B13-GA.1.18"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.19",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.19",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.19",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.18"
+      ]
+    },
+    {
+      "id": "15ac8e5e-6111-545f-b582-0cf12d44d39a",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 20,
+      "aspectIndex": 1,
+      "title": "verarbeiten sach-, adressaten- und situationsgerecht Informationen zu biologischen Sachverhal...",
+      "description": "verarbeiten sach-, adressaten- und situationsgerecht Informationen zu biologischen Sachverhalten.",
+      "sourceText": "verarbeiten sach-, adressaten- und situationsgerecht Informationen zu biologischen Sachverhalten.",
+      "sourceSpan": "B12-EA.1.20",
+      "parentBulletText": "verarbeiten sach-, adressaten- und situationsgerecht Informationen zu biologischen Sachverhalten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.20",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "verarbeiten sach-, adressaten- und situationsgerecht Informationen zu biologischen Sachverhalten.",
+      "rawSourceSpan": "B12-EA.1.20",
+      "rawParentBulletText": "verarbeiten sach-, adressaten- und situationsgerecht Informationen zu biologischen Sachverhalten.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "15ac8e5e-6111-545f-b582-0cf12d44d39a",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.20",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.20",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "1f8bab9a-8414-563a-b993-64a395ee3523",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.20",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.20",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "ca3a37d0-d3ac-5b38-b4cb-5cb562d5b5aa",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.20",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.20",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "7c733215-41eb-5638-9951-51cd21dbec49",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.19",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.19",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.20",
+        "B12-GA.1.20",
+        "B13-EA.1.20",
+        "B13-GA.1.19"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.20",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.20",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.20",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.19"
+      ]
+    },
+    {
+      "id": "0abbbcd7-302f-5eb1-af4d-fb05e1cc949a",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 21,
+      "aspectIndex": 1,
+      "title": "präsentieren biologische Sachverhalte sowie Lern- und Arbeitsergebnisse unter Einsatz sach-, ...",
+      "description": "präsentieren biologische Sachverhalte sowie Lern- und Arbeitsergebnisse unter Einsatz sach-, adressaten- und situationsgerechter Darstellungsformen mithilfe analoger und digitaler Medien.",
+      "sourceText": "präsentieren biologische Sachverhalte sowie Lern- und Arbeitsergebnisse unter Einsatz sach-, adressaten- und situationsgerechter Darstellungsformen mithilfe analoger und digitaler Medien.",
+      "sourceSpan": "B12-EA.1.21",
+      "parentBulletText": "präsentieren biologische Sachverhalte sowie Lern- und Arbeitsergebnisse unter Einsatz sach-, adressaten- und situationsgerechter Darstellungsformen mithilfe analoger und digitaler Medien.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.21",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "präsentieren biologische Sachverhalte sowie Lern- und Arbeitsergebnisse unter Einsatz sach-, adressaten- und situationsgerechter Darstellungsformen mithilfe analoger und digitaler Medien.",
+      "rawSourceSpan": "B12-EA.1.21",
+      "rawParentBulletText": "präsentieren biologische Sachverhalte sowie Lern- und Arbeitsergebnisse unter Einsatz sach-, adressaten- und situationsgerechter Darstellungsformen mithilfe analoger und digitaler Medien.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "0abbbcd7-302f-5eb1-af4d-fb05e1cc949a",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.21",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.21",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "5299712c-d3d4-56ab-b9d0-2499835df401",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.21",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.21",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "715de813-0a5f-50f3-ad25-55799d695ae4",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.21",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.21",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "4316319c-921a-54ed-bd45-89a04a308206",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.20",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.20",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.21",
+        "B12-GA.1.21",
+        "B13-EA.1.21",
+        "B13-GA.1.20"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.21",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.21",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.21",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.20"
+      ]
+    },
+    {
+      "id": "72038809-f11a-50dd-a273-a968e0cd9dbf",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 22,
+      "aspectIndex": 1,
+      "title": "prüfen die Urheberschaft, belegen verwendete Quellen und kennzeichnen Zitate.",
+      "description": "prüfen die Urheberschaft, belegen verwendete Quellen und kennzeichnen Zitate.",
+      "sourceText": "prüfen die Urheberschaft, belegen verwendete Quellen und kennzeichnen Zitate.",
+      "sourceSpan": "B12-EA.1.22",
+      "parentBulletText": "prüfen die Urheberschaft, belegen verwendete Quellen und kennzeichnen Zitate.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.22",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "prüfen die Urheberschaft, belegen verwendete Quellen und kennzeichnen Zitate.",
+      "rawSourceSpan": "B12-EA.1.22",
+      "rawParentBulletText": "prüfen die Urheberschaft, belegen verwendete Quellen und kennzeichnen Zitate.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "72038809-f11a-50dd-a273-a968e0cd9dbf",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.22",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.22",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "695ba2ad-461e-503b-9e0d-cb24bb01f0e1",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.22",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.22",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "ef88463d-e1e3-529e-84db-d5349cc9b893",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.22",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.22",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "3493eb75-c0c4-5238-a8c5-19617d59cf15",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.21",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.21",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.22",
+        "B12-GA.1.22",
+        "B13-EA.1.22",
+        "B13-GA.1.21"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.22",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.22",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.22",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.21"
+      ]
+    },
+    {
+      "id": "089ead71-0bc3-578a-91b9-3bea7d06db52",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 23,
+      "aspectIndex": 1,
+      "title": "tauschen sich mit anderen konstruktiv über biologische Sachverhalte aus. Sie argumentieren da...",
+      "description": "tauschen sich mit anderen konstruktiv über biologische Sachverhalte aus. Sie argumentieren dabei wissenschaftlich kriterien- und evidenzbasiert sowie situationsgerecht. Sie vertreten, reflektieren und korrigieren gegebenenfalls den eigenen Standpunkt.",
+      "sourceText": "tauschen sich mit anderen konstruktiv über biologische Sachverhalte aus. Sie argumentieren dabei wissenschaftlich kriterien- und evidenzbasiert sowie situationsgerecht. Sie vertreten, reflektieren und korrigieren gegebenenfalls den eigenen Standpunkt.",
+      "sourceSpan": "B12-EA.1.23",
+      "parentBulletText": "tauschen sich mit anderen konstruktiv über biologische Sachverhalte aus. Sie argumentieren dabei wissenschaftlich kriterien- und evidenzbasiert sowie situationsgerecht. Sie vertreten, reflektieren und korrigieren gegebenenfalls den eigenen Standpunkt.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.23",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "tauschen sich mit anderen konstruktiv über biologische Sachverhalte aus. Sie argumentieren dabei wissenschaftlich kriterien- und evidenzbasiert sowie situationsgerecht. Sie vertreten, reflektieren und korrigieren gegebenenfalls den eigenen Standpunkt.",
+      "rawSourceSpan": "B12-EA.1.23",
+      "rawParentBulletText": "tauschen sich mit anderen konstruktiv über biologische Sachverhalte aus. Sie argumentieren dabei wissenschaftlich kriterien- und evidenzbasiert sowie situationsgerecht. Sie vertreten, reflektieren und korrigieren gegebenenfalls den eigenen Standpunkt.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "089ead71-0bc3-578a-91b9-3bea7d06db52",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.23",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.23",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "391b9434-8d77-502c-bec1-e020ff8f649d",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.23",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.23",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "7db7a39f-4b55-59cb-9557-c853816541d7",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.23",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.23",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "3882891e-a265-50b7-9c1b-ecc67ed7ea21",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.22",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.22",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.23",
+        "B12-GA.1.23",
+        "B13-EA.1.23",
+        "B13-GA.1.22"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.23",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.23",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.23",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.22"
+      ]
+    },
+    {
+      "id": "bcf192b7-fa63-5ac3-b13f-0039feb00b0b",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 24,
+      "aspectIndex": 1,
+      "title": "analysieren Sachverhalte im Hinblick auf ihre Bewertungsrelevanz und betrachten relevante Sac...",
+      "description": "analysieren Sachverhalte im Hinblick auf ihre Bewertungsrelevanz und betrachten relevante Sachverhalte aus unterschiedlichen Perspektiven.",
+      "sourceText": "analysieren Sachverhalte im Hinblick auf ihre Bewertungsrelevanz und betrachten relevante Sachverhalte aus unterschiedlichen Perspektiven.",
+      "sourceSpan": "B12-EA.1.24",
+      "parentBulletText": "analysieren Sachverhalte im Hinblick auf ihre Bewertungsrelevanz und betrachten relevante Sachverhalte aus unterschiedlichen Perspektiven.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.24",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "analysieren Sachverhalte im Hinblick auf ihre Bewertungsrelevanz und betrachten relevante Sachverhalte aus unterschiedlichen Perspektiven.",
+      "rawSourceSpan": "B12-EA.1.24",
+      "rawParentBulletText": "analysieren Sachverhalte im Hinblick auf ihre Bewertungsrelevanz und betrachten relevante Sachverhalte aus unterschiedlichen Perspektiven.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "bcf192b7-fa63-5ac3-b13f-0039feb00b0b",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.24",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.24",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "96612bc7-4c2d-58c7-b4c6-15a57d005b24",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.24",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.24",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "903e8c42-8b6c-5cd5-a936-75912d416265",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.24",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.24",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "df8eeb82-a117-5549-aa9b-74dd8be2c1c1",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.23",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.23",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.24",
+        "B12-GA.1.24",
+        "B13-EA.1.24",
+        "B13-GA.1.23"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.24",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.24",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.24",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.23"
+      ]
+    },
+    {
+      "id": "ebcdf533-a915-57e4-b5f9-e1b790d7f620",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 25,
+      "aspectIndex": 1,
+      "title": "unterscheiden deskriptive und normative Aussagen und identifizieren Werte, die den normativen...",
+      "description": "unterscheiden deskriptive und normative Aussagen und identifizieren Werte, die den normativen Aussagen zugrunde liegen.",
+      "sourceText": "unterscheiden deskriptive und normative Aussagen und identifizieren Werte, die den normativen Aussagen zugrunde liegen.",
+      "sourceSpan": "B12-EA.1.25",
+      "parentBulletText": "unterscheiden deskriptive und normative Aussagen und identifizieren Werte, die den normativen Aussagen zugrunde liegen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.25",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "unterscheiden deskriptive und normative Aussagen und identifizieren Werte, die den normativen Aussagen zugrunde liegen.",
+      "rawSourceSpan": "B12-EA.1.25",
+      "rawParentBulletText": "unterscheiden deskriptive und normative Aussagen und identifizieren Werte, die den normativen Aussagen zugrunde liegen.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "ebcdf533-a915-57e4-b5f9-e1b790d7f620",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.25",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.25",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "83ee8fd7-4a7f-590b-ad37-f66198d1c69d",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.25",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.25",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "dba31694-547f-572f-b5a7-dcfc6ed6a8bc",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.25",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.25",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "f30a9a94-5610-57ad-8e8f-158b5594f0e8",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.24",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.24",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.25",
+        "B12-GA.1.25",
+        "B13-EA.1.25",
+        "B13-GA.1.24"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.25",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.25",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.25",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.24"
+      ]
+    },
+    {
+      "id": "ee7bfa35-b97d-5714-8aaf-78f1184e0215",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 26,
+      "aspectIndex": 1,
+      "title": "beurteilen Quellen hinsichtlich ihrer Herkunft und in Bezug auf spezifische Interessenlagen.",
+      "description": "beurteilen Quellen hinsichtlich ihrer Herkunft und in Bezug auf spezifische Interessenlagen.",
+      "sourceText": "beurteilen Quellen hinsichtlich ihrer Herkunft und in Bezug auf spezifische Interessenlagen.",
+      "sourceSpan": "B12-EA.1.26",
+      "parentBulletText": "beurteilen Quellen hinsichtlich ihrer Herkunft und in Bezug auf spezifische Interessenlagen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.26",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "beurteilen Quellen hinsichtlich ihrer Herkunft und in Bezug auf spezifische Interessenlagen.",
+      "rawSourceSpan": "B12-EA.1.26",
+      "rawParentBulletText": "beurteilen Quellen hinsichtlich ihrer Herkunft und in Bezug auf spezifische Interessenlagen.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "ee7bfa35-b97d-5714-8aaf-78f1184e0215",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.26",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.26",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "548c86b2-e612-502e-a150-c5802717354d",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.26",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.26",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "f43cb009-829c-5e39-878e-9d0554c86852",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.26",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.26",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "326021c3-cd3f-556c-8391-e30ca0ef8fd9",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.25",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.25",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.26",
+        "B12-GA.1.26",
+        "B13-EA.1.26",
+        "B13-GA.1.25"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.26",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.26",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.26",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.25"
+      ]
+    },
+    {
+      "id": "7ea5fd68-c411-50f2-8697-711c12fa28d4",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 27,
+      "aspectIndex": 1,
+      "title": "beurteilen Möglichkeiten und Grenzen biologischer Sichtweisen.",
+      "description": "beurteilen Möglichkeiten und Grenzen biologischer Sichtweisen.",
+      "sourceText": "beurteilen Möglichkeiten und Grenzen biologischer Sichtweisen.",
+      "sourceSpan": "B12-EA.1.27",
+      "parentBulletText": "beurteilen Möglichkeiten und Grenzen biologischer Sichtweisen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.27",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "beurteilen Möglichkeiten und Grenzen biologischer Sichtweisen.",
+      "rawSourceSpan": "B12-EA.1.27",
+      "rawParentBulletText": "beurteilen Möglichkeiten und Grenzen biologischer Sichtweisen.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "7ea5fd68-c411-50f2-8697-711c12fa28d4",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.27",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.27",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "9626874c-6e4f-5c0e-8975-64e692f18df5",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.27",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.27",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "84f2bd6c-b064-5d0b-bfb6-075d89546080",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.27",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.27",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "b736e444-c293-524d-9c6f-dccd5fde3100",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.26",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.26",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.27",
+        "B12-GA.1.27",
+        "B13-EA.1.27",
+        "B13-GA.1.26"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.27",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.27",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.27",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.26"
+      ]
+    },
+    {
+      "id": "540f78e7-e84a-511b-ad72-30aaf732c529",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 28,
+      "aspectIndex": 1,
+      "title": "stellen Bewertungskriterien auf, auch unter Berücksichtigung außerfachlicher Aspekte.",
+      "description": "stellen Bewertungskriterien auf, auch unter Berücksichtigung außerfachlicher Aspekte.",
+      "sourceText": "stellen Bewertungskriterien auf, auch unter Berücksichtigung außerfachlicher Aspekte.",
+      "sourceSpan": "B12-EA.1.28",
+      "parentBulletText": "stellen Bewertungskriterien auf, auch unter Berücksichtigung außerfachlicher Aspekte.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.28",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "stellen Bewertungskriterien auf, auch unter Berücksichtigung außerfachlicher Aspekte.",
+      "rawSourceSpan": "B12-EA.1.28",
+      "rawParentBulletText": "stellen Bewertungskriterien auf, auch unter Berücksichtigung außerfachlicher Aspekte.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "540f78e7-e84a-511b-ad72-30aaf732c529",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.28",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.28",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "5d78c731-799d-57a2-a010-ef1a315cf578",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.28",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.28",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "f34ef482-880d-50d9-be77-0fbd748070f5",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.28",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.28",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "57aba262-3d81-5463-9036-a729a9b72dce",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.27",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.27",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.28",
+        "B12-GA.1.28",
+        "B13-EA.1.28",
+        "B13-GA.1.27"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.28",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.28",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.28",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.27"
+      ]
+    },
+    {
+      "id": "b8f0ab01-fc00-50df-85b0-cd19387f0731",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 29,
+      "aspectIndex": 1,
+      "title": "bilden sich kriteriengeleitet Meinungen, indem sie die Handlungsoptionen auf der Basis reflek...",
+      "description": "bilden sich kriteriengeleitet Meinungen, indem sie die Handlungsoptionen auf der Basis reflektierter Wertvorstellungen abwägen, und treffen so Entscheidungen auf der Grundlage von Sachinformationen und Werten.",
+      "sourceText": "bilden sich kriteriengeleitet Meinungen, indem sie die Handlungsoptionen auf der Basis reflektierter Wertvorstellungen abwägen, und treffen so Entscheidungen auf der Grundlage von Sachinformationen und Werten.",
+      "sourceSpan": "B12-EA.1.29",
+      "parentBulletText": "bilden sich kriteriengeleitet Meinungen, indem sie die Handlungsoptionen auf der Basis reflektierter Wertvorstellungen abwägen, und treffen so Entscheidungen auf der Grundlage von Sachinformationen und Werten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.29",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "bilden sich kriteriengeleitet Meinungen, indem sie die Handlungsoptionen auf der Basis reflektierter Wertvorstellungen abwägen, und treffen so Entscheidungen auf der Grundlage von Sachinformationen und Werten.",
+      "rawSourceSpan": "B12-EA.1.29",
+      "rawParentBulletText": "bilden sich kriteriengeleitet Meinungen, indem sie die Handlungsoptionen auf der Basis reflektierter Wertvorstellungen abwägen, und treffen so Entscheidungen auf der Grundlage von Sachinformationen und Werten.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b8f0ab01-fc00-50df-85b0-cd19387f0731",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.29",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.29",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "05891b42-92b8-54ed-b65d-8ac63fd9d5cf",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.29",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.29",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "2e8ea987-0f70-58a4-b69f-7586848f5348",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.29",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.29",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "fd37f73b-7e55-585e-97e3-56f93d8e47e0",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.28",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.28",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.29",
+        "B12-GA.1.29",
+        "B13-EA.1.29",
+        "B13-GA.1.28"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.29",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.29",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.29",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.28"
+      ]
+    },
+    {
+      "id": "be7422d3-8de7-5907-8e5f-657484b6270b",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 30,
+      "aspectIndex": 1,
+      "title": "reflektieren kurz- und langfristige, lokale und globale Folgen eigener und gesellschaftlicher...",
+      "description": "reflektieren kurz- und langfristige, lokale und globale Folgen eigener und gesellschaftlicher Entscheidungen.",
+      "sourceText": "reflektieren kurz- und langfristige, lokale und globale Folgen eigener und gesellschaftlicher Entscheidungen.",
+      "sourceSpan": "B12-EA.1.30",
+      "parentBulletText": "reflektieren kurz- und langfristige, lokale und globale Folgen eigener und gesellschaftlicher Entscheidungen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.30",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "reflektieren kurz- und langfristige, lokale und globale Folgen eigener und gesellschaftlicher Entscheidungen.",
+      "rawSourceSpan": "B12-EA.1.30",
+      "rawParentBulletText": "reflektieren kurz- und langfristige, lokale und globale Folgen eigener und gesellschaftlicher Entscheidungen.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "be7422d3-8de7-5907-8e5f-657484b6270b",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.30",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.30",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "a7a429c2-5f02-5ee8-8d29-20642caa3266",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.30",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.30",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "ffa4c385-15af-539a-ba6d-a59153643f79",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.30",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.30",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "d2177a06-3dfe-583f-af6c-aa804185c3b7",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.29",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.29",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.30",
+        "B12-GA.1.30",
+        "B13-EA.1.30",
+        "B13-GA.1.29"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.30",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.30",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.30",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.29"
+      ]
+    },
+    {
+      "id": "ab4b91cc-3e72-5413-9a0b-7144a2502e56",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 31,
+      "aspectIndex": 1,
+      "title": "reflektieren den Prozess der Bewertung aus persönlicher, gesellschaftlicher und ethischer Per...",
+      "description": "reflektieren den Prozess der Bewertung aus persönlicher, gesellschaftlicher und ethischer Perspektive.",
+      "sourceText": "reflektieren den Prozess der Bewertung aus persönlicher, gesellschaftlicher und ethischer Perspektive.",
+      "sourceSpan": "B12-EA.1.31",
+      "parentBulletText": "reflektieren den Prozess der Bewertung aus persönlicher, gesellschaftlicher und ethischer Perspektive.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.31",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "reflektieren den Prozess der Bewertung aus persönlicher, gesellschaftlicher und ethischer Perspektive.",
+      "rawSourceSpan": "B12-EA.1.31",
+      "rawParentBulletText": "reflektieren den Prozess der Bewertung aus persönlicher, gesellschaftlicher und ethischer Perspektive.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "ab4b91cc-3e72-5413-9a0b-7144a2502e56",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.31",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.31",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "1373c4f6-2e18-5f0c-bfc8-222a2e9f3d01",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.31",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.31",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "9907e7d4-7b82-56b8-b9b3-b569ec01a30f",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.31",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.31",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "52567460-331d-5c1b-86bc-fce12d4aafea",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.30",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.30",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.31",
+        "B12-GA.1.31",
+        "B13-EA.1.31",
+        "B13-GA.1.30"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.31",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.31",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.31",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.30"
+      ]
+    },
+    {
+      "id": "50f29a21-d711-596b-88cd-89399509c8d6",
+      "passageId": "by-bio:B12-EA.1",
+      "topicCode": "B12-EA.1",
+      "bulletIndex": 32,
+      "aspectIndex": 1,
+      "title": "beurteilen und bewerten Auswirkungen von Anwendungen der Biologie im Sinne einer nachhaltigen...",
+      "description": "beurteilen und bewerten Auswirkungen von Anwendungen der Biologie im Sinne einer nachhaltigen Entwicklung aus ökologischer, ökonomischer, politischer und sozialer Perspektive.",
+      "sourceText": "beurteilen und bewerten Auswirkungen von Anwendungen der Biologie im Sinne einer nachhaltigen Entwicklung aus ökologischer, ökonomischer, politischer und sozialer Perspektive.",
+      "sourceSpan": "B12-EA.1.32",
+      "parentBulletText": "beurteilen und bewerten Auswirkungen von Anwendungen der Biologie im Sinne einer nachhaltigen Entwicklung aus ökologischer, ökonomischer, politischer und sozialer Perspektive.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.32",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.1",
+        "topic:B12-GA.1",
+        "topic:B13-EA.1",
+        "topic:B13-GA.1"
+      ],
+      "rawSourceText": "beurteilen und bewerten Auswirkungen von Anwendungen der Biologie im Sinne einer nachhaltigen Entwicklung aus ökologischer, ökonomischer, politischer und sozialer Perspektive.",
+      "rawSourceSpan": "B12-EA.1.32",
+      "rawParentBulletText": "beurteilen und bewerten Auswirkungen von Anwendungen der Biologie im Sinne einer nachhaltigen Entwicklung aus ökologischer, ökonomischer, politischer und sozialer Perspektive.",
+      "duplicateSourceGoalCount": 3,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "50f29a21-d711-596b-88cd-89399509c8d6",
+          "passageId": "by-bio:B12-EA.1",
+          "topicCode": "B12-EA.1",
+          "sourceSpan": "B12-EA.1.32",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.32",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "a5e64470-6aa1-53d8-b70f-f371aa8d038f",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.32",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.32",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "d742b770-5795-51e4-bcbf-d1d16e9b0e8e",
+          "passageId": "by-bio:B13-EA.1",
+          "topicCode": "B13-EA.1",
+          "sourceSpan": "B13-EA.1.32",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.32",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.1"
+          ]
+        },
+        {
+          "sourceGoalId": "65f8a86a-6499-5931-a03a-81a6440c6027",
+          "passageId": "by-bio:B13-GA.1",
+          "topicCode": "B13-GA.1",
+          "sourceSpan": "B13-GA.1.31",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.31",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.1",
+        "B12-GA.1",
+        "B13-EA.1",
+        "B13-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.1.32",
+        "B12-GA.1.32",
+        "B13-EA.1.32",
+        "B13-GA.1.31"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.1.32",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.32",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.1.32",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.1.31"
+      ]
+    },
+    {
+      "id": "0c7566f2-be2c-5880-b132-23664d7ebf50",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "beschreiben ein Modell zum Bau der DNA und vergleichen es mit einem entsprechenden Modell zum...",
+      "description": "beschreiben ein Modell zum Bau der DNA und vergleichen es mit einem entsprechenden Modell zum Bau der RNA.",
+      "sourceText": "beschreiben ein Modell zum Bau der DNA und vergleichen es mit einem entsprechenden Modell zum Bau der RNA.",
+      "sourceSpan": "B12-EA.2.1",
+      "parentBulletText": "beschreiben ein Modell zum Bau der DNA und vergleichen es mit einem entsprechenden Modell zum Bau der RNA.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.1",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "beschreiben ein Modell zum Bau der DNA und vergleichen es mit einem entsprechenden Modell zum Bau der RNA.",
+      "rawSourceSpan": "B12-EA.2.1",
+      "rawParentBulletText": "beschreiben ein Modell zum Bau der DNA und vergleichen es mit einem entsprechenden Modell zum Bau der RNA.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "0c7566f2-be2c-5880-b132-23664d7ebf50",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.1",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "aa344f0d-3854-56e1-b8bd-b801f5264a90",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.1",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.1",
+        "B12-GA.2.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.1",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.1"
+      ]
+    },
+    {
+      "id": "39a861e6-5be9-5b14-ad36-dc85159c3ff3",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "leiten aus Basensequenzen der DNA Aminosäuresequenzen von Proteinen sowie aus der Aminosäures...",
+      "description": "leiten aus Basensequenzen der DNA Aminosäuresequenzen von Proteinen sowie aus der Aminosäuresequenz von Proteinen mögliche Basensequenzen für eine codierende DNA ab, indem sie den genetischen Code anwenden.",
+      "sourceText": "leiten aus Basensequenzen der DNA Aminosäuresequenzen von Proteinen sowie aus der Aminosäuresequenz von Proteinen mögliche Basensequenzen für eine codierende DNA ab, indem sie den genetischen Code anwenden.",
+      "sourceSpan": "B12-EA.2.2",
+      "parentBulletText": "leiten aus Basensequenzen der DNA Aminosäuresequenzen von Proteinen sowie aus der Aminosäuresequenz von Proteinen mögliche Basensequenzen für eine codierende DNA ab, indem sie den genetischen Code anwenden.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.2",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "leiten aus Basensequenzen der DNA Aminosäuresequenzen von Proteinen sowie aus der Aminosäuresequenz von Proteinen mögliche Basensequenzen für eine codierende DNA ab, indem sie den genetischen Code anwenden.",
+      "rawSourceSpan": "B12-EA.2.2",
+      "rawParentBulletText": "leiten aus Basensequenzen der DNA Aminosäuresequenzen von Proteinen sowie aus der Aminosäuresequenz von Proteinen mögliche Basensequenzen für eine codierende DNA ab, indem sie den genetischen Code anwenden.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "39a861e6-5be9-5b14-ad36-dc85159c3ff3",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.2",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "eba16efd-5384-569b-998d-4250d582b900",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.2",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.2",
+        "B12-GA.2.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.2",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.2"
+      ]
+    },
+    {
+      "id": "fab3d1ba-1f52-5f40-a682-7e6b51323fc1",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "beschreiben den Mechanismus der Bildung von Proteinen durch die Proteinbiosynthese und erklär...",
+      "description": "beschreiben den Mechanismus der Bildung von Proteinen durch die Proteinbiosynthese und erklären deren Bedeutung für das Leben.",
+      "sourceText": "beschreiben den Mechanismus der Bildung von Proteinen durch die Proteinbiosynthese und erklären deren Bedeutung für das Leben.",
+      "sourceSpan": "B12-EA.2.3",
+      "parentBulletText": "beschreiben den Mechanismus der Bildung von Proteinen durch die Proteinbiosynthese und erklären deren Bedeutung für das Leben.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.3",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "beschreiben den Mechanismus der Bildung von Proteinen durch die Proteinbiosynthese und erklären deren Bedeutung für das Leben.",
+      "rawSourceSpan": "B12-EA.2.3",
+      "rawParentBulletText": "beschreiben den Mechanismus der Bildung von Proteinen durch die Proteinbiosynthese und erklären deren Bedeutung für das Leben.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "fab3d1ba-1f52-5f40-a682-7e6b51323fc1",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.3",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "16d55f6a-3f2f-5bc9-88c7-64cade27a3a1",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.3",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.3",
+        "B12-GA.2.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.3",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.3"
+      ]
+    },
+    {
+      "id": "fdd172c5-62c9-58e4-accb-84ffe4871f9c",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "erklären die Bedeutung des alternativen Spleißens für die Erhöhung der Proteinvielfalt bei Eu...",
+      "description": "erklären die Bedeutung des alternativen Spleißens für die Erhöhung der Proteinvielfalt bei Eukaryoten, die eine Voraussetzung für Selektionsprozesse in der Evolution darstellt.",
+      "sourceText": "erklären die Bedeutung des alternativen Spleißens für die Erhöhung der Proteinvielfalt bei Eukaryoten, die eine Voraussetzung für Selektionsprozesse in der Evolution darstellt.",
+      "sourceSpan": "B12-EA.2.4",
+      "parentBulletText": "erklären die Bedeutung des alternativen Spleißens für die Erhöhung der Proteinvielfalt bei Eukaryoten, die eine Voraussetzung für Selektionsprozesse in der Evolution darstellt.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.4",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2"
+      ],
+      "rawSourceText": "erklären die Bedeutung des alternativen Spleißens für die Erhöhung der Proteinvielfalt bei Eukaryoten, die eine Voraussetzung für Selektionsprozesse in der Evolution darstellt.",
+      "rawSourceSpan": "B12-EA.2.4",
+      "rawParentBulletText": "erklären die Bedeutung des alternativen Spleißens für die Erhöhung der Proteinvielfalt bei Eukaryoten, die eine Voraussetzung für Selektionsprozesse in der Evolution darstellt.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "fdd172c5-62c9-58e4-accb-84ffe4871f9c",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.4",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.4"
+      ]
+    },
+    {
+      "id": "a1f72875-f66a-523b-b0f3-10f35e309c18",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "beschreiben den Eingriff von Viren in die Proteinbiosynthese ihres Wirts und den Vermehrungsz...",
+      "description": "beschreiben den Eingriff von Viren in die Proteinbiosynthese ihres Wirts und den Vermehrungszyklus von Viren, um Auswirkungen auf den Wirt und mögliche Therapieansätze erläutern zu können.",
+      "sourceText": "beschreiben den Eingriff von Viren in die Proteinbiosynthese ihres Wirts und den Vermehrungszyklus von Viren, um Auswirkungen auf den Wirt und mögliche Therapieansätze erläutern zu können.",
+      "sourceSpan": "B12-EA.2.5",
+      "parentBulletText": "beschreiben den Eingriff von Viren in die Proteinbiosynthese ihres Wirts und den Vermehrungszyklus von Viren, um Auswirkungen auf den Wirt und mögliche Therapieansätze erläutern zu können.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.5",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2"
+      ],
+      "rawSourceText": "beschreiben den Eingriff von Viren in die Proteinbiosynthese ihres Wirts und den Vermehrungszyklus von Viren, um Auswirkungen auf den Wirt und mögliche Therapieansätze erläutern zu können.",
+      "rawSourceSpan": "B12-EA.2.5",
+      "rawParentBulletText": "beschreiben den Eingriff von Viren in die Proteinbiosynthese ihres Wirts und den Vermehrungszyklus von Viren, um Auswirkungen auf den Wirt und mögliche Therapieansätze erläutern zu können.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "a1f72875-f66a-523b-b0f3-10f35e309c18",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.5",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.5"
+      ]
+    },
+    {
+      "id": "282c7e7c-9abb-5a5f-aba4-e9e37ef8eb2b",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "erläutern die Wirkung von Antisense-RNA auf die Proteinbiosynthese, um daraus Anwendungsmögli...",
+      "description": "erläutern die Wirkung von Antisense-RNA auf die Proteinbiosynthese, um daraus Anwendungsmöglichkeiten in der Medizin abzuleiten.",
+      "sourceText": "erläutern die Wirkung von Antisense-RNA auf die Proteinbiosynthese, um daraus Anwendungsmöglichkeiten in der Medizin abzuleiten.",
+      "sourceSpan": "B12-EA.2.6",
+      "parentBulletText": "erläutern die Wirkung von Antisense-RNA auf die Proteinbiosynthese, um daraus Anwendungsmöglichkeiten in der Medizin abzuleiten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.6",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2"
+      ],
+      "rawSourceText": "erläutern die Wirkung von Antisense-RNA auf die Proteinbiosynthese, um daraus Anwendungsmöglichkeiten in der Medizin abzuleiten.",
+      "rawSourceSpan": "B12-EA.2.6",
+      "rawParentBulletText": "erläutern die Wirkung von Antisense-RNA auf die Proteinbiosynthese, um daraus Anwendungsmöglichkeiten in der Medizin abzuleiten.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "282c7e7c-9abb-5a5f-aba4-e9e37ef8eb2b",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.6",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.6"
+      ]
+    },
+    {
+      "id": "cdfda558-fe26-54dd-a59a-2b3f74088ce7",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "leiten mögliche Angriffsorte in Prokaryoten für Antibiotika aus Unterschieden zwischen der Pr...",
+      "description": "leiten mögliche Angriffsorte in Prokaryoten für Antibiotika aus Unterschieden zwischen der Proteinbiosynthese bei Prokaryoten und Eukaryoten ab.",
+      "sourceText": "leiten mögliche Angriffsorte in Prokaryoten für Antibiotika aus Unterschieden zwischen der Proteinbiosynthese bei Prokaryoten und Eukaryoten ab.",
+      "sourceSpan": "B12-EA.2.7",
+      "parentBulletText": "leiten mögliche Angriffsorte in Prokaryoten für Antibiotika aus Unterschieden zwischen der Proteinbiosynthese bei Prokaryoten und Eukaryoten ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.7",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2"
+      ],
+      "rawSourceText": "leiten mögliche Angriffsorte in Prokaryoten für Antibiotika aus Unterschieden zwischen der Proteinbiosynthese bei Prokaryoten und Eukaryoten ab.",
+      "rawSourceSpan": "B12-EA.2.7",
+      "rawParentBulletText": "leiten mögliche Angriffsorte in Prokaryoten für Antibiotika aus Unterschieden zwischen der Proteinbiosynthese bei Prokaryoten und Eukaryoten ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "cdfda558-fe26-54dd-a59a-2b3f74088ce7",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.7",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.7"
+      ]
+    },
+    {
+      "id": "8611455a-c279-54e1-ab6e-5d19389b3b2b",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette...",
+      "description": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen und erklären die Auswirkungen der Unterbrechung einer Genwirkkette.",
+      "sourceText": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen und erklären die Auswirkungen der Unterbrechung einer Genwirkkette.",
+      "sourceSpan": "B12-EA.2.8",
+      "parentBulletText": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen und erklären die Auswirkungen der Unterbrechung einer Genwirkkette.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.8",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2"
+      ],
+      "rawSourceText": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen und erklären die Auswirkungen der Unterbrechung einer Genwirkkette.",
+      "rawSourceSpan": "B12-EA.2.8",
+      "rawParentBulletText": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen und erklären die Auswirkungen der Unterbrechung einer Genwirkkette.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "8611455a-c279-54e1-ab6e-5d19389b3b2b",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.8",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.8"
+      ]
+    },
+    {
+      "id": "925fc9a9-6e86-54ff-a294-de755d5ba47a",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 9,
+      "aspectIndex": 1,
+      "title": "beschreiben mögliche Mechanismen zur Regulation der Genaktivität, um zu erklären, warum trotz...",
+      "description": "beschreiben mögliche Mechanismen zur Regulation der Genaktivität, um zu erklären, warum trotz gleicher genetischer Ausstattung von Zellen diese unterschiedliche Eigenschaften aufweisen können und so eine flexible Anpassung an Umweltbedingungen sowie eine Entwicklung und Spezialisierung in lebendigen Systemen möglich ist.",
+      "sourceText": "beschreiben mögliche Mechanismen zur Regulation der Genaktivität, um zu erklären, warum trotz gleicher genetischer Ausstattung von Zellen diese unterschiedliche Eigenschaften aufweisen können und so eine flexible Anpassung an Umweltbedingungen sowie eine Entwicklung und Spezialisierung in lebendigen Systemen möglich ist.",
+      "sourceSpan": "B12-EA.2.9",
+      "parentBulletText": "beschreiben mögliche Mechanismen zur Regulation der Genaktivität, um zu erklären, warum trotz gleicher genetischer Ausstattung von Zellen diese unterschiedliche Eigenschaften aufweisen können und so eine flexible Anpassung an Umweltbedingungen sowie eine Entwicklung und Spezialisierung in lebendigen Systemen möglich ist.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.9",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "beschreiben mögliche Mechanismen zur Regulation der Genaktivität, um zu erklären, warum trotz gleicher genetischer Ausstattung von Zellen diese unterschiedliche Eigenschaften aufweisen können und so eine flexible Anpassung an Umweltbedingungen sowie eine Entwicklung und Spezialisierung in lebendigen Systemen möglich ist.",
+      "rawSourceSpan": "B12-EA.2.9",
+      "rawParentBulletText": "beschreiben mögliche Mechanismen zur Regulation der Genaktivität, um zu erklären, warum trotz gleicher genetischer Ausstattung von Zellen diese unterschiedliche Eigenschaften aufweisen können und so eine flexible Anpassung an Umweltbedingungen sowie eine Entwicklung und Spezialisierung in lebendigen Systemen möglich ist.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "925fc9a9-6e86-54ff-a294-de755d5ba47a",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.9",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "57b20c8e-9ab5-59a3-aa43-41b5164808af",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.5",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.9",
+        "B12-GA.2.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.9",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.5"
+      ]
+    },
+    {
+      "id": "c641a2ae-ff77-5c32-8fa4-8ef984832282",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 10,
+      "aspectIndex": 1,
+      "title": "beurteilen die Bedeutung von Stammzellen für die Forschung und für medizinische Anwendungen u...",
+      "description": "beurteilen die Bedeutung von Stammzellen für die Forschung und für medizinische Anwendungen und bewerten deren Einsatz aus ethischer Sicht.",
+      "sourceText": "beurteilen die Bedeutung von Stammzellen für die Forschung und für medizinische Anwendungen und bewerten deren Einsatz aus ethischer Sicht.",
+      "sourceSpan": "B12-EA.2.10",
+      "parentBulletText": "beurteilen die Bedeutung von Stammzellen für die Forschung und für medizinische Anwendungen und bewerten deren Einsatz aus ethischer Sicht.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.10",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "beurteilen die Bedeutung von Stammzellen für die Forschung und für medizinische Anwendungen und bewerten deren Einsatz aus ethischer Sicht.",
+      "rawSourceSpan": "B12-EA.2.10",
+      "rawParentBulletText": "beurteilen die Bedeutung von Stammzellen für die Forschung und für medizinische Anwendungen und bewerten deren Einsatz aus ethischer Sicht.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "c641a2ae-ff77-5c32-8fa4-8ef984832282",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.10",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "e1026f41-04f5-5831-9ec9-85534f7ba3e6",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.6",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.10",
+        "B12-GA.2.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.10",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.6"
+      ]
+    },
+    {
+      "id": "7e1b0310-b857-5d05-b722-acc00ec5d7cb",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 11,
+      "aspectIndex": 1,
+      "title": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polym...",
+      "description": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären. Hierbei beschreiben sie die Bedeutung von Reparaturenzymen bei der natürlichen DNA-Replikation.",
+      "sourceText": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären. Hierbei beschreiben sie die Bedeutung von Reparaturenzymen bei der natürlichen DNA-Replikation.",
+      "sourceSpan": "B12-EA.2.11",
+      "parentBulletText": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären. Hierbei beschreiben sie die Bedeutung von Reparaturenzymen bei der natürlichen DNA-Replikation.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.11",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2"
+      ],
+      "rawSourceText": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären. Hierbei beschreiben sie die Bedeutung von Reparaturenzymen bei der natürlichen DNA-Replikation.",
+      "rawSourceSpan": "B12-EA.2.11",
+      "rawParentBulletText": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären. Hierbei beschreiben sie die Bedeutung von Reparaturenzymen bei der natürlichen DNA-Replikation.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "7e1b0310-b857-5d05-b722-acc00ec5d7cb",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.11",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.11"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.11"
+      ]
+    },
+    {
+      "id": "bf1337aa-15f3-58ba-b75e-f420ec5a6fac",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 12,
+      "aspectIndex": 1,
+      "title": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, ...",
+      "description": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Reproduktion.",
+      "sourceText": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Reproduktion.",
+      "sourceSpan": "B12-EA.2.12",
+      "parentBulletText": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Reproduktion.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.12",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Reproduktion.",
+      "rawSourceSpan": "B12-EA.2.12",
+      "rawParentBulletText": "beschreiben die Phasen des Zellzyklus und erklären seine biologische Bedeutung für Wachstum, Reparatur und ungeschlechtliche Reproduktion.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "bf1337aa-15f3-58ba-b75e-f420ec5a6fac",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.12",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.12",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "aef2f082-4a13-5e06-82e7-fd1b45dc62ef",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.8",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.12",
+        "B12-GA.2.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.12",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.8"
+      ]
+    },
+    {
+      "id": "ae888e32-ca41-555b-9fe6-c00c77c234c8",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 13,
+      "aspectIndex": 1,
+      "title": "erklären am Beispiel der Tumorbildung Ursachen und Auswirkungen von Störungen des Zellzyklus ...",
+      "description": "erklären am Beispiel der Tumorbildung Ursachen und Auswirkungen von Störungen des Zellzyklus und der Apoptose auf einen Organismus.",
+      "sourceText": "erklären am Beispiel der Tumorbildung Ursachen und Auswirkungen von Störungen des Zellzyklus und der Apoptose auf einen Organismus.",
+      "sourceSpan": "B12-EA.2.13",
+      "parentBulletText": "erklären am Beispiel der Tumorbildung Ursachen und Auswirkungen von Störungen des Zellzyklus und der Apoptose auf einen Organismus.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.13",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2"
+      ],
+      "rawSourceText": "erklären am Beispiel der Tumorbildung Ursachen und Auswirkungen von Störungen des Zellzyklus und der Apoptose auf einen Organismus.",
+      "rawSourceSpan": "B12-EA.2.13",
+      "rawParentBulletText": "erklären am Beispiel der Tumorbildung Ursachen und Auswirkungen von Störungen des Zellzyklus und der Apoptose auf einen Organismus.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "ae888e32-ca41-555b-9fe6-c00c77c234c8",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.13",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.13",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.13"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.13"
+      ]
+    },
+    {
+      "id": "15143e1e-c3ac-5034-b584-5d1d036b0d7d",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 14,
+      "aspectIndex": 1,
+      "title": "beschreiben den Ablauf der Meiose bei den unterschiedlichen Geschlechtern und erklären ihre B...",
+      "description": "beschreiben den Ablauf der Meiose bei den unterschiedlichen Geschlechtern und erklären ihre Bedeutung für die geschlechtliche Fortpflanzung.",
+      "sourceText": "beschreiben den Ablauf der Meiose bei den unterschiedlichen Geschlechtern und erklären ihre Bedeutung für die geschlechtliche Fortpflanzung.",
+      "sourceSpan": "B12-EA.2.14",
+      "parentBulletText": "beschreiben den Ablauf der Meiose bei den unterschiedlichen Geschlechtern und erklären ihre Bedeutung für die geschlechtliche Fortpflanzung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.14",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "beschreiben den Ablauf der Meiose bei den unterschiedlichen Geschlechtern und erklären ihre Bedeutung für die geschlechtliche Fortpflanzung.",
+      "rawSourceSpan": "B12-EA.2.14",
+      "rawParentBulletText": "beschreiben den Ablauf der Meiose bei den unterschiedlichen Geschlechtern und erklären ihre Bedeutung für die geschlechtliche Fortpflanzung.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "15143e1e-c3ac-5034-b584-5d1d036b0d7d",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.14",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.14",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "c0b5c94f-4146-5165-b6fb-a6d07fcdf462",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.9",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.14",
+        "B12-GA.2.9"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.14",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.9"
+      ]
+    },
+    {
+      "id": "2727ed1c-a4e6-5433-8d1b-1a71b73f7139",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 15,
+      "aspectIndex": 1,
+      "title": "erklären den Zusammenhang zwischen genetischen Neukombinationsprozessen und der Evolution der...",
+      "description": "erklären den Zusammenhang zwischen genetischen Neukombinationsprozessen und der Evolution der bisherigen sowie zukünftigen Biodiversität.",
+      "sourceText": "erklären den Zusammenhang zwischen genetischen Neukombinationsprozessen und der Evolution der bisherigen sowie zukünftigen Biodiversität.",
+      "sourceSpan": "B12-EA.2.15",
+      "parentBulletText": "erklären den Zusammenhang zwischen genetischen Neukombinationsprozessen und der Evolution der bisherigen sowie zukünftigen Biodiversität.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.15",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "erklären den Zusammenhang zwischen genetischen Neukombinationsprozessen und der Evolution der bisherigen sowie zukünftigen Biodiversität.",
+      "rawSourceSpan": "B12-EA.2.15",
+      "rawParentBulletText": "erklären den Zusammenhang zwischen genetischen Neukombinationsprozessen und der Evolution der bisherigen sowie zukünftigen Biodiversität.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "2727ed1c-a4e6-5433-8d1b-1a71b73f7139",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.15",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.15",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "2200aade-7a5d-5ccd-86fc-4ba646ff320d",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.10",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.15",
+        "B12-GA.2.10"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.15",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.10"
+      ]
+    },
+    {
+      "id": "50786132-04c6-5b1a-8639-30977924532e",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 16,
+      "aspectIndex": 1,
+      "title": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschre...",
+      "description": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen auf verschiedenen Organisationsebenen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.",
+      "sourceText": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen auf verschiedenen Organisationsebenen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.",
+      "sourceSpan": "B12-EA.2.16",
+      "parentBulletText": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen auf verschiedenen Organisationsebenen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.16",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2"
+      ],
+      "rawSourceText": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen auf verschiedenen Organisationsebenen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.",
+      "rawSourceSpan": "B12-EA.2.16",
+      "rawParentBulletText": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen auf verschiedenen Organisationsebenen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "50786132-04c6-5b1a-8639-30977924532e",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.16",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.16",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.16"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.16"
+      ]
+    },
+    {
+      "id": "ef3a58c6-09b3-5e91-80a0-fb3857268603",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 17,
+      "aspectIndex": 1,
+      "title": "unterscheiden verschiedene durch mutagene Einflüsse ausgelöste Genmutationen und erläutern de...",
+      "description": "unterscheiden verschiedene durch mutagene Einflüsse ausgelöste Genmutationen und erläutern deren Auswirkung auf die Funktion des codierten Proteins, um für die Bedeutung des Schutzes vor mutagenen Einflüssen sensibilisiert zu sein.",
+      "sourceText": "unterscheiden verschiedene durch mutagene Einflüsse ausgelöste Genmutationen und erläutern deren Auswirkung auf die Funktion des codierten Proteins, um für die Bedeutung des Schutzes vor mutagenen Einflüssen sensibilisiert zu sein.",
+      "sourceSpan": "B12-EA.2.17",
+      "parentBulletText": "unterscheiden verschiedene durch mutagene Einflüsse ausgelöste Genmutationen und erläutern deren Auswirkung auf die Funktion des codierten Proteins, um für die Bedeutung des Schutzes vor mutagenen Einflüssen sensibilisiert zu sein.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.17",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "unterscheiden verschiedene durch mutagene Einflüsse ausgelöste Genmutationen und erläutern deren Auswirkung auf die Funktion des codierten Proteins, um für die Bedeutung des Schutzes vor mutagenen Einflüssen sensibilisiert zu sein.",
+      "rawSourceSpan": "B12-EA.2.17",
+      "rawParentBulletText": "unterscheiden verschiedene durch mutagene Einflüsse ausgelöste Genmutationen und erläutern deren Auswirkung auf die Funktion des codierten Proteins, um für die Bedeutung des Schutzes vor mutagenen Einflüssen sensibilisiert zu sein.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "ef3a58c6-09b3-5e91-80a0-fb3857268603",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.17",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.17",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "f1cd45f3-3468-57fd-b104-4c8d2ddc0350",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.12",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.12",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.17",
+        "B12-GA.2.12"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.17",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.12"
+      ]
+    },
+    {
+      "id": "8509c74f-0657-555e-92f5-b01c7f298eee",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 18,
+      "aspectIndex": 1,
+      "title": "erläutern die prinzipielle Verfahrensweise und eine konkrete Technik zur künstlichen Veränder...",
+      "description": "erläutern die prinzipielle Verfahrensweise und eine konkrete Technik zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.",
+      "sourceText": "erläutern die prinzipielle Verfahrensweise und eine konkrete Technik zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.",
+      "sourceSpan": "B12-EA.2.18",
+      "parentBulletText": "erläutern die prinzipielle Verfahrensweise und eine konkrete Technik zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.18",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2"
+      ],
+      "rawSourceText": "erläutern die prinzipielle Verfahrensweise und eine konkrete Technik zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.",
+      "rawSourceSpan": "B12-EA.2.18",
+      "rawParentBulletText": "erläutern die prinzipielle Verfahrensweise und eine konkrete Technik zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "8509c74f-0657-555e-92f5-b01c7f298eee",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.18",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.18",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.18"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.18"
+      ]
+    },
+    {
+      "id": "f50c0050-ccf5-51e0-b0b4-05b89c659b82",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 19,
+      "aspectIndex": 1,
+      "title": "werten (ggf. selbst durchgeführte) Kreuzungsexperimente aus, um den statistischen Charakter d...",
+      "description": "werten (ggf. selbst durchgeführte) Kreuzungsexperimente aus, um den statistischen Charakter der Vererbung abzuleiten.",
+      "sourceText": "werten (ggf. selbst durchgeführte) Kreuzungsexperimente aus, um den statistischen Charakter der Vererbung abzuleiten.",
+      "sourceSpan": "B12-EA.2.19",
+      "parentBulletText": "werten (ggf. selbst durchgeführte) Kreuzungsexperimente aus, um den statistischen Charakter der Vererbung abzuleiten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.19",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2"
+      ],
+      "rawSourceText": "werten (ggf. selbst durchgeführte) Kreuzungsexperimente aus, um den statistischen Charakter der Vererbung abzuleiten.",
+      "rawSourceSpan": "B12-EA.2.19",
+      "rawParentBulletText": "werten (ggf. selbst durchgeführte) Kreuzungsexperimente aus, um den statistischen Charakter der Vererbung abzuleiten.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f50c0050-ccf5-51e0-b0b4-05b89c659b82",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.19",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.19",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.19"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.19"
+      ]
+    },
+    {
+      "id": "94009a44-3060-505a-876e-18e92796e0f5",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 20,
+      "aspectIndex": 1,
+      "title": "treffen Vorhersagen zur Genotypen- und Phänotypenverteilung bei Kreuzungen, indem sie Gesetzm...",
+      "description": "treffen Vorhersagen zur Genotypen- und Phänotypenverteilung bei Kreuzungen, indem sie Gesetzmäßigkeiten der Vererbung auf mono- und dihybride Erbgänge anwenden.",
+      "sourceText": "treffen Vorhersagen zur Genotypen- und Phänotypenverteilung bei Kreuzungen, indem sie Gesetzmäßigkeiten der Vererbung auf mono- und dihybride Erbgänge anwenden.",
+      "sourceSpan": "B12-EA.2.20",
+      "parentBulletText": "treffen Vorhersagen zur Genotypen- und Phänotypenverteilung bei Kreuzungen, indem sie Gesetzmäßigkeiten der Vererbung auf mono- und dihybride Erbgänge anwenden.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.20",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "treffen Vorhersagen zur Genotypen- und Phänotypenverteilung bei Kreuzungen, indem sie Gesetzmäßigkeiten der Vererbung auf mono- und dihybride Erbgänge anwenden.",
+      "rawSourceSpan": "B12-EA.2.20",
+      "rawParentBulletText": "treffen Vorhersagen zur Genotypen- und Phänotypenverteilung bei Kreuzungen, indem sie Gesetzmäßigkeiten der Vererbung auf mono- und dihybride Erbgänge anwenden.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "94009a44-3060-505a-876e-18e92796e0f5",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.20",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.20",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "adab638f-8d3f-5bde-860d-4dc6d233f01b",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.14",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.14",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.20",
+        "B12-GA.2.14"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.20",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.14"
+      ]
+    },
+    {
+      "id": "71c14f91-5d14-5c88-aba2-d149fec0812f",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 21,
+      "aspectIndex": 1,
+      "title": "erklären den direkten Einfluss von Umweltbedingungen auf die Genaktivität der nächsten Genera...",
+      "description": "erklären den direkten Einfluss von Umweltbedingungen auf die Genaktivität der nächsten Generation als Folge epigenetischer Regulationsmechanismen.",
+      "sourceText": "erklären den direkten Einfluss von Umweltbedingungen auf die Genaktivität der nächsten Generation als Folge epigenetischer Regulationsmechanismen.",
+      "sourceSpan": "B12-EA.2.21",
+      "parentBulletText": "erklären den direkten Einfluss von Umweltbedingungen auf die Genaktivität der nächsten Generation als Folge epigenetischer Regulationsmechanismen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.21",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2"
+      ],
+      "rawSourceText": "erklären den direkten Einfluss von Umweltbedingungen auf die Genaktivität der nächsten Generation als Folge epigenetischer Regulationsmechanismen.",
+      "rawSourceSpan": "B12-EA.2.21",
+      "rawParentBulletText": "erklären den direkten Einfluss von Umweltbedingungen auf die Genaktivität der nächsten Generation als Folge epigenetischer Regulationsmechanismen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "71c14f91-5d14-5c88-aba2-d149fec0812f",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.21",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.21",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.21"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.21"
+      ]
+    },
+    {
+      "id": "716c9998-c11d-5399-be7f-57ff3aa69870",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 22,
+      "aspectIndex": 1,
+      "title": "beschreiben die Veränderung des Wissens und die Bedeutung neuer Erkenntnisse bei der Erklärun...",
+      "description": "beschreiben die Veränderung des Wissens und die Bedeutung neuer Erkenntnisse bei der Erklärung von biologischen Phänomenen am Beispiel der Aufdeckung von Gesetzmäßigkeiten der Vererbung.",
+      "sourceText": "beschreiben die Veränderung des Wissens und die Bedeutung neuer Erkenntnisse bei der Erklärung von biologischen Phänomenen am Beispiel der Aufdeckung von Gesetzmäßigkeiten der Vererbung.",
+      "sourceSpan": "B12-EA.2.22",
+      "parentBulletText": "beschreiben die Veränderung des Wissens und die Bedeutung neuer Erkenntnisse bei der Erklärung von biologischen Phänomenen am Beispiel der Aufdeckung von Gesetzmäßigkeiten der Vererbung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.22",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "beschreiben die Veränderung des Wissens und die Bedeutung neuer Erkenntnisse bei der Erklärung von biologischen Phänomenen am Beispiel der Aufdeckung von Gesetzmäßigkeiten der Vererbung.",
+      "rawSourceSpan": "B12-EA.2.22",
+      "rawParentBulletText": "beschreiben die Veränderung des Wissens und die Bedeutung neuer Erkenntnisse bei der Erklärung von biologischen Phänomenen am Beispiel der Aufdeckung von Gesetzmäßigkeiten der Vererbung.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "716c9998-c11d-5399-be7f-57ff3aa69870",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.22",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.22",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "540356e1-46d0-581a-b631-917a6dbd09b4",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.15",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.15",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.22",
+        "B12-GA.2.15"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.22",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.15"
+      ]
+    },
+    {
+      "id": "f368e24c-c167-5f00-82ba-2bbab5597740",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 23,
+      "aspectIndex": 1,
+      "title": "analysieren Erbgänge mithilfe von Familienstammbäumen und treffen so Vorhersagen über Wahrsch...",
+      "description": "analysieren Erbgänge mithilfe von Familienstammbäumen und treffen so Vorhersagen über Wahrscheinlichkeiten des Auftretens unterschiedlicher genetisch bedingter Krankheiten.",
+      "sourceText": "analysieren Erbgänge mithilfe von Familienstammbäumen und treffen so Vorhersagen über Wahrscheinlichkeiten des Auftretens unterschiedlicher genetisch bedingter Krankheiten.",
+      "sourceSpan": "B12-EA.2.23",
+      "parentBulletText": "analysieren Erbgänge mithilfe von Familienstammbäumen und treffen so Vorhersagen über Wahrscheinlichkeiten des Auftretens unterschiedlicher genetisch bedingter Krankheiten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.23",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "analysieren Erbgänge mithilfe von Familienstammbäumen und treffen so Vorhersagen über Wahrscheinlichkeiten des Auftretens unterschiedlicher genetisch bedingter Krankheiten.",
+      "rawSourceSpan": "B12-EA.2.23",
+      "rawParentBulletText": "analysieren Erbgänge mithilfe von Familienstammbäumen und treffen so Vorhersagen über Wahrscheinlichkeiten des Auftretens unterschiedlicher genetisch bedingter Krankheiten.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f368e24c-c167-5f00-82ba-2bbab5597740",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.23",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.23",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "35e1d7af-88d4-522b-bdbb-04bc7aefaf3a",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.16",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.16",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.23",
+        "B12-GA.2.16"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.23",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.16"
+      ]
+    },
+    {
+      "id": "b1eb1baa-2859-5fdc-9737-2220be2b6da3",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 24,
+      "aspectIndex": 1,
+      "title": "grenzen Methoden der genetischen Familienberatung gegeneinander ab, um ihre Vor- und Nachteil...",
+      "description": "grenzen Methoden der genetischen Familienberatung gegeneinander ab, um ihre Vor- und Nachteile zu bewerten und in entsprechenden Entscheidungssituationen eine begründete Entscheidung auch aus ethischer Sicht treffen zu können.",
+      "sourceText": "grenzen Methoden der genetischen Familienberatung gegeneinander ab, um ihre Vor- und Nachteile zu bewerten und in entsprechenden Entscheidungssituationen eine begründete Entscheidung auch aus ethischer Sicht treffen zu können.",
+      "sourceSpan": "B12-EA.2.24",
+      "parentBulletText": "grenzen Methoden der genetischen Familienberatung gegeneinander ab, um ihre Vor- und Nachteile zu bewerten und in entsprechenden Entscheidungssituationen eine begründete Entscheidung auch aus ethischer Sicht treffen zu können.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.24",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "grenzen Methoden der genetischen Familienberatung gegeneinander ab, um ihre Vor- und Nachteile zu bewerten und in entsprechenden Entscheidungssituationen eine begründete Entscheidung auch aus ethischer Sicht treffen zu können.",
+      "rawSourceSpan": "B12-EA.2.24",
+      "rawParentBulletText": "grenzen Methoden der genetischen Familienberatung gegeneinander ab, um ihre Vor- und Nachteile zu bewerten und in entsprechenden Entscheidungssituationen eine begründete Entscheidung auch aus ethischer Sicht treffen zu können.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b1eb1baa-2859-5fdc-9737-2220be2b6da3",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.24",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.24",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "0d751669-f348-5d55-90d5-be4a86e23f2a",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.17",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.17",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.24",
+        "B12-GA.2.17"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.24",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.17"
+      ]
+    },
+    {
+      "id": "43240b1a-10e4-5c51-ad89-92dbed53d3f1",
+      "passageId": "by-bio:B12-EA.2",
+      "topicCode": "B12-EA.2",
+      "bulletIndex": 25,
+      "aspectIndex": 1,
+      "title": "erläutern die Bedeutung der DNA-Analytik beim Menschen in medizinischen sowie gesellschaftlic...",
+      "description": "erläutern die Bedeutung der DNA-Analytik beim Menschen in medizinischen sowie gesellschaftlichen Kontexten. Sie analysieren und bewerten die DNA-Analytik unter ethischen Gesichtspunkten.",
+      "sourceText": "erläutern die Bedeutung der DNA-Analytik beim Menschen in medizinischen sowie gesellschaftlichen Kontexten. Sie analysieren und bewerten die DNA-Analytik unter ethischen Gesichtspunkten.",
+      "sourceSpan": "B12-EA.2.25",
+      "parentBulletText": "erläutern die Bedeutung der DNA-Analytik beim Menschen in medizinischen sowie gesellschaftlichen Kontexten. Sie analysieren und bewerten die DNA-Analytik unter ethischen Gesichtspunkten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.25",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.2",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "erläutern die Bedeutung der DNA-Analytik beim Menschen in medizinischen sowie gesellschaftlichen Kontexten. Sie analysieren und bewerten die DNA-Analytik unter ethischen Gesichtspunkten.",
+      "rawSourceSpan": "B12-EA.2.25",
+      "rawParentBulletText": "erläutern die Bedeutung der DNA-Analytik beim Menschen in medizinischen sowie gesellschaftlichen Kontexten. Sie analysieren und bewerten die DNA-Analytik unter ethischen Gesichtspunkten.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "43240b1a-10e4-5c51-ad89-92dbed53d3f1",
+          "passageId": "by-bio:B12-EA.2",
+          "topicCode": "B12-EA.2",
+          "sourceSpan": "B12-EA.2.25",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.25",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "ab51d4be-cbe9-5381-885c-01c818731656",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.18",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.18",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.2",
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.2.25",
+        "B12-GA.2.18"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.2.25",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.18"
+      ]
+    },
+    {
+      "id": "550a30ba-48e0-5822-8733-38683473e37e",
+      "passageId": "by-bio:B12-EA.3",
+      "topicCode": "B12-EA.3",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "erstellen für ausgewählte Gruppen von Lebewesen einen Stammbaum (auch Kladogramm), indem sie ...",
+      "description": "erstellen für ausgewählte Gruppen von Lebewesen einen Stammbaum (auch Kladogramm), indem sie molekulare Merkmale vergleichen.",
+      "sourceText": "erstellen für ausgewählte Gruppen von Lebewesen einen Stammbaum (auch Kladogramm), indem sie molekulare Merkmale vergleichen.",
+      "sourceSpan": "B12-EA.3.1",
+      "parentBulletText": "erstellen für ausgewählte Gruppen von Lebewesen einen Stammbaum (auch Kladogramm), indem sie molekulare Merkmale vergleichen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.1",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.3",
+        "topic:B12-GA.3"
+      ],
+      "rawSourceText": "erstellen für ausgewählte Gruppen von Lebewesen einen Stammbaum (auch Kladogramm), indem sie molekulare Merkmale vergleichen.",
+      "rawSourceSpan": "B12-EA.3.1",
+      "rawParentBulletText": "erstellen für ausgewählte Gruppen von Lebewesen einen Stammbaum (auch Kladogramm), indem sie molekulare Merkmale vergleichen.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "550a30ba-48e0-5822-8733-38683473e37e",
+          "passageId": "by-bio:B12-EA.3",
+          "topicCode": "B12-EA.3",
+          "sourceSpan": "B12-EA.3.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.1",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "6070f87e-700f-5b57-9081-71d5f71975a4",
+          "passageId": "by-bio:B12-GA.3",
+          "topicCode": "B12-GA.3",
+          "sourceSpan": "B12-GA.3.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.1",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.3",
+        "B12-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.3.1",
+        "B12-GA.3.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.1",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.1"
+      ]
+    },
+    {
+      "id": "57f30f58-36b5-5cc6-8ae3-32d20bcdd6fb",
+      "passageId": "by-bio:B12-EA.3",
+      "topicCode": "B12-EA.3",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "vergleichen unterschiedliche historische und aktuelle Ansätze zur Systematisierung von Lebewe...",
+      "description": "vergleichen unterschiedliche historische und aktuelle Ansätze zur Systematisierung von Lebewesen und beurteilen deren Aussagekraft.",
+      "sourceText": "vergleichen unterschiedliche historische und aktuelle Ansätze zur Systematisierung von Lebewesen und beurteilen deren Aussagekraft.",
+      "sourceSpan": "B12-EA.3.2",
+      "parentBulletText": "vergleichen unterschiedliche historische und aktuelle Ansätze zur Systematisierung von Lebewesen und beurteilen deren Aussagekraft.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.2",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.3",
+        "topic:B12-GA.3"
+      ],
+      "rawSourceText": "vergleichen unterschiedliche historische und aktuelle Ansätze zur Systematisierung von Lebewesen und beurteilen deren Aussagekraft.",
+      "rawSourceSpan": "B12-EA.3.2",
+      "rawParentBulletText": "vergleichen unterschiedliche historische und aktuelle Ansätze zur Systematisierung von Lebewesen und beurteilen deren Aussagekraft.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "57f30f58-36b5-5cc6-8ae3-32d20bcdd6fb",
+          "passageId": "by-bio:B12-EA.3",
+          "topicCode": "B12-EA.3",
+          "sourceSpan": "B12-EA.3.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.2",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "b6f0ffeb-cb42-5b59-9828-83b3bf24d6b2",
+          "passageId": "by-bio:B12-GA.3",
+          "topicCode": "B12-GA.3",
+          "sourceSpan": "B12-GA.3.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.2",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.3",
+        "B12-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.3.2",
+        "B12-GA.3.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.2",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.2"
+      ]
+    },
+    {
+      "id": "b201be13-27a4-5d82-b407-85e930e3a7fa",
+      "passageId": "by-bio:B12-EA.3",
+      "topicCode": "B12-EA.3",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "bestimmen unterschiedliche Tier- und Pflanzenarten.",
+      "description": "bestimmen unterschiedliche Tier- und Pflanzenarten.",
+      "sourceText": "bestimmen unterschiedliche Tier- und Pflanzenarten.",
+      "sourceSpan": "B12-EA.3.3",
+      "parentBulletText": "bestimmen unterschiedliche Tier- und Pflanzenarten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.3",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.3",
+        "topic:B12-GA.3"
+      ],
+      "rawSourceText": "bestimmen unterschiedliche Tier- und Pflanzenarten.",
+      "rawSourceSpan": "B12-EA.3.3",
+      "rawParentBulletText": "bestimmen unterschiedliche Tier- und Pflanzenarten.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b201be13-27a4-5d82-b407-85e930e3a7fa",
+          "passageId": "by-bio:B12-EA.3",
+          "topicCode": "B12-EA.3",
+          "sourceSpan": "B12-EA.3.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.3",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "18555578-2d98-598b-b601-4ffee0ce4de7",
+          "passageId": "by-bio:B12-GA.3",
+          "topicCode": "B12-GA.3",
+          "sourceSpan": "B12-GA.3.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.3",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.3",
+        "B12-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.3.3",
+        "B12-GA.3.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.3",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.3"
+      ]
+    },
+    {
+      "id": "851e9fa5-7931-5c0b-95f0-6a82b0a19382",
+      "passageId": "by-bio:B12-EA.3",
+      "topicCode": "B12-EA.3",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "beurteilen die Aussagekraft verschiedener Erklärungsansätze zu Mechanismen der Evolution und ...",
+      "description": "beurteilen die Aussagekraft verschiedener Erklärungsansätze zu Mechanismen der Evolution und überprüfen ihre Vereinbarkeit mit dem heutigen Wissensstand der Genetik.",
+      "sourceText": "beurteilen die Aussagekraft verschiedener Erklärungsansätze zu Mechanismen der Evolution und überprüfen ihre Vereinbarkeit mit dem heutigen Wissensstand der Genetik.",
+      "sourceSpan": "B12-EA.3.4",
+      "parentBulletText": "beurteilen die Aussagekraft verschiedener Erklärungsansätze zu Mechanismen der Evolution und überprüfen ihre Vereinbarkeit mit dem heutigen Wissensstand der Genetik.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.4",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.3",
+        "topic:B12-GA.3"
+      ],
+      "rawSourceText": "beurteilen die Aussagekraft verschiedener Erklärungsansätze zu Mechanismen der Evolution und überprüfen ihre Vereinbarkeit mit dem heutigen Wissensstand der Genetik.",
+      "rawSourceSpan": "B12-EA.3.4",
+      "rawParentBulletText": "beurteilen die Aussagekraft verschiedener Erklärungsansätze zu Mechanismen der Evolution und überprüfen ihre Vereinbarkeit mit dem heutigen Wissensstand der Genetik.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "851e9fa5-7931-5c0b-95f0-6a82b0a19382",
+          "passageId": "by-bio:B12-EA.3",
+          "topicCode": "B12-EA.3",
+          "sourceSpan": "B12-EA.3.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.4",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "f2ff89cd-06e4-55a5-a880-73847466736b",
+          "passageId": "by-bio:B12-GA.3",
+          "topicCode": "B12-GA.3",
+          "sourceSpan": "B12-GA.3.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.4",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.3",
+        "B12-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.3.4",
+        "B12-GA.3.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.4",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.4"
+      ]
+    },
+    {
+      "id": "eaab3236-03ce-5029-b5c5-88ee3115224e",
+      "passageId": "by-bio:B12-EA.3",
+      "topicCode": "B12-EA.3",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die E...",
+      "description": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten u. a. in der Ordnung der Primaten als Zusammenspiel der Evolutionsfaktoren zu erklären.",
+      "sourceText": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten u. a. in der Ordnung der Primaten als Zusammenspiel der Evolutionsfaktoren zu erklären.",
+      "sourceSpan": "B12-EA.3.5",
+      "parentBulletText": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten u. a. in der Ordnung der Primaten als Zusammenspiel der Evolutionsfaktoren zu erklären.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.5",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.3"
+      ],
+      "rawSourceText": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten u. a. in der Ordnung der Primaten als Zusammenspiel der Evolutionsfaktoren zu erklären.",
+      "rawSourceSpan": "B12-EA.3.5",
+      "rawParentBulletText": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten u. a. in der Ordnung der Primaten als Zusammenspiel der Evolutionsfaktoren zu erklären.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "eaab3236-03ce-5029-b5c5-88ee3115224e",
+          "passageId": "by-bio:B12-EA.3",
+          "topicCode": "B12-EA.3",
+          "sourceSpan": "B12-EA.3.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.5",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.3"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.3.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.5"
+      ]
+    },
+    {
+      "id": "fc865de8-bde4-5d64-a5f6-91718b8296a2",
+      "passageId": "by-bio:B12-EA.3",
+      "topicCode": "B12-EA.3",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "erklären u. a. auch beim Menschen wechselseitige Angepasstheiten zwischen interagierenden art...",
+      "description": "erklären u. a. auch beim Menschen wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.",
+      "sourceText": "erklären u. a. auch beim Menschen wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.",
+      "sourceSpan": "B12-EA.3.6",
+      "parentBulletText": "erklären u. a. auch beim Menschen wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.6",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.3"
+      ],
+      "rawSourceText": "erklären u. a. auch beim Menschen wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.",
+      "rawSourceSpan": "B12-EA.3.6",
+      "rawParentBulletText": "erklären u. a. auch beim Menschen wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "fc865de8-bde4-5d64-a5f6-91718b8296a2",
+          "passageId": "by-bio:B12-EA.3",
+          "topicCode": "B12-EA.3",
+          "sourceSpan": "B12-EA.3.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.6",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.3"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.3.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.6"
+      ]
+    },
+    {
+      "id": "0cc6db35-8c8c-5819-8fab-a5d5553f1ab2",
+      "passageId": "by-bio:B12-EA.3",
+      "topicCode": "B12-EA.3",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "leiten Selektionsvorteile des Menschen ab, die sich durch die v. a. sprachliche Weitergabe vo...",
+      "description": "leiten Selektionsvorteile des Menschen ab, die sich durch die v. a. sprachliche Weitergabe von erlerntem Verhalten und Wissen an andere und an nachfolgende Generationen ergeben und erklären so die Bedeutung der sozialen und kulturellen Evolution des Menschen und seine weltweite Verbreitung.",
+      "sourceText": "leiten Selektionsvorteile des Menschen ab, die sich durch die v. a. sprachliche Weitergabe von erlerntem Verhalten und Wissen an andere und an nachfolgende Generationen ergeben und erklären so die Bedeutung der sozialen und kulturellen Evolution des Menschen und seine weltweite Verbreitung.",
+      "sourceSpan": "B12-EA.3.7",
+      "parentBulletText": "leiten Selektionsvorteile des Menschen ab, die sich durch die v. a. sprachliche Weitergabe von erlerntem Verhalten und Wissen an andere und an nachfolgende Generationen ergeben und erklären so die Bedeutung der sozialen und kulturellen Evolution des Menschen und seine weltweite Verbreitung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.7",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.3"
+      ],
+      "rawSourceText": "leiten Selektionsvorteile des Menschen ab, die sich durch die v. a. sprachliche Weitergabe von erlerntem Verhalten und Wissen an andere und an nachfolgende Generationen ergeben und erklären so die Bedeutung der sozialen und kulturellen Evolution des Menschen und seine weltweite Verbreitung.",
+      "rawSourceSpan": "B12-EA.3.7",
+      "rawParentBulletText": "leiten Selektionsvorteile des Menschen ab, die sich durch die v. a. sprachliche Weitergabe von erlerntem Verhalten und Wissen an andere und an nachfolgende Generationen ergeben und erklären so die Bedeutung der sozialen und kulturellen Evolution des Menschen und seine weltweite Verbreitung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "0cc6db35-8c8c-5819-8fab-a5d5553f1ab2",
+          "passageId": "by-bio:B12-EA.3",
+          "topicCode": "B12-EA.3",
+          "sourceSpan": "B12-EA.3.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.7",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.3"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.3.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.7"
+      ]
+    },
+    {
+      "id": "37f54cd5-3abd-53ae-8be4-9568258f1cf0",
+      "passageId": "by-bio:B12-EA.3",
+      "topicCode": "B12-EA.3",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "beschreiben, wie der Mensch seine Umwelt an seine Bedürfnisse aktiv anpasst, vergleichen dies...",
+      "description": "beschreiben, wie der Mensch seine Umwelt an seine Bedürfnisse aktiv anpasst, vergleichen dies mit den Mechanismen zur Entstehung von Angepasstheiten durch die natürliche Selektion und zeigen Grenzen und Gefahren eines menschlichen Eingriffs in natürliche Evolutionsprozesse auf.",
+      "sourceText": "beschreiben, wie der Mensch seine Umwelt an seine Bedürfnisse aktiv anpasst, vergleichen dies mit den Mechanismen zur Entstehung von Angepasstheiten durch die natürliche Selektion und zeigen Grenzen und Gefahren eines menschlichen Eingriffs in natürliche Evolutionsprozesse auf.",
+      "sourceSpan": "B12-EA.3.8",
+      "parentBulletText": "beschreiben, wie der Mensch seine Umwelt an seine Bedürfnisse aktiv anpasst, vergleichen dies mit den Mechanismen zur Entstehung von Angepasstheiten durch die natürliche Selektion und zeigen Grenzen und Gefahren eines menschlichen Eingriffs in natürliche Evolutionsprozesse auf.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.8",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.3"
+      ],
+      "rawSourceText": "beschreiben, wie der Mensch seine Umwelt an seine Bedürfnisse aktiv anpasst, vergleichen dies mit den Mechanismen zur Entstehung von Angepasstheiten durch die natürliche Selektion und zeigen Grenzen und Gefahren eines menschlichen Eingriffs in natürliche Evolutionsprozesse auf.",
+      "rawSourceSpan": "B12-EA.3.8",
+      "rawParentBulletText": "beschreiben, wie der Mensch seine Umwelt an seine Bedürfnisse aktiv anpasst, vergleichen dies mit den Mechanismen zur Entstehung von Angepasstheiten durch die natürliche Selektion und zeigen Grenzen und Gefahren eines menschlichen Eingriffs in natürliche Evolutionsprozesse auf.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "37f54cd5-3abd-53ae-8be4-9568258f1cf0",
+          "passageId": "by-bio:B12-EA.3",
+          "topicCode": "B12-EA.3",
+          "sourceSpan": "B12-EA.3.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.8",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.3"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.3.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.3.8"
+      ]
+    },
+    {
+      "id": "1a12e377-cf64-553b-aac5-56e6591a3c19",
+      "passageId": "by-bio:B12-EA.4",
+      "topicCode": "B12-EA.4",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "erklären das Auftreten verschiedener Verhaltensweisen, indem sie deren Einfluss auf die Gesam...",
+      "description": "erklären das Auftreten verschiedener Verhaltensweisen, indem sie deren Einfluss auf die Gesamtfitness des Lebewesens beurteilen.",
+      "sourceText": "erklären das Auftreten verschiedener Verhaltensweisen, indem sie deren Einfluss auf die Gesamtfitness des Lebewesens beurteilen.",
+      "sourceSpan": "B12-EA.4.1",
+      "parentBulletText": "erklären das Auftreten verschiedener Verhaltensweisen, indem sie deren Einfluss auf die Gesamtfitness des Lebewesens beurteilen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.4.1",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.4",
+        "topic:B12-GA.4"
+      ],
+      "rawSourceText": "erklären das Auftreten verschiedener Verhaltensweisen, indem sie deren Einfluss auf die Gesamtfitness des Lebewesens beurteilen.",
+      "rawSourceSpan": "B12-EA.4.1",
+      "rawParentBulletText": "erklären das Auftreten verschiedener Verhaltensweisen, indem sie deren Einfluss auf die Gesamtfitness des Lebewesens beurteilen.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "1a12e377-cf64-553b-aac5-56e6591a3c19",
+          "passageId": "by-bio:B12-EA.4",
+          "topicCode": "B12-EA.4",
+          "sourceSpan": "B12-EA.4.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.4.1",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.4"
+          ]
+        },
+        {
+          "sourceGoalId": "631dc286-59e6-58a4-b7bf-da263388c31e",
+          "passageId": "by-bio:B12-GA.4",
+          "topicCode": "B12-GA.4",
+          "sourceSpan": "B12-GA.4.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.4.1",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.4",
+        "B12-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.4.1",
+        "B12-GA.4.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.4.1",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.4.1"
+      ]
+    },
+    {
+      "id": "317634d4-e406-5105-81a2-b46fa315cdc1",
+      "passageId": "by-bio:B12-EA.4",
+      "topicCode": "B12-EA.4",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben de...",
+      "description": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Kommunikation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.",
+      "sourceText": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Kommunikation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.",
+      "sourceSpan": "B12-EA.4.2",
+      "parentBulletText": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Kommunikation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.4.2",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.4"
+      ],
+      "rawSourceText": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Kommunikation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.",
+      "rawSourceSpan": "B12-EA.4.2",
+      "rawParentBulletText": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Kommunikation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "317634d4-e406-5105-81a2-b46fa315cdc1",
+          "passageId": "by-bio:B12-EA.4",
+          "topicCode": "B12-EA.4",
+          "sourceSpan": "B12-EA.4.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.4.2",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.4"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.4.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.4.2"
+      ]
+    },
+    {
+      "id": "490877b0-809e-5ba7-bf56-d91053b3ec80",
+      "passageId": "by-bio:B12-EA.4",
+      "topicCode": "B12-EA.4",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "analysieren das Sozialverhalten der Primaten im Hinblick auf exogene und endogene Ursachen, u...",
+      "description": "analysieren das Sozialverhalten der Primaten im Hinblick auf exogene und endogene Ursachen, um ausgewählte menschliche Verhaltensweisen zu erklären. Dabei treten sie einseitig biologistischen Erklärungsansätzen kritisch gegenüber.",
+      "sourceText": "analysieren das Sozialverhalten der Primaten im Hinblick auf exogene und endogene Ursachen, um ausgewählte menschliche Verhaltensweisen zu erklären. Dabei treten sie einseitig biologistischen Erklärungsansätzen kritisch gegenüber.",
+      "sourceSpan": "B12-EA.4.3",
+      "parentBulletText": "analysieren das Sozialverhalten der Primaten im Hinblick auf exogene und endogene Ursachen, um ausgewählte menschliche Verhaltensweisen zu erklären. Dabei treten sie einseitig biologistischen Erklärungsansätzen kritisch gegenüber.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.4.3",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-EA.4"
+      ],
+      "rawSourceText": "analysieren das Sozialverhalten der Primaten im Hinblick auf exogene und endogene Ursachen, um ausgewählte menschliche Verhaltensweisen zu erklären. Dabei treten sie einseitig biologistischen Erklärungsansätzen kritisch gegenüber.",
+      "rawSourceSpan": "B12-EA.4.3",
+      "rawParentBulletText": "analysieren das Sozialverhalten der Primaten im Hinblick auf exogene und endogene Ursachen, um ausgewählte menschliche Verhaltensweisen zu erklären. Dabei treten sie einseitig biologistischen Erklärungsansätzen kritisch gegenüber.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "490877b0-809e-5ba7-bf56-d91053b3ec80",
+          "passageId": "by-bio:B12-EA.4",
+          "topicCode": "B12-EA.4",
+          "sourceSpan": "B12-EA.4.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.4.3",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B12-EA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-EA.4"
+      ],
+      "mergedSourceSpans": [
+        "B12-EA.4.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-EA.4.3"
+      ]
+    },
+    {
+      "id": "59dc19df-7734-536a-801e-2d1bce412f1a",
+      "passageId": "by-bio:B12-GA.1",
+      "topicCode": "B12-GA.1",
+      "bulletIndex": 15,
+      "aspectIndex": 1,
+      "title": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieori...",
+      "description": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung) sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.",
+      "sourceText": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung) sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.",
+      "sourceSpan": "B12-GA.1.15",
+      "parentBulletText": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung) sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.15",
+      "courseLevel": "GK_LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-GA.1"
+      ],
+      "rawSourceText": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung) sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.",
+      "rawSourceSpan": "B12-GA.1.15",
+      "rawParentBulletText": "reflektieren die Kriterien wissenschaftlicher Wissensproduktion (Evidenzbasierung, Theorieorientierung) sowie die Bedingungen und Eigenschaften biologischer Erkenntnisgewinnung.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "59dc19df-7734-536a-801e-2d1bce412f1a",
+          "passageId": "by-bio:B12-GA.1",
+          "topicCode": "B12-GA.1",
+          "sourceSpan": "B12-GA.1.15",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.15",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.1"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-GA.1"
+      ],
+      "mergedSourceSpans": [
+        "B12-GA.1.15"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.1.15"
+      ]
+    },
+    {
+      "id": "f06e9a1f-f17c-56bf-9bb7-4571903e17f4",
+      "passageId": "by-bio:B12-GA.2",
+      "topicCode": "B12-GA.2",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette...",
+      "description": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen.",
+      "sourceText": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen.",
+      "sourceSpan": "B12-GA.2.4",
+      "parentBulletText": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.4",
+      "courseLevel": "GK_LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen.",
+      "rawSourceSpan": "B12-GA.2.4",
+      "rawParentBulletText": "erläutern die Aufgaben von Proteinen sowie das Zusammenwirken von Genen in einer Genwirkkette bei der Ausbildung von Merkmalen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f06e9a1f-f17c-56bf-9bb7-4571903e17f4",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.4",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-GA.2.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.4"
+      ]
+    },
+    {
+      "id": "2170fbb3-d82f-56d1-bf7e-03f1cf9a3146",
+      "passageId": "by-bio:B12-GA.2",
+      "topicCode": "B12-GA.2",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polym...",
+      "description": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären.",
+      "sourceText": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären.",
+      "sourceSpan": "B12-GA.2.7",
+      "parentBulletText": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.7",
+      "courseLevel": "GK_LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären.",
+      "rawSourceSpan": "B12-GA.2.7",
+      "rawParentBulletText": "vergleichen den natürlichen Prozess der DNA-Replikation mit dem technischen Prozess der Polymerase-Kettenreaktion (PCR), um an diesem Beispiel Probleme und Lösungen in der technischen Umsetzung natürlicher Prozesse zu erklären.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "2170fbb3-d82f-56d1-bf7e-03f1cf9a3146",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.7",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-GA.2.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.7"
+      ]
+    },
+    {
+      "id": "d6cb1a75-d31f-5195-8148-d079aa17abbf",
+      "passageId": "by-bio:B12-GA.2",
+      "topicCode": "B12-GA.2",
+      "bulletIndex": 11,
+      "aspectIndex": 1,
+      "title": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschre...",
+      "description": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.",
+      "sourceText": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.",
+      "sourceSpan": "B12-GA.2.11",
+      "parentBulletText": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.11",
+      "courseLevel": "GK_LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.",
+      "rawSourceSpan": "B12-GA.2.11",
+      "rawParentBulletText": "leiten aus der Auswertung von Karyogrammen verschiedene Typen von Genommutationen ab, beschreiben deren Auswirkungen auf das Lebewesen und differenzieren zwischen einer Änderung des Genotyps, des Phänotyps und einer Krankheit.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "d6cb1a75-d31f-5195-8148-d079aa17abbf",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.11",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-GA.2.11"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.11"
+      ]
+    },
+    {
+      "id": "61a685c4-b335-5c2b-a803-60c1c9e2cea6",
+      "passageId": "by-bio:B12-GA.2",
+      "topicCode": "B12-GA.2",
+      "bulletIndex": 13,
+      "aspectIndex": 1,
+      "title": "erläutern die prinzipielle Verfahrensweise zur künstlichen Veränderung von Erbanlagen sowie v...",
+      "description": "erläutern die prinzipielle Verfahrensweise zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.",
+      "sourceText": "erläutern die prinzipielle Verfahrensweise zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.",
+      "sourceSpan": "B12-GA.2.13",
+      "parentBulletText": "erläutern die prinzipielle Verfahrensweise zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.13",
+      "courseLevel": "GK_LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-GA.2"
+      ],
+      "rawSourceText": "erläutern die prinzipielle Verfahrensweise zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.",
+      "rawSourceSpan": "B12-GA.2.13",
+      "rawParentBulletText": "erläutern die prinzipielle Verfahrensweise zur künstlichen Veränderung von Erbanlagen sowie verschiedene Anwendungen von gentechnischen Verfahren und bewerten deren gesellschaftliche Auswirkungen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "61a685c4-b335-5c2b-a803-60c1c9e2cea6",
+          "passageId": "by-bio:B12-GA.2",
+          "topicCode": "B12-GA.2",
+          "sourceSpan": "B12-GA.2.13",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.13",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B12-GA.2.13"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.2.13"
+      ]
+    },
+    {
+      "id": "f0fa6aa1-9abc-5d93-91e6-04eac282bc51",
+      "passageId": "by-bio:B12-GA.3",
+      "topicCode": "B12-GA.3",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die E...",
+      "description": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten als Zusammenspiel der Evolutionsfaktoren zu erklären.",
+      "sourceText": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten als Zusammenspiel der Evolutionsfaktoren zu erklären.",
+      "sourceSpan": "B12-GA.3.5",
+      "parentBulletText": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten als Zusammenspiel der Evolutionsfaktoren zu erklären.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.5",
+      "courseLevel": "GK_LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-GA.3"
+      ],
+      "rawSourceText": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten als Zusammenspiel der Evolutionsfaktoren zu erklären.",
+      "rawSourceSpan": "B12-GA.3.5",
+      "rawParentBulletText": "wenden die synthetische Evolutionstheorie an, um die Entstehung der Biodiversität sowie die Entstehung von Arten als Zusammenspiel der Evolutionsfaktoren zu erklären.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f0fa6aa1-9abc-5d93-91e6-04eac282bc51",
+          "passageId": "by-bio:B12-GA.3",
+          "topicCode": "B12-GA.3",
+          "sourceSpan": "B12-GA.3.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.5",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B12-GA.3.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.5"
+      ]
+    },
+    {
+      "id": "852535e6-de83-5661-93ff-b58a9228e132",
+      "passageId": "by-bio:B12-GA.3",
+      "topicCode": "B12-GA.3",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "erklären wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Erg...",
+      "description": "erklären wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.",
+      "sourceText": "erklären wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.",
+      "sourceSpan": "B12-GA.3.6",
+      "parentBulletText": "erklären wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.6",
+      "courseLevel": "GK_LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-GA.3"
+      ],
+      "rawSourceText": "erklären wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.",
+      "rawSourceSpan": "B12-GA.3.6",
+      "rawParentBulletText": "erklären wechselseitige Angepasstheiten zwischen interagierenden artfremden Lebewesen als Ergebnis einer Koevolution.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "852535e6-de83-5661-93ff-b58a9228e132",
+          "passageId": "by-bio:B12-GA.3",
+          "topicCode": "B12-GA.3",
+          "sourceSpan": "B12-GA.3.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.6",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B12-GA.3.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.3.6"
+      ]
+    },
+    {
+      "id": "6a1a0f1b-854e-5b5a-94e5-f4189f2f16d8",
+      "passageId": "by-bio:B12-GA.4",
+      "topicCode": "B12-GA.4",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben de...",
+      "description": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.",
+      "sourceText": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.",
+      "sourceSpan": "B12-GA.4.2",
+      "parentBulletText": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.4.2",
+      "courseLevel": "GK_LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B12-GA.4"
+      ],
+      "rawSourceText": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.",
+      "rawSourceSpan": "B12-GA.4.2",
+      "rawParentBulletText": "wenden Methoden der verhaltensökologischen Forschung an, um Verhaltensweisen zum Überleben des Individuums bei Kooperation, Aggression und Fortpflanzung zu analysieren und deren Bedeutung für die Weitergabe der genetischen Information zu erklären.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "6a1a0f1b-854e-5b5a-94e5-f4189f2f16d8",
+          "passageId": "by-bio:B12-GA.4",
+          "topicCode": "B12-GA.4",
+          "sourceSpan": "B12-GA.4.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.4.2",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B12-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B12-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B12-GA.4.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B12-GA.4.2"
+      ]
+    },
+    {
+      "id": "6f8d420f-8a58-5c17-86fd-32925065f51f",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "skizzieren den Aufbau einer Nervenzelle und stellen die Besonderheiten dieses spezialisierten...",
+      "description": "skizzieren den Aufbau einer Nervenzelle und stellen die Besonderheiten dieses spezialisierten Zelltyps in einen Struktur-Funktions-Zusammenhang.",
+      "sourceText": "skizzieren den Aufbau einer Nervenzelle und stellen die Besonderheiten dieses spezialisierten Zelltyps in einen Struktur-Funktions-Zusammenhang.",
+      "sourceSpan": "B13-EA.2.1",
+      "parentBulletText": "skizzieren den Aufbau einer Nervenzelle und stellen die Besonderheiten dieses spezialisierten Zelltyps in einen Struktur-Funktions-Zusammenhang.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.1",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2",
+        "topic:B13-GA.2"
+      ],
+      "rawSourceText": "skizzieren den Aufbau einer Nervenzelle und stellen die Besonderheiten dieses spezialisierten Zelltyps in einen Struktur-Funktions-Zusammenhang.",
+      "rawSourceSpan": "B13-EA.2.1",
+      "rawParentBulletText": "skizzieren den Aufbau einer Nervenzelle und stellen die Besonderheiten dieses spezialisierten Zelltyps in einen Struktur-Funktions-Zusammenhang.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "6f8d420f-8a58-5c17-86fd-32925065f51f",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.1",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "bece32f5-e9d0-507a-bfe0-6dda01dbfc3c",
+          "passageId": "by-bio:B13-GA.2",
+          "topicCode": "B13-GA.2",
+          "sourceSpan": "B13-GA.2.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.1",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2",
+        "B13-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.1",
+        "B13-GA.2.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.1",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.1"
+      ]
+    },
+    {
+      "id": "7b155c7c-c2f7-5c17-950d-df62a8ec5825",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "beschreiben den Aufbau von Biomembranen nach dem Flüssig-Mosaik-Modell, um Transportvorgänge ...",
+      "description": "beschreiben den Aufbau von Biomembranen nach dem Flüssig-Mosaik-Modell, um Transportvorgänge zwischen Kompartimenten zu erläutern.",
+      "sourceText": "beschreiben den Aufbau von Biomembranen nach dem Flüssig-Mosaik-Modell, um Transportvorgänge zwischen Kompartimenten zu erläutern.",
+      "sourceSpan": "B13-EA.2.2",
+      "parentBulletText": "beschreiben den Aufbau von Biomembranen nach dem Flüssig-Mosaik-Modell, um Transportvorgänge zwischen Kompartimenten zu erläutern.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.2",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2",
+        "topic:B13-GA.2"
+      ],
+      "rawSourceText": "beschreiben den Aufbau von Biomembranen nach dem Flüssig-Mosaik-Modell, um Transportvorgänge zwischen Kompartimenten zu erläutern.",
+      "rawSourceSpan": "B13-EA.2.2",
+      "rawParentBulletText": "beschreiben den Aufbau von Biomembranen nach dem Flüssig-Mosaik-Modell, um Transportvorgänge zwischen Kompartimenten zu erläutern.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "7b155c7c-c2f7-5c17-950d-df62a8ec5825",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.2",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "c457c4ca-7492-5719-860c-0bc17798d837",
+          "passageId": "by-bio:B13-GA.2",
+          "topicCode": "B13-GA.2",
+          "sourceSpan": "B13-GA.2.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.2",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2",
+        "B13-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.2",
+        "B13-GA.2.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.2",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.2"
+      ]
+    },
+    {
+      "id": "f4c6e71e-2d1b-5ccb-91d1-3930cf43fd62",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "erklären anhand von Messdaten zur Ionenverteilung die Ladungsverhältnisse an der Biomembran e...",
+      "description": "erklären anhand von Messdaten zur Ionenverteilung die Ladungsverhältnisse an der Biomembran einer Nervenzelle im Ruhezustand und leiten daraus ab, dass zur Aufrechterhaltung des Ruhepotentials Energie aufgewendet werden muss.",
+      "sourceText": "erklären anhand von Messdaten zur Ionenverteilung die Ladungsverhältnisse an der Biomembran einer Nervenzelle im Ruhezustand und leiten daraus ab, dass zur Aufrechterhaltung des Ruhepotentials Energie aufgewendet werden muss.",
+      "sourceSpan": "B13-EA.2.3",
+      "parentBulletText": "erklären anhand von Messdaten zur Ionenverteilung die Ladungsverhältnisse an der Biomembran einer Nervenzelle im Ruhezustand und leiten daraus ab, dass zur Aufrechterhaltung des Ruhepotentials Energie aufgewendet werden muss.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.3",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2",
+        "topic:B13-GA.2"
+      ],
+      "rawSourceText": "erklären anhand von Messdaten zur Ionenverteilung die Ladungsverhältnisse an der Biomembran einer Nervenzelle im Ruhezustand und leiten daraus ab, dass zur Aufrechterhaltung des Ruhepotentials Energie aufgewendet werden muss.",
+      "rawSourceSpan": "B13-EA.2.3",
+      "rawParentBulletText": "erklären anhand von Messdaten zur Ionenverteilung die Ladungsverhältnisse an der Biomembran einer Nervenzelle im Ruhezustand und leiten daraus ab, dass zur Aufrechterhaltung des Ruhepotentials Energie aufgewendet werden muss.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f4c6e71e-2d1b-5ccb-91d1-3930cf43fd62",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.3",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "ab0ea3f5-9cb6-55ca-bc14-5e4767401b2b",
+          "passageId": "by-bio:B13-GA.2",
+          "topicCode": "B13-GA.2",
+          "sourceSpan": "B13-GA.2.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.3",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2",
+        "B13-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.3",
+        "B13-GA.2.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.3",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.3"
+      ]
+    },
+    {
+      "id": "269118af-aed0-52ff-8ed1-9fc787313313",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "erklären die auftretenden Potentialänderungen bei einem Aktionspotential, indem sie die Vorgä...",
+      "description": "erklären die auftretenden Potentialänderungen bei einem Aktionspotential, indem sie die Vorgänge auf der Teilchenebene bei überschwelliger Depolarisation an der Axonmembran beschreiben, und erklären, wie Informationen codiert werden.",
+      "sourceText": "erklären die auftretenden Potentialänderungen bei einem Aktionspotential, indem sie die Vorgänge auf der Teilchenebene bei überschwelliger Depolarisation an der Axonmembran beschreiben, und erklären, wie Informationen codiert werden.",
+      "sourceSpan": "B13-EA.2.4",
+      "parentBulletText": "erklären die auftretenden Potentialänderungen bei einem Aktionspotential, indem sie die Vorgänge auf der Teilchenebene bei überschwelliger Depolarisation an der Axonmembran beschreiben, und erklären, wie Informationen codiert werden.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.4",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2",
+        "topic:B13-GA.2"
+      ],
+      "rawSourceText": "erklären die auftretenden Potentialänderungen bei einem Aktionspotential, indem sie die Vorgänge auf der Teilchenebene bei überschwelliger Depolarisation an der Axonmembran beschreiben, und erklären, wie Informationen codiert werden.",
+      "rawSourceSpan": "B13-EA.2.4",
+      "rawParentBulletText": "erklären die auftretenden Potentialänderungen bei einem Aktionspotential, indem sie die Vorgänge auf der Teilchenebene bei überschwelliger Depolarisation an der Axonmembran beschreiben, und erklären, wie Informationen codiert werden.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "269118af-aed0-52ff-8ed1-9fc787313313",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.4",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "aa59713f-6b12-571f-88c1-1b133e68efef",
+          "passageId": "by-bio:B13-GA.2",
+          "topicCode": "B13-GA.2",
+          "sourceSpan": "B13-GA.2.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.4",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2",
+        "B13-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.4",
+        "B13-GA.2.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.4",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.4"
+      ]
+    },
+    {
+      "id": "3843a735-191d-5951-aa43-61620b96b8e9",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "beschreiben und vergleichen die Weiterleitung der Potentialänderung an verschiedenen Nervenfa...",
+      "description": "beschreiben und vergleichen die Weiterleitung der Potentialänderung an verschiedenen Nervenfasern, um die unterschiedliche Leistungsfähigkeit von Nervensystemen bei Wirbellosen und Wirbeltieren zu erklären.",
+      "sourceText": "beschreiben und vergleichen die Weiterleitung der Potentialänderung an verschiedenen Nervenfasern, um die unterschiedliche Leistungsfähigkeit von Nervensystemen bei Wirbellosen und Wirbeltieren zu erklären.",
+      "sourceSpan": "B13-EA.2.5",
+      "parentBulletText": "beschreiben und vergleichen die Weiterleitung der Potentialänderung an verschiedenen Nervenfasern, um die unterschiedliche Leistungsfähigkeit von Nervensystemen bei Wirbellosen und Wirbeltieren zu erklären.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.5",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2",
+        "topic:B13-GA.2"
+      ],
+      "rawSourceText": "beschreiben und vergleichen die Weiterleitung der Potentialänderung an verschiedenen Nervenfasern, um die unterschiedliche Leistungsfähigkeit von Nervensystemen bei Wirbellosen und Wirbeltieren zu erklären.",
+      "rawSourceSpan": "B13-EA.2.5",
+      "rawParentBulletText": "beschreiben und vergleichen die Weiterleitung der Potentialänderung an verschiedenen Nervenfasern, um die unterschiedliche Leistungsfähigkeit von Nervensystemen bei Wirbellosen und Wirbeltieren zu erklären.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "3843a735-191d-5951-aa43-61620b96b8e9",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.5",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "69480042-02f6-5b21-9eb8-446c83030ae9",
+          "passageId": "by-bio:B13-GA.2",
+          "topicCode": "B13-GA.2",
+          "sourceSpan": "B13-GA.2.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.5",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2",
+        "B13-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.5",
+        "B13-GA.2.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.5",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.5"
+      ]
+    },
+    {
+      "id": "1ab76608-e31b-5f03-822a-962c02ee922d",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "leiten aus den Vorgängen bei der Informationsübertragung an erregenden chemischen Synapsen Mö...",
+      "description": "leiten aus den Vorgängen bei der Informationsübertragung an erregenden chemischen Synapsen Möglichkeiten ab, diese Informationsübertragung durch Zufuhr von Stoffen zu beeinflussen.",
+      "sourceText": "leiten aus den Vorgängen bei der Informationsübertragung an erregenden chemischen Synapsen Möglichkeiten ab, diese Informationsübertragung durch Zufuhr von Stoffen zu beeinflussen.",
+      "sourceSpan": "B13-EA.2.6",
+      "parentBulletText": "leiten aus den Vorgängen bei der Informationsübertragung an erregenden chemischen Synapsen Möglichkeiten ab, diese Informationsübertragung durch Zufuhr von Stoffen zu beeinflussen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.6",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2",
+        "topic:B13-GA.2"
+      ],
+      "rawSourceText": "leiten aus den Vorgängen bei der Informationsübertragung an erregenden chemischen Synapsen Möglichkeiten ab, diese Informationsübertragung durch Zufuhr von Stoffen zu beeinflussen.",
+      "rawSourceSpan": "B13-EA.2.6",
+      "rawParentBulletText": "leiten aus den Vorgängen bei der Informationsübertragung an erregenden chemischen Synapsen Möglichkeiten ab, diese Informationsübertragung durch Zufuhr von Stoffen zu beeinflussen.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "1ab76608-e31b-5f03-822a-962c02ee922d",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.6",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "440e1929-2bf9-5325-b03a-7a9ae71f846c",
+          "passageId": "by-bio:B13-GA.2",
+          "topicCode": "B13-GA.2",
+          "sourceSpan": "B13-GA.2.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.6",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2",
+        "B13-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.6",
+        "B13-GA.2.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.6",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.6"
+      ]
+    },
+    {
+      "id": "8832a55d-988a-5848-81d4-1dc529f7b6e9",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "beschreiben die Symptome der Krankheit Depression und erklären deren Ausbildung im Zusammenha...",
+      "description": "beschreiben die Symptome der Krankheit Depression und erklären deren Ausbildung im Zusammenhang mit Veränderungen im Gehirnstoffwechsel vor dem Hintergrund eines multifaktoriellen Entstehungsmodells, um mit Betroffenen besser umzugehen sowie eine Therapiemöglichkeit abzuleiten.",
+      "sourceText": "beschreiben die Symptome der Krankheit Depression und erklären deren Ausbildung im Zusammenhang mit Veränderungen im Gehirnstoffwechsel vor dem Hintergrund eines multifaktoriellen Entstehungsmodells, um mit Betroffenen besser umzugehen sowie eine Therapiemöglichkeit abzuleiten.",
+      "sourceSpan": "B13-EA.2.7",
+      "parentBulletText": "beschreiben die Symptome der Krankheit Depression und erklären deren Ausbildung im Zusammenhang mit Veränderungen im Gehirnstoffwechsel vor dem Hintergrund eines multifaktoriellen Entstehungsmodells, um mit Betroffenen besser umzugehen sowie eine Therapiemöglichkeit abzuleiten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.7",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2",
+        "topic:B13-GA.2"
+      ],
+      "rawSourceText": "beschreiben die Symptome der Krankheit Depression und erklären deren Ausbildung im Zusammenhang mit Veränderungen im Gehirnstoffwechsel vor dem Hintergrund eines multifaktoriellen Entstehungsmodells, um mit Betroffenen besser umzugehen sowie eine Therapiemöglichkeit abzuleiten.",
+      "rawSourceSpan": "B13-EA.2.7",
+      "rawParentBulletText": "beschreiben die Symptome der Krankheit Depression und erklären deren Ausbildung im Zusammenhang mit Veränderungen im Gehirnstoffwechsel vor dem Hintergrund eines multifaktoriellen Entstehungsmodells, um mit Betroffenen besser umzugehen sowie eine Therapiemöglichkeit abzuleiten.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "8832a55d-988a-5848-81d4-1dc529f7b6e9",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.7",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        },
+        {
+          "sourceGoalId": "9112f03c-86f5-5f64-b8d6-4ec1d687d7ed",
+          "passageId": "by-bio:B13-GA.2",
+          "topicCode": "B13-GA.2",
+          "sourceSpan": "B13-GA.2.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.7",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2",
+        "B13-GA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.7",
+        "B13-GA.2.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.7",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.2.7"
+      ]
+    },
+    {
+      "id": "644bde9d-2d47-57a2-aff3-5dc5bf956f31",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "vergleichen die postsynaptischen Potentialänderungen, die sich aus der Verschaltung mehrerer ...",
+      "description": "vergleichen die postsynaptischen Potentialänderungen, die sich aus der Verschaltung mehrerer Nervenzellen ergeben, und leiten die Notwendigkeit von erregenden und hemmenden Synapsen für eine geregelte Signalübertragung ab.",
+      "sourceText": "vergleichen die postsynaptischen Potentialänderungen, die sich aus der Verschaltung mehrerer Nervenzellen ergeben, und leiten die Notwendigkeit von erregenden und hemmenden Synapsen für eine geregelte Signalübertragung ab.",
+      "sourceSpan": "B13-EA.2.8",
+      "parentBulletText": "vergleichen die postsynaptischen Potentialänderungen, die sich aus der Verschaltung mehrerer Nervenzellen ergeben, und leiten die Notwendigkeit von erregenden und hemmenden Synapsen für eine geregelte Signalübertragung ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.8",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2"
+      ],
+      "rawSourceText": "vergleichen die postsynaptischen Potentialänderungen, die sich aus der Verschaltung mehrerer Nervenzellen ergeben, und leiten die Notwendigkeit von erregenden und hemmenden Synapsen für eine geregelte Signalübertragung ab.",
+      "rawSourceSpan": "B13-EA.2.8",
+      "rawParentBulletText": "vergleichen die postsynaptischen Potentialänderungen, die sich aus der Verschaltung mehrerer Nervenzellen ergeben, und leiten die Notwendigkeit von erregenden und hemmenden Synapsen für eine geregelte Signalübertragung ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "644bde9d-2d47-57a2-aff3-5dc5bf956f31",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.8",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.8"
+      ]
+    },
+    {
+      "id": "e026e617-09d5-53d1-aa11-9cdb8f3d6b00",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 9,
+      "aspectIndex": 1,
+      "title": "erklären in Grundzügen die Möglichkeit sowie den medizinischen Nutzen, die elektrische Aktivi...",
+      "description": "erklären in Grundzügen die Möglichkeit sowie den medizinischen Nutzen, die elektrische Aktivität der Nervenzellen mithilfe neurophysiologischer Verfahren sichtbar zu machen.",
+      "sourceText": "erklären in Grundzügen die Möglichkeit sowie den medizinischen Nutzen, die elektrische Aktivität der Nervenzellen mithilfe neurophysiologischer Verfahren sichtbar zu machen.",
+      "sourceSpan": "B13-EA.2.9",
+      "parentBulletText": "erklären in Grundzügen die Möglichkeit sowie den medizinischen Nutzen, die elektrische Aktivität der Nervenzellen mithilfe neurophysiologischer Verfahren sichtbar zu machen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.9",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2"
+      ],
+      "rawSourceText": "erklären in Grundzügen die Möglichkeit sowie den medizinischen Nutzen, die elektrische Aktivität der Nervenzellen mithilfe neurophysiologischer Verfahren sichtbar zu machen.",
+      "rawSourceSpan": "B13-EA.2.9",
+      "rawParentBulletText": "erklären in Grundzügen die Möglichkeit sowie den medizinischen Nutzen, die elektrische Aktivität der Nervenzellen mithilfe neurophysiologischer Verfahren sichtbar zu machen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "e026e617-09d5-53d1-aa11-9cdb8f3d6b00",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.9",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.9"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.9"
+      ]
+    },
+    {
+      "id": "1935a0a9-d746-5b57-b1b7-82cc155ce91e",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 10,
+      "aspectIndex": 1,
+      "title": "erläutern die Notwendigkeit der neuronalen Plastizität als Voraussetzung für Lernprozesse.",
+      "description": "erläutern die Notwendigkeit der neuronalen Plastizität als Voraussetzung für Lernprozesse.",
+      "sourceText": "erläutern die Notwendigkeit der neuronalen Plastizität als Voraussetzung für Lernprozesse.",
+      "sourceSpan": "B13-EA.2.10",
+      "parentBulletText": "erläutern die Notwendigkeit der neuronalen Plastizität als Voraussetzung für Lernprozesse.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.10",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2"
+      ],
+      "rawSourceText": "erläutern die Notwendigkeit der neuronalen Plastizität als Voraussetzung für Lernprozesse.",
+      "rawSourceSpan": "B13-EA.2.10",
+      "rawParentBulletText": "erläutern die Notwendigkeit der neuronalen Plastizität als Voraussetzung für Lernprozesse.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "1935a0a9-d746-5b57-b1b7-82cc155ce91e",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.10",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.10"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.10"
+      ]
+    },
+    {
+      "id": "8c6774a3-2a98-5b76-9ecd-8ad97f97440c",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 11,
+      "aspectIndex": 1,
+      "title": "erklären die Symptome von Multipler Sklerose und Parkinson als Störungen des neuronalen Systems.",
+      "description": "erklären die Symptome von Multipler Sklerose und Parkinson als Störungen des neuronalen Systems.",
+      "sourceText": "erklären die Symptome von Multipler Sklerose und Parkinson als Störungen des neuronalen Systems.",
+      "sourceSpan": "B13-EA.2.11",
+      "parentBulletText": "erklären die Symptome von Multipler Sklerose und Parkinson als Störungen des neuronalen Systems.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.11",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2"
+      ],
+      "rawSourceText": "erklären die Symptome von Multipler Sklerose und Parkinson als Störungen des neuronalen Systems.",
+      "rawSourceSpan": "B13-EA.2.11",
+      "rawParentBulletText": "erklären die Symptome von Multipler Sklerose und Parkinson als Störungen des neuronalen Systems.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "8c6774a3-2a98-5b76-9ecd-8ad97f97440c",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.11",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.11"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.11"
+      ]
+    },
+    {
+      "id": "453a6fad-aecc-502f-a5b3-a9e9c54aa9e2",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 12,
+      "aspectIndex": 1,
+      "title": "leiten aus dem Vergleich der Informationsübertragung von Nerven- und Hormonsystem am Beispiel...",
+      "description": "leiten aus dem Vergleich der Informationsübertragung von Nerven- und Hormonsystem am Beispiel der Stressreaktion die Bedeutung der Verschränkung dieser Organsysteme ab.",
+      "sourceText": "leiten aus dem Vergleich der Informationsübertragung von Nerven- und Hormonsystem am Beispiel der Stressreaktion die Bedeutung der Verschränkung dieser Organsysteme ab.",
+      "sourceSpan": "B13-EA.2.12",
+      "parentBulletText": "leiten aus dem Vergleich der Informationsübertragung von Nerven- und Hormonsystem am Beispiel der Stressreaktion die Bedeutung der Verschränkung dieser Organsysteme ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.12",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2"
+      ],
+      "rawSourceText": "leiten aus dem Vergleich der Informationsübertragung von Nerven- und Hormonsystem am Beispiel der Stressreaktion die Bedeutung der Verschränkung dieser Organsysteme ab.",
+      "rawSourceSpan": "B13-EA.2.12",
+      "rawParentBulletText": "leiten aus dem Vergleich der Informationsübertragung von Nerven- und Hormonsystem am Beispiel der Stressreaktion die Bedeutung der Verschränkung dieser Organsysteme ab.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "453a6fad-aecc-502f-a5b3-a9e9c54aa9e2",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.12",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.12",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.12"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.12"
+      ]
+    },
+    {
+      "id": "8028cba5-0828-574a-a884-48e656649e0f",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 13,
+      "aspectIndex": 1,
+      "title": "beschreiben die Regulation einer Hormonkonzentration und erklären die Auswirkungen von chroni...",
+      "description": "beschreiben die Regulation einer Hormonkonzentration und erklären die Auswirkungen von chronischem Stress auch als Eingriff in einen weiteren hormonellen Regelkreis.",
+      "sourceText": "beschreiben die Regulation einer Hormonkonzentration und erklären die Auswirkungen von chronischem Stress auch als Eingriff in einen weiteren hormonellen Regelkreis.",
+      "sourceSpan": "B13-EA.2.13",
+      "parentBulletText": "beschreiben die Regulation einer Hormonkonzentration und erklären die Auswirkungen von chronischem Stress auch als Eingriff in einen weiteren hormonellen Regelkreis.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.13",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2"
+      ],
+      "rawSourceText": "beschreiben die Regulation einer Hormonkonzentration und erklären die Auswirkungen von chronischem Stress auch als Eingriff in einen weiteren hormonellen Regelkreis.",
+      "rawSourceSpan": "B13-EA.2.13",
+      "rawParentBulletText": "beschreiben die Regulation einer Hormonkonzentration und erklären die Auswirkungen von chronischem Stress auch als Eingriff in einen weiteren hormonellen Regelkreis.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "8028cba5-0828-574a-a884-48e656649e0f",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.13",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.13",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.13"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.13"
+      ]
+    },
+    {
+      "id": "0a6b6a3f-47a1-5a90-bc23-75417cfecdd6",
+      "passageId": "by-bio:B13-EA.2",
+      "topicCode": "B13-EA.2",
+      "bulletIndex": 14,
+      "aspectIndex": 1,
+      "title": "erklären das Zustandekommen eines Rezeptorpotentials an einer Sinneszelle durch Beschreibung ...",
+      "description": "erklären das Zustandekommen eines Rezeptorpotentials an einer Sinneszelle durch Beschreibung der bei Reizeinwirkung ablaufenden Vorgänge auf Teilchenebene und wenden ihr Wissen zur Erklärung sinnesphysiologischer Phänomene an.",
+      "sourceText": "erklären das Zustandekommen eines Rezeptorpotentials an einer Sinneszelle durch Beschreibung der bei Reizeinwirkung ablaufenden Vorgänge auf Teilchenebene und wenden ihr Wissen zur Erklärung sinnesphysiologischer Phänomene an.",
+      "sourceSpan": "B13-EA.2.14",
+      "parentBulletText": "erklären das Zustandekommen eines Rezeptorpotentials an einer Sinneszelle durch Beschreibung der bei Reizeinwirkung ablaufenden Vorgänge auf Teilchenebene und wenden ihr Wissen zur Erklärung sinnesphysiologischer Phänomene an.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.14",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.2"
+      ],
+      "rawSourceText": "erklären das Zustandekommen eines Rezeptorpotentials an einer Sinneszelle durch Beschreibung der bei Reizeinwirkung ablaufenden Vorgänge auf Teilchenebene und wenden ihr Wissen zur Erklärung sinnesphysiologischer Phänomene an.",
+      "rawSourceSpan": "B13-EA.2.14",
+      "rawParentBulletText": "erklären das Zustandekommen eines Rezeptorpotentials an einer Sinneszelle durch Beschreibung der bei Reizeinwirkung ablaufenden Vorgänge auf Teilchenebene und wenden ihr Wissen zur Erklärung sinnesphysiologischer Phänomene an.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "0a6b6a3f-47a1-5a90-bc23-75417cfecdd6",
+          "passageId": "by-bio:B13-EA.2",
+          "topicCode": "B13-EA.2",
+          "sourceSpan": "B13-EA.2.14",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.14",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.2"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.2"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.2.14"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.2.14"
+      ]
+    },
+    {
+      "id": "51a5bf48-51c9-518f-b4e6-fe4a8c073b7d",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "beschreiben das Grundprinzip der Assimilation und legen deren Bedeutung für das Leben auf der...",
+      "description": "beschreiben das Grundprinzip der Assimilation und legen deren Bedeutung für das Leben auf der Erde dar.",
+      "sourceText": "beschreiben das Grundprinzip der Assimilation und legen deren Bedeutung für das Leben auf der Erde dar.",
+      "sourceSpan": "B13-EA.3.1",
+      "parentBulletText": "beschreiben das Grundprinzip der Assimilation und legen deren Bedeutung für das Leben auf der Erde dar.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.1",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3",
+        "topic:B13-GA.3"
+      ],
+      "rawSourceText": "beschreiben das Grundprinzip der Assimilation und legen deren Bedeutung für das Leben auf der Erde dar.",
+      "rawSourceSpan": "B13-EA.3.1",
+      "rawParentBulletText": "beschreiben das Grundprinzip der Assimilation und legen deren Bedeutung für das Leben auf der Erde dar.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "51a5bf48-51c9-518f-b4e6-fe4a8c073b7d",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.1",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "68fc5ecc-bec9-51e9-9bfd-e3ae996d02a5",
+          "passageId": "by-bio:B13-GA.3",
+          "topicCode": "B13-GA.3",
+          "sourceSpan": "B13-GA.3.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.1",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3",
+        "B13-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.1",
+        "B13-GA.3.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.1",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.1"
+      ]
+    },
+    {
+      "id": "b342744e-60c2-5ce2-b281-5eb19943a1ce",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "erklären, welche Außenfaktoren die Photosynthese beeinflussen, legen dar, wie sich Veränderun...",
+      "description": "erklären, welche Außenfaktoren die Photosynthese beeinflussen, legen dar, wie sich Veränderungen der Außenfaktoren auf die Photosyntheserate auswirken, und beurteilen deren Folgen für Wild- und Nutzpflanzen.",
+      "sourceText": "erklären, welche Außenfaktoren die Photosynthese beeinflussen, legen dar, wie sich Veränderungen der Außenfaktoren auf die Photosyntheserate auswirken, und beurteilen deren Folgen für Wild- und Nutzpflanzen.",
+      "sourceSpan": "B13-EA.3.2",
+      "parentBulletText": "erklären, welche Außenfaktoren die Photosynthese beeinflussen, legen dar, wie sich Veränderungen der Außenfaktoren auf die Photosyntheserate auswirken, und beurteilen deren Folgen für Wild- und Nutzpflanzen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.2",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3",
+        "topic:B13-GA.3"
+      ],
+      "rawSourceText": "erklären, welche Außenfaktoren die Photosynthese beeinflussen, legen dar, wie sich Veränderungen der Außenfaktoren auf die Photosyntheserate auswirken, und beurteilen deren Folgen für Wild- und Nutzpflanzen.",
+      "rawSourceSpan": "B13-EA.3.2",
+      "rawParentBulletText": "erklären, welche Außenfaktoren die Photosynthese beeinflussen, legen dar, wie sich Veränderungen der Außenfaktoren auf die Photosyntheserate auswirken, und beurteilen deren Folgen für Wild- und Nutzpflanzen.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b342744e-60c2-5ce2-b281-5eb19943a1ce",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.2",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "b90c9126-7d04-56e9-bdb6-30192be14b9d",
+          "passageId": "by-bio:B13-GA.3",
+          "topicCode": "B13-GA.3",
+          "sourceSpan": "B13-GA.3.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.2",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3",
+        "B13-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.2",
+        "B13-GA.3.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.2",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.2"
+      ]
+    },
+    {
+      "id": "2cc41e62-ec79-5add-9d43-2499b4e147b2",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "trennen die verschiedenen Photosynthesefarbstoffe in einem Blattextrakt durch Chromatographie...",
+      "description": "trennen die verschiedenen Photosynthesefarbstoffe in einem Blattextrakt durch Chromatographie, um zu zeigen, dass ein Farbstoffgemisch für die Absorption von Licht verantwortlich ist.",
+      "sourceText": "trennen die verschiedenen Photosynthesefarbstoffe in einem Blattextrakt durch Chromatographie, um zu zeigen, dass ein Farbstoffgemisch für die Absorption von Licht verantwortlich ist.",
+      "sourceSpan": "B13-EA.3.3",
+      "parentBulletText": "trennen die verschiedenen Photosynthesefarbstoffe in einem Blattextrakt durch Chromatographie, um zu zeigen, dass ein Farbstoffgemisch für die Absorption von Licht verantwortlich ist.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.3",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3",
+        "topic:B13-GA.3"
+      ],
+      "rawSourceText": "trennen die verschiedenen Photosynthesefarbstoffe in einem Blattextrakt durch Chromatographie, um zu zeigen, dass ein Farbstoffgemisch für die Absorption von Licht verantwortlich ist.",
+      "rawSourceSpan": "B13-EA.3.3",
+      "rawParentBulletText": "trennen die verschiedenen Photosynthesefarbstoffe in einem Blattextrakt durch Chromatographie, um zu zeigen, dass ein Farbstoffgemisch für die Absorption von Licht verantwortlich ist.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "2cc41e62-ec79-5add-9d43-2499b4e147b2",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.3",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "4937d96f-d201-5b33-8846-adaed54f90fd",
+          "passageId": "by-bio:B13-GA.3",
+          "topicCode": "B13-GA.3",
+          "sourceSpan": "B13-GA.3.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.3",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3",
+        "B13-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.3",
+        "B13-GA.3.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.3",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.3"
+      ]
+    },
+    {
+      "id": "b0468d88-9a13-5f8c-ac3b-02c0761dda94",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "stellen einen Zusammenhang zwischen molekularen, anatomischen und morphologischen Strukturen ...",
+      "description": "stellen einen Zusammenhang zwischen molekularen, anatomischen und morphologischen Strukturen her, indem sie auf verschiedenen Organisationsebenen die Angepasstheiten einer Pflanze an die Photosynthese erläutern.",
+      "sourceText": "stellen einen Zusammenhang zwischen molekularen, anatomischen und morphologischen Strukturen her, indem sie auf verschiedenen Organisationsebenen die Angepasstheiten einer Pflanze an die Photosynthese erläutern.",
+      "sourceSpan": "B13-EA.3.4",
+      "parentBulletText": "stellen einen Zusammenhang zwischen molekularen, anatomischen und morphologischen Strukturen her, indem sie auf verschiedenen Organisationsebenen die Angepasstheiten einer Pflanze an die Photosynthese erläutern.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.4",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3",
+        "topic:B13-GA.3"
+      ],
+      "rawSourceText": "stellen einen Zusammenhang zwischen molekularen, anatomischen und morphologischen Strukturen her, indem sie auf verschiedenen Organisationsebenen die Angepasstheiten einer Pflanze an die Photosynthese erläutern.",
+      "rawSourceSpan": "B13-EA.3.4",
+      "rawParentBulletText": "stellen einen Zusammenhang zwischen molekularen, anatomischen und morphologischen Strukturen her, indem sie auf verschiedenen Organisationsebenen die Angepasstheiten einer Pflanze an die Photosynthese erläutern.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b0468d88-9a13-5f8c-ac3b-02c0761dda94",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.4",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "52dacb20-f483-57f5-b807-d0525a92a90a",
+          "passageId": "by-bio:B13-GA.3",
+          "topicCode": "B13-GA.3",
+          "sourceSpan": "B13-GA.3.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.4",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3",
+        "B13-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.4",
+        "B13-GA.3.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.4",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.4"
+      ]
+    },
+    {
+      "id": "861204d6-ce05-53c9-979f-6a69513a2313",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "beschreiben die Tracer-Methode als Werkzeug, um Stoffwechselwege, z. B. bei der Photosynthese...",
+      "description": "beschreiben die Tracer-Methode als Werkzeug, um Stoffwechselwege, z. B. bei der Photosynthese, aufzuklären.",
+      "sourceText": "beschreiben die Tracer-Methode als Werkzeug, um Stoffwechselwege, z. B. bei der Photosynthese, aufzuklären.",
+      "sourceSpan": "B13-EA.3.5",
+      "parentBulletText": "beschreiben die Tracer-Methode als Werkzeug, um Stoffwechselwege, z. B. bei der Photosynthese, aufzuklären.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.5",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3"
+      ],
+      "rawSourceText": "beschreiben die Tracer-Methode als Werkzeug, um Stoffwechselwege, z. B. bei der Photosynthese, aufzuklären.",
+      "rawSourceSpan": "B13-EA.3.5",
+      "rawParentBulletText": "beschreiben die Tracer-Methode als Werkzeug, um Stoffwechselwege, z. B. bei der Photosynthese, aufzuklären.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "861204d6-ce05-53c9-979f-6a69513a2313",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.5",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.5"
+      ]
+    },
+    {
+      "id": "f9c70e85-e4e4-57ce-908a-6baa772ec0d9",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "erklären die Bildung von NADPH und ATP, die für den Glucose-Aufbau benötigt werden, mithilfe ...",
+      "description": "erklären die Bildung von NADPH und ATP, die für den Glucose-Aufbau benötigt werden, mithilfe eines energetischen Modells und der chemiosmotischen Theorie zum Ablauf der lichtabhängigen Reaktionen.",
+      "sourceText": "erklären die Bildung von NADPH und ATP, die für den Glucose-Aufbau benötigt werden, mithilfe eines energetischen Modells und der chemiosmotischen Theorie zum Ablauf der lichtabhängigen Reaktionen.",
+      "sourceSpan": "B13-EA.3.6",
+      "parentBulletText": "erklären die Bildung von NADPH und ATP, die für den Glucose-Aufbau benötigt werden, mithilfe eines energetischen Modells und der chemiosmotischen Theorie zum Ablauf der lichtabhängigen Reaktionen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.6",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3",
+        "topic:B13-GA.3"
+      ],
+      "rawSourceText": "erklären die Bildung von NADPH und ATP, die für den Glucose-Aufbau benötigt werden, mithilfe eines energetischen Modells und der chemiosmotischen Theorie zum Ablauf der lichtabhängigen Reaktionen.",
+      "rawSourceSpan": "B13-EA.3.6",
+      "rawParentBulletText": "erklären die Bildung von NADPH und ATP, die für den Glucose-Aufbau benötigt werden, mithilfe eines energetischen Modells und der chemiosmotischen Theorie zum Ablauf der lichtabhängigen Reaktionen.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "f9c70e85-e4e4-57ce-908a-6baa772ec0d9",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.6",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "bf6a16aa-bb6b-5393-9d0b-ee81d6ce3cb8",
+          "passageId": "by-bio:B13-GA.3",
+          "topicCode": "B13-GA.3",
+          "sourceSpan": "B13-GA.3.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.5",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3",
+        "B13-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.6",
+        "B13-GA.3.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.6",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.5"
+      ]
+    },
+    {
+      "id": "b6e605f6-75ed-590f-8769-72e631f02a0f",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "charakterisieren den Calvin-Zyklus als Schlüsselstelle für den Aufbau von energiereichen orga...",
+      "description": "charakterisieren den Calvin-Zyklus als Schlüsselstelle für den Aufbau von energiereichen organischen Verbindungen unter Verwendung von NADPH und ATP aus den lichtabhängigen Reaktionen.",
+      "sourceText": "charakterisieren den Calvin-Zyklus als Schlüsselstelle für den Aufbau von energiereichen organischen Verbindungen unter Verwendung von NADPH und ATP aus den lichtabhängigen Reaktionen.",
+      "sourceSpan": "B13-EA.3.7",
+      "parentBulletText": "charakterisieren den Calvin-Zyklus als Schlüsselstelle für den Aufbau von energiereichen organischen Verbindungen unter Verwendung von NADPH und ATP aus den lichtabhängigen Reaktionen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.7",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3",
+        "topic:B13-GA.3"
+      ],
+      "rawSourceText": "charakterisieren den Calvin-Zyklus als Schlüsselstelle für den Aufbau von energiereichen organischen Verbindungen unter Verwendung von NADPH und ATP aus den lichtabhängigen Reaktionen.",
+      "rawSourceSpan": "B13-EA.3.7",
+      "rawParentBulletText": "charakterisieren den Calvin-Zyklus als Schlüsselstelle für den Aufbau von energiereichen organischen Verbindungen unter Verwendung von NADPH und ATP aus den lichtabhängigen Reaktionen.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b6e605f6-75ed-590f-8769-72e631f02a0f",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.7",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "85368f70-5bd9-505d-a526-59163690bf59",
+          "passageId": "by-bio:B13-GA.3",
+          "topicCode": "B13-GA.3",
+          "sourceSpan": "B13-GA.3.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.6",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3",
+        "B13-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.7",
+        "B13-GA.3.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.7",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.6"
+      ]
+    },
+    {
+      "id": "a6d4b0eb-e267-558e-9e13-6eb671484c30",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "vergleichen C3- und C4-Pflanzen im Hinblick auf anatomische Besonderheiten und biochemische P...",
+      "description": "vergleichen C3- und C4-Pflanzen im Hinblick auf anatomische Besonderheiten und biochemische Prozesse, um daraus abzuleiten, dass Stoffwechselwege von Pflanzen eine Angepasstheit an unterschiedliche Standorte sind.",
+      "sourceText": "vergleichen C3- und C4-Pflanzen im Hinblick auf anatomische Besonderheiten und biochemische Prozesse, um daraus abzuleiten, dass Stoffwechselwege von Pflanzen eine Angepasstheit an unterschiedliche Standorte sind.",
+      "sourceSpan": "B13-EA.3.8",
+      "parentBulletText": "vergleichen C3- und C4-Pflanzen im Hinblick auf anatomische Besonderheiten und biochemische Prozesse, um daraus abzuleiten, dass Stoffwechselwege von Pflanzen eine Angepasstheit an unterschiedliche Standorte sind.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.8",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3"
+      ],
+      "rawSourceText": "vergleichen C3- und C4-Pflanzen im Hinblick auf anatomische Besonderheiten und biochemische Prozesse, um daraus abzuleiten, dass Stoffwechselwege von Pflanzen eine Angepasstheit an unterschiedliche Standorte sind.",
+      "rawSourceSpan": "B13-EA.3.8",
+      "rawParentBulletText": "vergleichen C3- und C4-Pflanzen im Hinblick auf anatomische Besonderheiten und biochemische Prozesse, um daraus abzuleiten, dass Stoffwechselwege von Pflanzen eine Angepasstheit an unterschiedliche Standorte sind.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "a6d4b0eb-e267-558e-9e13-6eb671484c30",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.8",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.8"
+      ]
+    },
+    {
+      "id": "81a64cd9-7f21-59a7-9d2a-f34d2d76c939",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 9,
+      "aspectIndex": 1,
+      "title": "beschreiben, wie Pflanzen Stoffe ineinander umwandeln können und so Biomasse aufbauen, die si...",
+      "description": "beschreiben, wie Pflanzen Stoffe ineinander umwandeln können und so Biomasse aufbauen, die sie und heterotrophe Lebewesen als Grundlage für ihren Energie- und Baustoffwechsel nutzen.",
+      "sourceText": "beschreiben, wie Pflanzen Stoffe ineinander umwandeln können und so Biomasse aufbauen, die sie und heterotrophe Lebewesen als Grundlage für ihren Energie- und Baustoffwechsel nutzen.",
+      "sourceSpan": "B13-EA.3.9",
+      "parentBulletText": "beschreiben, wie Pflanzen Stoffe ineinander umwandeln können und so Biomasse aufbauen, die sie und heterotrophe Lebewesen als Grundlage für ihren Energie- und Baustoffwechsel nutzen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.9",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3",
+        "topic:B13-GA.3"
+      ],
+      "rawSourceText": "beschreiben, wie Pflanzen Stoffe ineinander umwandeln können und so Biomasse aufbauen, die sie und heterotrophe Lebewesen als Grundlage für ihren Energie- und Baustoffwechsel nutzen.",
+      "rawSourceSpan": "B13-EA.3.9",
+      "rawParentBulletText": "beschreiben, wie Pflanzen Stoffe ineinander umwandeln können und so Biomasse aufbauen, die sie und heterotrophe Lebewesen als Grundlage für ihren Energie- und Baustoffwechsel nutzen.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "81a64cd9-7f21-59a7-9d2a-f34d2d76c939",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.9",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "8dfbf944-a8f0-554e-9d59-ab3cdb58c4f1",
+          "passageId": "by-bio:B13-GA.3",
+          "topicCode": "B13-GA.3",
+          "sourceSpan": "B13-GA.3.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.7",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3",
+        "B13-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.9",
+        "B13-GA.3.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.9",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.7"
+      ]
+    },
+    {
+      "id": "14dde0e1-1b0e-5f7c-8adb-c318dd505cad",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 10,
+      "aspectIndex": 1,
+      "title": "planen selbstständig Experimente, um Hypothesen zur Beeinflussung der Enzymaktivität durch ve...",
+      "description": "planen selbstständig Experimente, um Hypothesen zur Beeinflussung der Enzymaktivität durch verschiedene Außenfaktoren zu überprüfen.",
+      "sourceText": "planen selbstständig Experimente, um Hypothesen zur Beeinflussung der Enzymaktivität durch verschiedene Außenfaktoren zu überprüfen.",
+      "sourceSpan": "B13-EA.3.10",
+      "parentBulletText": "planen selbstständig Experimente, um Hypothesen zur Beeinflussung der Enzymaktivität durch verschiedene Außenfaktoren zu überprüfen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.10",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3"
+      ],
+      "rawSourceText": "planen selbstständig Experimente, um Hypothesen zur Beeinflussung der Enzymaktivität durch verschiedene Außenfaktoren zu überprüfen.",
+      "rawSourceSpan": "B13-EA.3.10",
+      "rawParentBulletText": "planen selbstständig Experimente, um Hypothesen zur Beeinflussung der Enzymaktivität durch verschiedene Außenfaktoren zu überprüfen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "14dde0e1-1b0e-5f7c-8adb-c318dd505cad",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.10",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.10"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.10"
+      ]
+    },
+    {
+      "id": "e22d6665-417a-5e63-aaa8-e2cbf1b3899f",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 11,
+      "aspectIndex": 1,
+      "title": "erklären die Bedeutung von Enzymen für eine bedarfsgerechte Regulation des Stoffwechsels.",
+      "description": "erklären die Bedeutung von Enzymen für eine bedarfsgerechte Regulation des Stoffwechsels.",
+      "sourceText": "erklären die Bedeutung von Enzymen für eine bedarfsgerechte Regulation des Stoffwechsels.",
+      "sourceSpan": "B13-EA.3.11",
+      "parentBulletText": "erklären die Bedeutung von Enzymen für eine bedarfsgerechte Regulation des Stoffwechsels.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.11",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3",
+        "topic:B13-GA.3"
+      ],
+      "rawSourceText": "erklären die Bedeutung von Enzymen für eine bedarfsgerechte Regulation des Stoffwechsels.",
+      "rawSourceSpan": "B13-EA.3.11",
+      "rawParentBulletText": "erklären die Bedeutung von Enzymen für eine bedarfsgerechte Regulation des Stoffwechsels.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "e22d6665-417a-5e63-aaa8-e2cbf1b3899f",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.11",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "3e676595-9911-52ed-847f-b8ad908afed4",
+          "passageId": "by-bio:B13-GA.3",
+          "topicCode": "B13-GA.3",
+          "sourceSpan": "B13-GA.3.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.8",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3",
+        "B13-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.11",
+        "B13-GA.3.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.11",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.8"
+      ]
+    },
+    {
+      "id": "e412f11f-bc30-5de4-b06d-8712fbf88b08",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 12,
+      "aspectIndex": 1,
+      "title": "erklären die Bildung von ATP unter Sauerstoffmangelbedingungen mithilfe verschiedener anaerob...",
+      "description": "erklären die Bildung von ATP unter Sauerstoffmangelbedingungen mithilfe verschiedener anaerober Abbauwege von Glucose.",
+      "sourceText": "erklären die Bildung von ATP unter Sauerstoffmangelbedingungen mithilfe verschiedener anaerober Abbauwege von Glucose.",
+      "sourceSpan": "B13-EA.3.12",
+      "parentBulletText": "erklären die Bildung von ATP unter Sauerstoffmangelbedingungen mithilfe verschiedener anaerober Abbauwege von Glucose.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.12",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3",
+        "topic:B13-GA.3"
+      ],
+      "rawSourceText": "erklären die Bildung von ATP unter Sauerstoffmangelbedingungen mithilfe verschiedener anaerober Abbauwege von Glucose.",
+      "rawSourceSpan": "B13-EA.3.12",
+      "rawParentBulletText": "erklären die Bildung von ATP unter Sauerstoffmangelbedingungen mithilfe verschiedener anaerober Abbauwege von Glucose.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "e412f11f-bc30-5de4-b06d-8712fbf88b08",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.12",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.12",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "f2835a99-5b1d-5810-9c8e-381f6397c450",
+          "passageId": "by-bio:B13-GA.3",
+          "topicCode": "B13-GA.3",
+          "sourceSpan": "B13-GA.3.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.9",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3",
+        "B13-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.12",
+        "B13-GA.3.9"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.12",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.9"
+      ]
+    },
+    {
+      "id": "b1a59da6-a2e7-5cb1-94ae-84d59a40f303",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 13,
+      "aspectIndex": 1,
+      "title": "beschreiben im Überblick den aeroben Abbauweg von Glucose zu Kohlenstoffdioxid, die Bildung v...",
+      "description": "beschreiben im Überblick den aeroben Abbauweg von Glucose zu Kohlenstoffdioxid, die Bildung von Energieäquivalenten und die Regeneration von NAD+ und FAD zur Aufrechterhaltung der Abbaureaktionen und vergleichen sie mit den aufbauenden Stoffwechselwegen der Photosynthese, um grundlegende Prinzipien des Stoffwechsels abzuleiten.",
+      "sourceText": "beschreiben im Überblick den aeroben Abbauweg von Glucose zu Kohlenstoffdioxid, die Bildung von Energieäquivalenten und die Regeneration von NAD+ und FAD zur Aufrechterhaltung der Abbaureaktionen und vergleichen sie mit den aufbauenden Stoffwechselwegen der Photosynthese, um grundlegende Prinzipien des Stoffwechsels abzuleiten.",
+      "sourceSpan": "B13-EA.3.13",
+      "parentBulletText": "beschreiben im Überblick den aeroben Abbauweg von Glucose zu Kohlenstoffdioxid, die Bildung von Energieäquivalenten und die Regeneration von NAD+ und FAD zur Aufrechterhaltung der Abbaureaktionen und vergleichen sie mit den aufbauenden Stoffwechselwegen der Photosynthese, um grundlegende Prinzipien des Stoffwechsels abzuleiten.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.13",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3",
+        "topic:B13-GA.3"
+      ],
+      "rawSourceText": "beschreiben im Überblick den aeroben Abbauweg von Glucose zu Kohlenstoffdioxid, die Bildung von Energieäquivalenten und die Regeneration von NAD+ und FAD zur Aufrechterhaltung der Abbaureaktionen und vergleichen sie mit den aufbauenden Stoffwechselwegen der Photosynthese, um grundlegende Prinzipien des Stoffwechsels abzuleiten.",
+      "rawSourceSpan": "B13-EA.3.13",
+      "rawParentBulletText": "beschreiben im Überblick den aeroben Abbauweg von Glucose zu Kohlenstoffdioxid, die Bildung von Energieäquivalenten und die Regeneration von NAD+ und FAD zur Aufrechterhaltung der Abbaureaktionen und vergleichen sie mit den aufbauenden Stoffwechselwegen der Photosynthese, um grundlegende Prinzipien des Stoffwechsels abzuleiten.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "b1a59da6-a2e7-5cb1-94ae-84d59a40f303",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.13",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.13",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "7a030bea-9c23-5916-a1fc-e46077067f48",
+          "passageId": "by-bio:B13-GA.3",
+          "topicCode": "B13-GA.3",
+          "sourceSpan": "B13-GA.3.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.10",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3",
+        "B13-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.13",
+        "B13-GA.3.10"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.13",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.10"
+      ]
+    },
+    {
+      "id": "a89a52a6-d175-57d8-9304-a3f9a02aa4a5",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 14,
+      "aspectIndex": 1,
+      "title": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben und anaeroben Abb...",
+      "description": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben und anaeroben Abbaus von Glucose, unter welchen Bedingungen die jeweiligen Abbauwege begünstigt werden.",
+      "sourceText": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben und anaeroben Abbaus von Glucose, unter welchen Bedingungen die jeweiligen Abbauwege begünstigt werden.",
+      "sourceSpan": "B13-EA.3.14",
+      "parentBulletText": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben und anaeroben Abbaus von Glucose, unter welchen Bedingungen die jeweiligen Abbauwege begünstigt werden.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.14",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3",
+        "topic:B13-GA.3"
+      ],
+      "rawSourceText": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben und anaeroben Abbaus von Glucose, unter welchen Bedingungen die jeweiligen Abbauwege begünstigt werden.",
+      "rawSourceSpan": "B13-EA.3.14",
+      "rawParentBulletText": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben und anaeroben Abbaus von Glucose, unter welchen Bedingungen die jeweiligen Abbauwege begünstigt werden.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "a89a52a6-d175-57d8-9304-a3f9a02aa4a5",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.14",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.14",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        },
+        {
+          "sourceGoalId": "36664479-0903-530e-aabe-01347942d347",
+          "passageId": "by-bio:B13-GA.3",
+          "topicCode": "B13-GA.3",
+          "sourceSpan": "B13-GA.3.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.11",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3",
+        "B13-GA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.14",
+        "B13-GA.3.11"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.14",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.3.11"
+      ]
+    },
+    {
+      "id": "83c2d8a2-7922-5bb2-9082-e76c7c255b75",
+      "passageId": "by-bio:B13-EA.3",
+      "topicCode": "B13-EA.3",
+      "bulletIndex": 15,
+      "aspectIndex": 1,
+      "title": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben Abbaus von Glucos...",
+      "description": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben Abbaus von Glucose und Fetten die besondere Eignung von Fetten als Energiespeicher.",
+      "sourceText": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben Abbaus von Glucose und Fetten die besondere Eignung von Fetten als Energiespeicher.",
+      "sourceSpan": "B13-EA.3.15",
+      "parentBulletText": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben Abbaus von Glucose und Fetten die besondere Eignung von Fetten als Energiespeicher.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.15",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.3"
+      ],
+      "rawSourceText": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben Abbaus von Glucose und Fetten die besondere Eignung von Fetten als Energiespeicher.",
+      "rawSourceSpan": "B13-EA.3.15",
+      "rawParentBulletText": "erklären anhand eines Vergleichs der Stoff- und Energiebilanzen des aeroben Abbaus von Glucose und Fetten die besondere Eignung von Fetten als Energiespeicher.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "83c2d8a2-7922-5bb2-9082-e76c7c255b75",
+          "passageId": "by-bio:B13-EA.3",
+          "topicCode": "B13-EA.3",
+          "sourceSpan": "B13-EA.3.15",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.15",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.3"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.3"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.3.15"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.3.15"
+      ]
+    },
+    {
+      "id": "9c592678-5737-5cc2-a26b-129d21809937",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 1,
+      "aspectIndex": 1,
+      "title": "charakterisieren ein Biotop, indem sie abiotische Faktoren messen und analysieren.",
+      "description": "charakterisieren ein Biotop, indem sie abiotische Faktoren messen und analysieren.",
+      "sourceText": "charakterisieren ein Biotop, indem sie abiotische Faktoren messen und analysieren.",
+      "sourceSpan": "B13-EA.4.1",
+      "parentBulletText": "charakterisieren ein Biotop, indem sie abiotische Faktoren messen und analysieren.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.1",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4",
+        "topic:B13-GA.4"
+      ],
+      "rawSourceText": "charakterisieren ein Biotop, indem sie abiotische Faktoren messen und analysieren.",
+      "rawSourceSpan": "B13-EA.4.1",
+      "rawParentBulletText": "charakterisieren ein Biotop, indem sie abiotische Faktoren messen und analysieren.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "9c592678-5737-5cc2-a26b-129d21809937",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.1",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        },
+        {
+          "sourceGoalId": "2bd93013-c2f3-50e6-a46b-660b74a87770",
+          "passageId": "by-bio:B13-GA.4",
+          "topicCode": "B13-GA.4",
+          "sourceSpan": "B13-GA.4.1",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.1",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4",
+        "B13-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.1",
+        "B13-GA.4.1"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.1",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.1"
+      ]
+    },
+    {
+      "id": "e08c3873-98f8-575d-b3a7-29d02b096d33",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 2,
+      "aspectIndex": 1,
+      "title": "nutzen Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose qua...",
+      "description": "nutzen Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose qualitativ zu erfassen.",
+      "sourceText": "nutzen Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose qualitativ zu erfassen.",
+      "sourceSpan": "B13-EA.4.2",
+      "parentBulletText": "nutzen Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose qualitativ zu erfassen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.2",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4",
+        "topic:B13-GA.4"
+      ],
+      "rawSourceText": "nutzen Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose qualitativ zu erfassen.",
+      "rawSourceSpan": "B13-EA.4.2",
+      "rawParentBulletText": "nutzen Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose qualitativ zu erfassen.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "e08c3873-98f8-575d-b3a7-29d02b096d33",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.2",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        },
+        {
+          "sourceGoalId": "148a6cb5-f5a0-5f31-a1ed-991c87aa2ec8",
+          "passageId": "by-bio:B13-GA.4",
+          "topicCode": "B13-GA.4",
+          "sourceSpan": "B13-GA.4.2",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.2",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4",
+        "B13-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.2",
+        "B13-GA.4.2"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.2",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.2"
+      ]
+    },
+    {
+      "id": "cb9339eb-77ea-5101-a053-9d33d1ad9160",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 3,
+      "aspectIndex": 1,
+      "title": "erheben Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose qu...",
+      "description": "erheben Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose quantitativ zu erfassen.",
+      "sourceText": "erheben Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose quantitativ zu erfassen.",
+      "sourceSpan": "B13-EA.4.3",
+      "parentBulletText": "erheben Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose quantitativ zu erfassen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.3",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4"
+      ],
+      "rawSourceText": "erheben Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose quantitativ zu erfassen.",
+      "rawSourceSpan": "B13-EA.4.3",
+      "rawParentBulletText": "erheben Daten aus wissenschaftlicher Feldforschung, um die Zusammensetzung einer Biozönose quantitativ zu erfassen.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "cb9339eb-77ea-5101-a053-9d33d1ad9160",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.3",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.3"
+      ]
+    },
+    {
+      "id": "a1ad7b4e-8e58-5f07-976c-8917f3278ef6",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 4,
+      "aspectIndex": 1,
+      "title": "beschreiben Nahrungsbeziehungen zwischen Arten, ordnen sie einer Trophieebene zu und erläuter...",
+      "description": "beschreiben Nahrungsbeziehungen zwischen Arten, ordnen sie einer Trophieebene zu und erläutern einen Stoffkreislauf sowie den Energiefluss in einem Ökosystem.",
+      "sourceText": "beschreiben Nahrungsbeziehungen zwischen Arten, ordnen sie einer Trophieebene zu und erläutern einen Stoffkreislauf sowie den Energiefluss in einem Ökosystem.",
+      "sourceSpan": "B13-EA.4.4",
+      "parentBulletText": "beschreiben Nahrungsbeziehungen zwischen Arten, ordnen sie einer Trophieebene zu und erläutern einen Stoffkreislauf sowie den Energiefluss in einem Ökosystem.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.4",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4",
+        "topic:B13-GA.4"
+      ],
+      "rawSourceText": "beschreiben Nahrungsbeziehungen zwischen Arten, ordnen sie einer Trophieebene zu und erläutern einen Stoffkreislauf sowie den Energiefluss in einem Ökosystem.",
+      "rawSourceSpan": "B13-EA.4.4",
+      "rawParentBulletText": "beschreiben Nahrungsbeziehungen zwischen Arten, ordnen sie einer Trophieebene zu und erläutern einen Stoffkreislauf sowie den Energiefluss in einem Ökosystem.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "a1ad7b4e-8e58-5f07-976c-8917f3278ef6",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.4",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        },
+        {
+          "sourceGoalId": "8fee9e13-e6fb-54a7-8928-7e4c9d8b3c1b",
+          "passageId": "by-bio:B13-GA.4",
+          "topicCode": "B13-GA.4",
+          "sourceSpan": "B13-GA.4.3",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.3",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4",
+        "B13-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.4",
+        "B13-GA.4.3"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.4",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.3"
+      ]
+    },
+    {
+      "id": "1d8afbf7-53ac-5e23-9c55-017759c91883",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 5,
+      "aspectIndex": 1,
+      "title": "erklären unter Einbeziehung von Laborversuchen die ökologische Potenz von Lebewesen bezüglich...",
+      "description": "erklären unter Einbeziehung von Laborversuchen die ökologische Potenz von Lebewesen bezüglich abiotischer Faktoren, um die Eignung von Lebensräumen für Lebewesen zu beurteilen.",
+      "sourceText": "erklären unter Einbeziehung von Laborversuchen die ökologische Potenz von Lebewesen bezüglich abiotischer Faktoren, um die Eignung von Lebensräumen für Lebewesen zu beurteilen.",
+      "sourceSpan": "B13-EA.4.5",
+      "parentBulletText": "erklären unter Einbeziehung von Laborversuchen die ökologische Potenz von Lebewesen bezüglich abiotischer Faktoren, um die Eignung von Lebensräumen für Lebewesen zu beurteilen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.5",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4",
+        "topic:B13-GA.4"
+      ],
+      "rawSourceText": "erklären unter Einbeziehung von Laborversuchen die ökologische Potenz von Lebewesen bezüglich abiotischer Faktoren, um die Eignung von Lebensräumen für Lebewesen zu beurteilen.",
+      "rawSourceSpan": "B13-EA.4.5",
+      "rawParentBulletText": "erklären unter Einbeziehung von Laborversuchen die ökologische Potenz von Lebewesen bezüglich abiotischer Faktoren, um die Eignung von Lebensräumen für Lebewesen zu beurteilen.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "1d8afbf7-53ac-5e23-9c55-017759c91883",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.5",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        },
+        {
+          "sourceGoalId": "8d43eda3-6383-542b-8cb6-4eefe4c45be2",
+          "passageId": "by-bio:B13-GA.4",
+          "topicCode": "B13-GA.4",
+          "sourceSpan": "B13-GA.4.4",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.4",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4",
+        "B13-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.5",
+        "B13-GA.4.4"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.5",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.4"
+      ]
+    },
+    {
+      "id": "344bc982-be2b-58ae-b270-72f9fac98ad9",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "beschreiben die unterschiedliche Einflussnahme biotischer Faktoren auf ein Lebewesen und erkl...",
+      "description": "beschreiben die unterschiedliche Einflussnahme biotischer Faktoren auf ein Lebewesen und erklären das Konzept der ökologischen Nische als Zusammenspiel biotischer und abiotischer Faktoren, aus dem sich die Zusammensetzung der Biozönose eines Ökosystems ergibt.",
+      "sourceText": "beschreiben die unterschiedliche Einflussnahme biotischer Faktoren auf ein Lebewesen und erklären das Konzept der ökologischen Nische als Zusammenspiel biotischer und abiotischer Faktoren, aus dem sich die Zusammensetzung der Biozönose eines Ökosystems ergibt.",
+      "sourceSpan": "B13-EA.4.6",
+      "parentBulletText": "beschreiben die unterschiedliche Einflussnahme biotischer Faktoren auf ein Lebewesen und erklären das Konzept der ökologischen Nische als Zusammenspiel biotischer und abiotischer Faktoren, aus dem sich die Zusammensetzung der Biozönose eines Ökosystems ergibt.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.6",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4",
+        "topic:B13-GA.4"
+      ],
+      "rawSourceText": "beschreiben die unterschiedliche Einflussnahme biotischer Faktoren auf ein Lebewesen und erklären das Konzept der ökologischen Nische als Zusammenspiel biotischer und abiotischer Faktoren, aus dem sich die Zusammensetzung der Biozönose eines Ökosystems ergibt.",
+      "rawSourceSpan": "B13-EA.4.6",
+      "rawParentBulletText": "beschreiben die unterschiedliche Einflussnahme biotischer Faktoren auf ein Lebewesen und erklären das Konzept der ökologischen Nische als Zusammenspiel biotischer und abiotischer Faktoren, aus dem sich die Zusammensetzung der Biozönose eines Ökosystems ergibt.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "344bc982-be2b-58ae-b270-72f9fac98ad9",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.6",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        },
+        {
+          "sourceGoalId": "e6c0ded7-e175-5a5b-993c-d9d196ce77ae",
+          "passageId": "by-bio:B13-GA.4",
+          "topicCode": "B13-GA.4",
+          "sourceSpan": "B13-GA.4.5",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.5",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4",
+        "B13-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.6",
+        "B13-GA.4.5"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.6",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.5"
+      ]
+    },
+    {
+      "id": "cab06faf-bb5a-5f1e-8a50-6f2430dd6ebc",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 7,
+      "aspectIndex": 1,
+      "title": "unterscheiden verschiedene Fortpflanzungsstrategien, erläutern die verschiedenen Phasen der P...",
+      "description": "unterscheiden verschiedene Fortpflanzungsstrategien, erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.",
+      "sourceText": "unterscheiden verschiedene Fortpflanzungsstrategien, erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.",
+      "sourceSpan": "B13-EA.4.7",
+      "parentBulletText": "unterscheiden verschiedene Fortpflanzungsstrategien, erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.7",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4"
+      ],
+      "rawSourceText": "unterscheiden verschiedene Fortpflanzungsstrategien, erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.",
+      "rawSourceSpan": "B13-EA.4.7",
+      "rawParentBulletText": "unterscheiden verschiedene Fortpflanzungsstrategien, erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "cab06faf-bb5a-5f1e-8a50-6f2430dd6ebc",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.7",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.7"
+      ]
+    },
+    {
+      "id": "76396e7e-380d-5145-b80a-e07be34b1adb",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 8,
+      "aspectIndex": 1,
+      "title": "unterscheiden Bereiche, in denen der Mensch die Ressourcen von Ökosystemen nutzt und erklären...",
+      "description": "unterscheiden Bereiche, in denen der Mensch die Ressourcen von Ökosystemen nutzt und erklären die Bedeutung dieser Ökosystemleistungen für den Menschen.",
+      "sourceText": "unterscheiden Bereiche, in denen der Mensch die Ressourcen von Ökosystemen nutzt und erklären die Bedeutung dieser Ökosystemleistungen für den Menschen.",
+      "sourceSpan": "B13-EA.4.8",
+      "parentBulletText": "unterscheiden Bereiche, in denen der Mensch die Ressourcen von Ökosystemen nutzt und erklären die Bedeutung dieser Ökosystemleistungen für den Menschen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.8",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4",
+        "topic:B13-GA.4"
+      ],
+      "rawSourceText": "unterscheiden Bereiche, in denen der Mensch die Ressourcen von Ökosystemen nutzt und erklären die Bedeutung dieser Ökosystemleistungen für den Menschen.",
+      "rawSourceSpan": "B13-EA.4.8",
+      "rawParentBulletText": "unterscheiden Bereiche, in denen der Mensch die Ressourcen von Ökosystemen nutzt und erklären die Bedeutung dieser Ökosystemleistungen für den Menschen.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "76396e7e-380d-5145-b80a-e07be34b1adb",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.8",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        },
+        {
+          "sourceGoalId": "0fc8ab21-c591-53a0-bc8c-4ebc9fc952e8",
+          "passageId": "by-bio:B13-GA.4",
+          "topicCode": "B13-GA.4",
+          "sourceSpan": "B13-GA.4.7",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.7",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4",
+        "B13-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.8",
+        "B13-GA.4.7"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.8",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.7"
+      ]
+    },
+    {
+      "id": "e1e63025-54b6-51de-ba35-8343f70f6c30",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 9,
+      "aspectIndex": 1,
+      "title": "vergleichen verschieden stark beeinflusste Ökosysteme nach dem Konzept der Ökosystemleistunge...",
+      "description": "vergleichen verschieden stark beeinflusste Ökosysteme nach dem Konzept der Ökosystemleistungen, um den Wert von Erhalt bzw. Renaturierung durch einen Ökosystemmanagementprozess einzuschätzen.",
+      "sourceText": "vergleichen verschieden stark beeinflusste Ökosysteme nach dem Konzept der Ökosystemleistungen, um den Wert von Erhalt bzw. Renaturierung durch einen Ökosystemmanagementprozess einzuschätzen.",
+      "sourceSpan": "B13-EA.4.9",
+      "parentBulletText": "vergleichen verschieden stark beeinflusste Ökosysteme nach dem Konzept der Ökosystemleistungen, um den Wert von Erhalt bzw. Renaturierung durch einen Ökosystemmanagementprozess einzuschätzen.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.9",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4",
+        "topic:B13-GA.4"
+      ],
+      "rawSourceText": "vergleichen verschieden stark beeinflusste Ökosysteme nach dem Konzept der Ökosystemleistungen, um den Wert von Erhalt bzw. Renaturierung durch einen Ökosystemmanagementprozess einzuschätzen.",
+      "rawSourceSpan": "B13-EA.4.9",
+      "rawParentBulletText": "vergleichen verschieden stark beeinflusste Ökosysteme nach dem Konzept der Ökosystemleistungen, um den Wert von Erhalt bzw. Renaturierung durch einen Ökosystemmanagementprozess einzuschätzen.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "e1e63025-54b6-51de-ba35-8343f70f6c30",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.9",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        },
+        {
+          "sourceGoalId": "60dd81ee-67d7-5b65-add8-07fc9c111c85",
+          "passageId": "by-bio:B13-GA.4",
+          "topicCode": "B13-GA.4",
+          "sourceSpan": "B13-GA.4.8",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.8",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4",
+        "B13-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.9",
+        "B13-GA.4.8"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.9",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.8"
+      ]
+    },
+    {
+      "id": "aff07640-c257-575c-b4ed-0df8c4e63c42",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 10,
+      "aspectIndex": 1,
+      "title": "reflektieren die anthropozentrische Bewertung der Natur und sind sich dadurch der Notwendigke...",
+      "description": "reflektieren die anthropozentrische Bewertung der Natur und sind sich dadurch der Notwendigkeit einer Werteabwägung bewusst.",
+      "sourceText": "reflektieren die anthropozentrische Bewertung der Natur und sind sich dadurch der Notwendigkeit einer Werteabwägung bewusst.",
+      "sourceSpan": "B13-EA.4.10",
+      "parentBulletText": "reflektieren die anthropozentrische Bewertung der Natur und sind sich dadurch der Notwendigkeit einer Werteabwägung bewusst.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.10",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4",
+        "topic:B13-GA.4"
+      ],
+      "rawSourceText": "reflektieren die anthropozentrische Bewertung der Natur und sind sich dadurch der Notwendigkeit einer Werteabwägung bewusst.",
+      "rawSourceSpan": "B13-EA.4.10",
+      "rawParentBulletText": "reflektieren die anthropozentrische Bewertung der Natur und sind sich dadurch der Notwendigkeit einer Werteabwägung bewusst.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "aff07640-c257-575c-b4ed-0df8c4e63c42",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.10",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        },
+        {
+          "sourceGoalId": "5ebbc77b-8ed7-543d-831d-ca82c9365409",
+          "passageId": "by-bio:B13-GA.4",
+          "topicCode": "B13-GA.4",
+          "sourceSpan": "B13-GA.4.9",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.9",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4",
+        "B13-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.10",
+        "B13-GA.4.9"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.10",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.9"
+      ]
+    },
+    {
+      "id": "64e79e74-14ce-5d51-8fb4-fbcea8bb1108",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 11,
+      "aspectIndex": 1,
+      "title": "beschreiben abiotische Wechselwirkungen, mit denen sich Biome gegenseitig beeinflussen, um ih...",
+      "description": "beschreiben abiotische Wechselwirkungen, mit denen sich Biome gegenseitig beeinflussen, um ihre weltweite Vernetzung zu erläutern und die Auswirkungen von Störungen auf die Biodiversität zu modellieren.",
+      "sourceText": "beschreiben abiotische Wechselwirkungen, mit denen sich Biome gegenseitig beeinflussen, um ihre weltweite Vernetzung zu erläutern und die Auswirkungen von Störungen auf die Biodiversität zu modellieren.",
+      "sourceSpan": "B13-EA.4.11",
+      "parentBulletText": "beschreiben abiotische Wechselwirkungen, mit denen sich Biome gegenseitig beeinflussen, um ihre weltweite Vernetzung zu erläutern und die Auswirkungen von Störungen auf die Biodiversität zu modellieren.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.11",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4"
+      ],
+      "rawSourceText": "beschreiben abiotische Wechselwirkungen, mit denen sich Biome gegenseitig beeinflussen, um ihre weltweite Vernetzung zu erläutern und die Auswirkungen von Störungen auf die Biodiversität zu modellieren.",
+      "rawSourceSpan": "B13-EA.4.11",
+      "rawParentBulletText": "beschreiben abiotische Wechselwirkungen, mit denen sich Biome gegenseitig beeinflussen, um ihre weltweite Vernetzung zu erläutern und die Auswirkungen von Störungen auf die Biodiversität zu modellieren.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "64e79e74-14ce-5d51-8fb4-fbcea8bb1108",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.11",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.11",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.11"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.11"
+      ]
+    },
+    {
+      "id": "4fa3224c-60b1-51d9-9075-ba66439a729b",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 12,
+      "aspectIndex": 1,
+      "title": "erklären an konkreten Beispielen die globalen Auswirkungen lokaler menschlicher Eingriffe auf...",
+      "description": "erklären an konkreten Beispielen die globalen Auswirkungen lokaler menschlicher Eingriffe auf die Biosphäre.",
+      "sourceText": "erklären an konkreten Beispielen die globalen Auswirkungen lokaler menschlicher Eingriffe auf die Biosphäre.",
+      "sourceSpan": "B13-EA.4.12",
+      "parentBulletText": "erklären an konkreten Beispielen die globalen Auswirkungen lokaler menschlicher Eingriffe auf die Biosphäre.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.12",
+      "courseLevel": "LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4"
+      ],
+      "rawSourceText": "erklären an konkreten Beispielen die globalen Auswirkungen lokaler menschlicher Eingriffe auf die Biosphäre.",
+      "rawSourceSpan": "B13-EA.4.12",
+      "rawParentBulletText": "erklären an konkreten Beispielen die globalen Auswirkungen lokaler menschlicher Eingriffe auf die Biosphäre.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "4fa3224c-60b1-51d9-9075-ba66439a729b",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.12",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.12",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.12"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.12"
+      ]
+    },
+    {
+      "id": "e8e2f7a6-c2e2-537e-85aa-cd00aeb61941",
+      "passageId": "by-bio:B13-EA.4",
+      "topicCode": "B13-EA.4",
+      "bulletIndex": 13,
+      "aspectIndex": 1,
+      "title": "analysieren aus verschiedenen Perspektiven Dilemmata, die sich durch Interessenkonflikte aus ...",
+      "description": "analysieren aus verschiedenen Perspektiven Dilemmata, die sich durch Interessenkonflikte aus der persönlichen Lebenswelt zwischen ökonomischen und ökologischen Erfordernissen ergeben und leiten durch eine individuelle Wertehierarchisierung Handlungsoptionen für eine nachhaltige Lebensweise auf persönlicher und gesellschaftlicher Ebene ab.",
+      "sourceText": "analysieren aus verschiedenen Perspektiven Dilemmata, die sich durch Interessenkonflikte aus der persönlichen Lebenswelt zwischen ökonomischen und ökologischen Erfordernissen ergeben und leiten durch eine individuelle Wertehierarchisierung Handlungsoptionen für eine nachhaltige Lebensweise auf persönlicher und gesellschaftlicher Ebene ab.",
+      "sourceSpan": "B13-EA.4.13",
+      "parentBulletText": "analysieren aus verschiedenen Perspektiven Dilemmata, die sich durch Interessenkonflikte aus der persönlichen Lebenswelt zwischen ökonomischen und ökologischen Erfordernissen ergeben und leiten durch eine individuelle Wertehierarchisierung Handlungsoptionen für eine nachhaltige Lebensweise auf persönlicher und gesellschaftlicher Ebene ab.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.13",
+      "courseLevel": "GK_LK+LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "courseLevel:LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-EA.4",
+        "topic:B13-GA.4"
+      ],
+      "rawSourceText": "analysieren aus verschiedenen Perspektiven Dilemmata, die sich durch Interessenkonflikte aus der persönlichen Lebenswelt zwischen ökonomischen und ökologischen Erfordernissen ergeben und leiten durch eine individuelle Wertehierarchisierung Handlungsoptionen für eine nachhaltige Lebensweise auf persönlicher und gesellschaftlicher Ebene ab.",
+      "rawSourceSpan": "B13-EA.4.13",
+      "rawParentBulletText": "analysieren aus verschiedenen Perspektiven Dilemmata, die sich durch Interessenkonflikte aus der persönlichen Lebenswelt zwischen ökonomischen und ökologischen Erfordernissen ergeben und leiten durch eine individuelle Wertehierarchisierung Handlungsoptionen für eine nachhaltige Lebensweise auf persönlicher und gesellschaftlicher Ebene ab.",
+      "duplicateSourceGoalCount": 1,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "e8e2f7a6-c2e2-537e-85aa-cd00aeb61941",
+          "passageId": "by-bio:B13-EA.4",
+          "topicCode": "B13-EA.4",
+          "sourceSpan": "B13-EA.4.13",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.13",
+          "courseLevel": "LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:LK",
+            "topic:B13-EA.4"
+          ]
+        },
+        {
+          "sourceGoalId": "4fa6769a-e5c6-5fc1-8e63-3330ff8c74eb",
+          "passageId": "by-bio:B13-GA.4",
+          "topicCode": "B13-GA.4",
+          "sourceSpan": "B13-GA.4.10",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.10",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-EA.4",
+        "B13-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-EA.4.13",
+        "B13-GA.4.10"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-EA.4.13",
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.10"
+      ]
+    },
+    {
+      "id": "869296c0-5dd5-5c02-9e9f-bf6fe53420e1",
+      "passageId": "by-bio:B13-GA.4",
+      "topicCode": "B13-GA.4",
+      "bulletIndex": 6,
+      "aspectIndex": 1,
+      "title": "erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit d...",
+      "description": "erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.",
+      "sourceText": "erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.",
+      "sourceSpan": "B13-GA.4.6",
+      "parentBulletText": "erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.",
+      "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.6",
+      "courseLevel": "GK_LK",
+      "granularity": "officialCompetency",
+      "tags": [
+        "courseLevel:GK_LK",
+        "jurisdiction:DE-BY",
+        "stage:SekII",
+        "topic:B13-GA.4"
+      ],
+      "rawSourceText": "erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.",
+      "rawSourceSpan": "B13-GA.4.6",
+      "rawParentBulletText": "erläutern die verschiedenen Phasen der Populationsentwicklung und begründen die Dynamik mit dem Einfluss von Umweltfaktoren auf die Population und selbstregulierenden Faktoren in der Population.",
+      "duplicateSourceGoalCount": 0,
+      "sourceOccurrences": [
+        {
+          "sourceGoalId": "869296c0-5dd5-5c02-9e9f-bf6fe53420e1",
+          "passageId": "by-bio:B13-GA.4",
+          "topicCode": "B13-GA.4",
+          "sourceSpan": "B13-GA.4.6",
+          "sourceRef": "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.6",
+          "courseLevel": "GK_LK",
+          "tags": [
+            "jurisdiction:DE-BY",
+            "stage:SekII",
+            "courseLevel:GK_LK",
+            "topic:B13-GA.4"
+          ]
+        }
+      ],
+      "mergedTopicCodes": [
+        "B13-GA.4"
+      ],
+      "mergedSourceSpans": [
+        "B13-GA.4.6"
+      ],
+      "mergedSourceRefs": [
+        "LehrplanPLUS Bayern Gymnasium Biologie, B13-GA.4.6"
+      ]
+    }
+  ],
+  "qualityReview": {
+    "sourceGoalCountPeerBaseline": {
+      "accepted": true,
+      "details": "Identische Kompetenzformulierungen aus parallelen GA/EA-Profilen wurden auf 222 repraesentative Source-Ziele normalisiert; 32 Originalpassagen und 362 Fundstellen bleiben ueber sourceOccurrences erhalten."
+    }
+  }
+}

--- a/curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_biology_source_extraction_to_canonical_biology.review.json
+++ b/curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_biology_source_extraction_to_canonical_biology.review.json
@@ -1,0 +1,406 @@
+{
+  "version": 1,
+  "reviewId": "bavaria_biology_source_extraction_to_canonical_biology.review",
+  "sourceLandscapeId": "357a7003-b636-570e-a0bd-6bb63518d2f6",
+  "targetLandscapeId": "08a43a1b-d97e-522c-9dfa-c950a493364e",
+  "sourceExtractionPath": "curricula/DE/Gymnasium/input/BY/gymnasium/source-extraction/DE_BY_BIOLOGIE_GYMNASIUM_LEHRPLANPLUS.source-extraction.json",
+  "status": "incomplete",
+  "summary": {
+    "sourceGoals": 222,
+    "originalSourceGoalsBeforeDeduplication": 362,
+    "duplicateTextGroups": 78,
+    "reviewedSourceGoals": 0,
+    "seedMappedSourceGoals": 62,
+    "mappedSourceGoals": 0,
+    "needsCanonicalGoal": 0,
+    "exactMappings": 42,
+    "partialMappings": 22
+  },
+  "mappings": [
+    {
+      "legacyGoalId": "091a3a55-29bf-50dd-a701-bed0026280fe",
+      "canonicalGoalId": "ce19b80f-d392-5851-ac92-750c85adfb3e",
+      "matchType": "exact",
+      "reviewDecisionId": "091a3a55-29bf-50dd-a701-bed0026280fe"
+    },
+    {
+      "legacyGoalId": "ad855269-70c3-526c-951b-cc2d54106f36",
+      "canonicalGoalId": "146d70e0-b494-59fa-b8b6-29da18b36893",
+      "matchType": "exact",
+      "reviewDecisionId": "ad855269-70c3-526c-951b-cc2d54106f36"
+    },
+    {
+      "legacyGoalId": "92e3879a-12e7-56d6-b8c0-94e61db932c4",
+      "canonicalGoalId": "97a15c19-c345-589e-8b3c-9f2b97a60095",
+      "matchType": "partial",
+      "reviewDecisionId": "92e3879a-12e7-56d6-b8c0-94e61db932c4"
+    },
+    {
+      "legacyGoalId": "f9d70cb7-d9fa-5351-bd87-b5a1ac48c918",
+      "canonicalGoalId": "19758e09-1bc4-5ee4-bf52-89b3bc28e947",
+      "matchType": "exact",
+      "reviewDecisionId": "f9d70cb7-d9fa-5351-bd87-b5a1ac48c918"
+    },
+    {
+      "legacyGoalId": "0236413c-a800-5cc7-94d8-071e45ed8948",
+      "canonicalGoalId": "19758e09-1bc4-5ee4-bf52-89b3bc28e947",
+      "matchType": "exact",
+      "reviewDecisionId": "0236413c-a800-5cc7-94d8-071e45ed8948"
+    },
+    {
+      "legacyGoalId": "d275b9f4-09ed-5b32-951c-df550720204d",
+      "canonicalGoalId": "02cabf54-0b70-572c-b85a-7409e686a48e",
+      "matchType": "partial",
+      "reviewDecisionId": "d275b9f4-09ed-5b32-951c-df550720204d"
+    },
+    {
+      "legacyGoalId": "d51e6243-8b61-5bb5-b9e8-99456895d22a",
+      "canonicalGoalId": "fdc82200-dfc1-53ec-a5b9-bd4cfaf1e35f",
+      "matchType": "exact",
+      "reviewDecisionId": "d51e6243-8b61-5bb5-b9e8-99456895d22a"
+    },
+    {
+      "legacyGoalId": "dc5044f4-bf54-5642-8201-49dcf8dce9e1",
+      "canonicalGoalId": "5b2571d9-f079-52b2-b21b-8f389c7409f4",
+      "matchType": "partial",
+      "reviewDecisionId": "dc5044f4-bf54-5642-8201-49dcf8dce9e1"
+    },
+    {
+      "legacyGoalId": "e4f857b8-85da-58e5-9fb4-b4f05048d3b5",
+      "canonicalGoalId": "0daa79f6-8f61-5506-98f9-65db83062ba8",
+      "matchType": "exact",
+      "reviewDecisionId": "e4f857b8-85da-58e5-9fb4-b4f05048d3b5"
+    },
+    {
+      "legacyGoalId": "a6ad1554-558e-51e4-9d05-aa9b38ebfa40",
+      "canonicalGoalId": "475eebb4-4eb0-524f-b1ec-4a672bf856d2",
+      "matchType": "exact",
+      "reviewDecisionId": "a6ad1554-558e-51e4-9d05-aa9b38ebfa40"
+    },
+    {
+      "legacyGoalId": "e0bbe3b2-96d7-5e7a-b8c1-d649a084e355",
+      "canonicalGoalId": "ec88fc1d-ee0f-5a01-9464-dc358241050e",
+      "matchType": "exact",
+      "reviewDecisionId": "e0bbe3b2-96d7-5e7a-b8c1-d649a084e355"
+    },
+    {
+      "legacyGoalId": "1ad96d9d-03d9-565f-94b2-94f6ed17c523",
+      "canonicalGoalId": "d11b3b18-deec-5d1a-bff6-512cddf595a2",
+      "matchType": "exact",
+      "reviewDecisionId": "1ad96d9d-03d9-565f-94b2-94f6ed17c523"
+    },
+    {
+      "legacyGoalId": "2802979c-6270-521c-87e0-1ed9360d6bea",
+      "canonicalGoalId": "e36bebef-d7e3-57d0-bf01-236799d41cb7",
+      "matchType": "partial",
+      "reviewDecisionId": "2802979c-6270-521c-87e0-1ed9360d6bea"
+    },
+    {
+      "legacyGoalId": "b17074cd-317a-512a-a4d8-6fbd5d037dd4",
+      "canonicalGoalId": "7008979d-7890-5f7b-ad07-27b8bb597cbe",
+      "matchType": "exact",
+      "reviewDecisionId": "b17074cd-317a-512a-a4d8-6fbd5d037dd4"
+    },
+    {
+      "legacyGoalId": "efe8409f-0ba6-58e4-80ae-3967c4e9f4be",
+      "canonicalGoalId": "002543f9-2d14-5c57-99b4-fb4bf7e53734",
+      "matchType": "exact",
+      "reviewDecisionId": "efe8409f-0ba6-58e4-80ae-3967c4e9f4be"
+    },
+    {
+      "legacyGoalId": "dc172e4b-d8df-5b79-85ca-1116c2b64019",
+      "canonicalGoalId": "9f73b963-5fac-5a90-a993-d7b7c0cc8526",
+      "matchType": "exact",
+      "reviewDecisionId": "dc172e4b-d8df-5b79-85ca-1116c2b64019"
+    },
+    {
+      "legacyGoalId": "2310bc26-c562-59d5-a45e-343d6b031c94",
+      "canonicalGoalId": "002543f9-2d14-5c57-99b4-fb4bf7e53734",
+      "matchType": "exact",
+      "reviewDecisionId": "2310bc26-c562-59d5-a45e-343d6b031c94"
+    },
+    {
+      "legacyGoalId": "791145f3-650f-5e1a-84f7-2619aceb6a6a",
+      "canonicalGoalId": "302c6d6d-bf10-5dbc-adda-65e4b5c63e49",
+      "matchType": "exact",
+      "reviewDecisionId": "791145f3-650f-5e1a-84f7-2619aceb6a6a"
+    },
+    {
+      "legacyGoalId": "6f8d420f-8a58-5c17-86fd-32925065f51f",
+      "canonicalGoalId": "ce19b80f-d392-5851-ac92-750c85adfb3e",
+      "matchType": "exact",
+      "reviewDecisionId": "6f8d420f-8a58-5c17-86fd-32925065f51f"
+    },
+    {
+      "legacyGoalId": "1ab76608-e31b-5f03-822a-962c02ee922d",
+      "canonicalGoalId": "ff1bf88f-2413-5668-a071-ce9fc499cba3",
+      "matchType": "exact",
+      "reviewDecisionId": "1ab76608-e31b-5f03-822a-962c02ee922d"
+    },
+    {
+      "legacyGoalId": "8832a55d-988a-5848-81d4-1dc529f7b6e9",
+      "canonicalGoalId": "485ef1c3-8997-52b7-91f5-b1ddf179013d",
+      "matchType": "exact",
+      "reviewDecisionId": "8832a55d-988a-5848-81d4-1dc529f7b6e9"
+    },
+    {
+      "legacyGoalId": "644bde9d-2d47-57a2-aff3-5dc5bf956f31",
+      "canonicalGoalId": "e1117126-4e78-5a37-a645-2debc167219b",
+      "matchType": "exact",
+      "reviewDecisionId": "644bde9d-2d47-57a2-aff3-5dc5bf956f31"
+    },
+    {
+      "legacyGoalId": "e026e617-09d5-53d1-aa11-9cdb8f3d6b00",
+      "canonicalGoalId": "afde0001-d7d7-5ed3-8a60-383e8da5620e",
+      "matchType": "exact",
+      "reviewDecisionId": "e026e617-09d5-53d1-aa11-9cdb8f3d6b00"
+    },
+    {
+      "legacyGoalId": "1935a0a9-d746-5b57-b1b7-82cc155ce91e",
+      "canonicalGoalId": "347110a1-1d2e-5195-8acc-64e7e3893ce5",
+      "matchType": "exact",
+      "reviewDecisionId": "1935a0a9-d746-5b57-b1b7-82cc155ce91e"
+    },
+    {
+      "legacyGoalId": "8c6774a3-2a98-5b76-9ecd-8ad97f97440c",
+      "canonicalGoalId": "485ef1c3-8997-52b7-91f5-b1ddf179013d",
+      "matchType": "exact",
+      "reviewDecisionId": "8c6774a3-2a98-5b76-9ecd-8ad97f97440c"
+    },
+    {
+      "legacyGoalId": "453a6fad-aecc-502f-a5b3-a9e9c54aa9e2",
+      "canonicalGoalId": "19758e09-1bc4-5ee4-bf52-89b3bc28e947",
+      "matchType": "exact",
+      "reviewDecisionId": "453a6fad-aecc-502f-a5b3-a9e9c54aa9e2"
+    },
+    {
+      "legacyGoalId": "0a6b6a3f-47a1-5a90-bc23-75417cfecdd6",
+      "canonicalGoalId": "78748ef2-93fb-5ec3-8c1e-90e42b9ea863",
+      "matchType": "exact",
+      "reviewDecisionId": "0a6b6a3f-47a1-5a90-bc23-75417cfecdd6"
+    },
+    {
+      "legacyGoalId": "51a5bf48-51c9-518f-b4e6-fe4a8c073b7d",
+      "canonicalGoalId": "8678d0b5-8b74-5b01-8143-91bfea1e4482",
+      "matchType": "exact",
+      "reviewDecisionId": "51a5bf48-51c9-518f-b4e6-fe4a8c073b7d"
+    },
+    {
+      "legacyGoalId": "b342744e-60c2-5ce2-b281-5eb19943a1ce",
+      "canonicalGoalId": "32f47903-0788-5c27-ac88-7464f481f2f7",
+      "matchType": "exact",
+      "reviewDecisionId": "b342744e-60c2-5ce2-b281-5eb19943a1ce"
+    },
+    {
+      "legacyGoalId": "f9c70e85-e4e4-57ce-908a-6baa772ec0d9",
+      "canonicalGoalId": "6020a221-ad96-50dc-9b99-b0bf6815366f",
+      "matchType": "exact",
+      "reviewDecisionId": "f9c70e85-e4e4-57ce-908a-6baa772ec0d9"
+    },
+    {
+      "legacyGoalId": "861204d6-ce05-53c9-979f-6a69513a2313",
+      "canonicalGoalId": "ce6550f0-4ec3-5dd9-ab02-0296da98a371",
+      "matchType": "exact",
+      "reviewDecisionId": "861204d6-ce05-53c9-979f-6a69513a2313"
+    },
+    {
+      "legacyGoalId": "a6d4b0eb-e267-558e-9e13-6eb671484c30",
+      "canonicalGoalId": "de5ba3a5-7c5f-5ee3-89d3-c97a0d4eeaf0",
+      "matchType": "exact",
+      "reviewDecisionId": "a6d4b0eb-e267-558e-9e13-6eb671484c30"
+    },
+    {
+      "legacyGoalId": "e412f11f-bc30-5de4-b06d-8712fbf88b08",
+      "canonicalGoalId": "8e2244e1-8616-5f24-859f-8e10df1c887b",
+      "matchType": "exact",
+      "reviewDecisionId": "e412f11f-bc30-5de4-b06d-8712fbf88b08"
+    },
+    {
+      "legacyGoalId": "b1a59da6-a2e7-5cb1-94ae-84d59a40f303",
+      "canonicalGoalId": "135447a0-5d55-564a-afc3-3e3fbed77819",
+      "matchType": "exact",
+      "reviewDecisionId": "b1a59da6-a2e7-5cb1-94ae-84d59a40f303"
+    },
+    {
+      "legacyGoalId": "9c592678-5737-5cc2-a26b-129d21809937",
+      "canonicalGoalId": "ac4a650d-45a9-519d-9e4d-1f87910f8844",
+      "matchType": "exact",
+      "reviewDecisionId": "9c592678-5737-5cc2-a26b-129d21809937"
+    },
+    {
+      "legacyGoalId": "e08c3873-98f8-575d-b3a7-29d02b096d33",
+      "canonicalGoalId": "ac4a650d-45a9-519d-9e4d-1f87910f8844",
+      "matchType": "exact",
+      "reviewDecisionId": "e08c3873-98f8-575d-b3a7-29d02b096d33"
+    },
+    {
+      "legacyGoalId": "cb9339eb-77ea-5101-a053-9d33d1ad9160",
+      "canonicalGoalId": "ac4a650d-45a9-519d-9e4d-1f87910f8844",
+      "matchType": "exact",
+      "reviewDecisionId": "cb9339eb-77ea-5101-a053-9d33d1ad9160"
+    },
+    {
+      "legacyGoalId": "a1ad7b4e-8e58-5f07-976c-8917f3278ef6",
+      "canonicalGoalId": "ea5d75af-d97f-593a-bea4-722a41d12eb8",
+      "matchType": "exact",
+      "reviewDecisionId": "a1ad7b4e-8e58-5f07-976c-8917f3278ef6"
+    },
+    {
+      "legacyGoalId": "1d8afbf7-53ac-5e23-9c55-017759c91883",
+      "canonicalGoalId": "80a61704-a372-5ba3-adb8-340fbde05433",
+      "matchType": "exact",
+      "reviewDecisionId": "1d8afbf7-53ac-5e23-9c55-017759c91883"
+    },
+    {
+      "legacyGoalId": "869296c0-5dd5-5c02-9e9f-bf6fe53420e1",
+      "canonicalGoalId": "89ce2fc2-67ff-587a-b448-227cb68f53e1",
+      "matchType": "exact",
+      "reviewDecisionId": "869296c0-5dd5-5c02-9e9f-bf6fe53420e1"
+    },
+    {
+      "legacyGoalId": "cab06faf-bb5a-5f1e-8a50-6f2430dd6ebc",
+      "canonicalGoalId": "89ce2fc2-67ff-587a-b448-227cb68f53e1",
+      "matchType": "partial",
+      "reviewDecisionId": "cab06faf-bb5a-5f1e-8a50-6f2430dd6ebc"
+    },
+    {
+      "legacyGoalId": "76396e7e-380d-5145-b80a-e07be34b1adb",
+      "canonicalGoalId": "ae3f50bf-33c7-535f-8d13-191ee330c0fa",
+      "matchType": "exact",
+      "reviewDecisionId": "76396e7e-380d-5145-b80a-e07be34b1adb"
+    },
+    {
+      "legacyGoalId": "e1e63025-54b6-51de-ba35-8343f70f6c30",
+      "canonicalGoalId": "25eaa5cf-e8f9-573d-8a53-8ae9d1cd02e2",
+      "matchType": "exact",
+      "reviewDecisionId": "e1e63025-54b6-51de-ba35-8343f70f6c30"
+    },
+    {
+      "legacyGoalId": "aff07640-c257-575c-b4ed-0df8c4e63c42",
+      "canonicalGoalId": "05ff76d0-5850-5984-9855-45e77f06a94e",
+      "matchType": "exact",
+      "reviewDecisionId": "aff07640-c257-575c-b4ed-0df8c4e63c42"
+    },
+    {
+      "legacyGoalId": "e8e2f7a6-c2e2-537e-85aa-cd00aeb61941",
+      "canonicalGoalId": "914fb22b-e19e-5f5e-adfd-eff27bf5f1f5",
+      "matchType": "partial",
+      "reviewDecisionId": "e8e2f7a6-c2e2-537e-85aa-cd00aeb61941"
+    },
+    {
+      "legacyGoalId": "64e79e74-14ce-5d51-8fb4-fbcea8bb1108",
+      "canonicalGoalId": "52d195f7-af13-570a-adc5-0eb27eaab6da",
+      "matchType": "partial",
+      "reviewDecisionId": "64e79e74-14ce-5d51-8fb4-fbcea8bb1108"
+    },
+    {
+      "legacyGoalId": "673d3825-e43d-585c-9ee7-58bb143fd382",
+      "canonicalGoalId": "7c6bf0cc-6ed8-56b1-b44a-642f7a069a5f",
+      "matchType": "partial",
+      "reviewDecisionId": "673d3825-e43d-585c-9ee7-58bb143fd382"
+    },
+    {
+      "legacyGoalId": "ea1d4041-df5d-55e4-8286-3898c3063826",
+      "canonicalGoalId": "91df35c7-e384-50d6-bb3a-37e74a6086f1",
+      "matchType": "exact",
+      "reviewDecisionId": "ea1d4041-df5d-55e4-8286-3898c3063826"
+    },
+    {
+      "legacyGoalId": "b0468d88-9a13-5f8c-ac3b-02c0761dda94",
+      "canonicalGoalId": "e0d04e58-1591-5230-bfa6-5c685b56d25b",
+      "matchType": "partial",
+      "reviewDecisionId": "b0468d88-9a13-5f8c-ac3b-02c0761dda94"
+    },
+    {
+      "legacyGoalId": "b0468d88-9a13-5f8c-ac3b-02c0761dda94",
+      "canonicalGoalId": "fc8c4b02-02f2-5ad6-b481-224d36121da1",
+      "matchType": "partial",
+      "reviewDecisionId": "b0468d88-9a13-5f8c-ac3b-02c0761dda94"
+    },
+    {
+      "legacyGoalId": "caa62aba-fb03-5b28-8df1-d09624168990",
+      "canonicalGoalId": "28850d2e-062d-5341-ac66-bd787a8fc84f",
+      "matchType": "partial",
+      "reviewDecisionId": "caa62aba-fb03-5b28-8df1-d09624168990"
+    },
+    {
+      "legacyGoalId": "d0cf0ae9-8943-5c29-9708-b394592d214c",
+      "canonicalGoalId": "0dbe758c-73c8-530b-bbbd-fb55540f942f",
+      "matchType": "partial",
+      "reviewDecisionId": "d0cf0ae9-8943-5c29-9708-b394592d214c"
+    },
+    {
+      "legacyGoalId": "39e911cd-891b-5aa3-af27-bf5d3053d6ff",
+      "canonicalGoalId": "0d96a802-2a8d-5445-a7fa-02387f6b1f2d",
+      "matchType": "partial",
+      "reviewDecisionId": "39e911cd-891b-5aa3-af27-bf5d3053d6ff"
+    },
+    {
+      "legacyGoalId": "b6e605f6-75ed-590f-8769-72e631f02a0f",
+      "canonicalGoalId": "e6f128c8-b38e-5167-9367-77e079a994c3",
+      "matchType": "partial",
+      "reviewDecisionId": "b6e605f6-75ed-590f-8769-72e631f02a0f"
+    },
+    {
+      "legacyGoalId": "81a64cd9-7f21-59a7-9d2a-f34d2d76c939",
+      "canonicalGoalId": "576d59e2-397a-5654-b853-7c0c4870fbd3",
+      "matchType": "partial",
+      "reviewDecisionId": "81a64cd9-7f21-59a7-9d2a-f34d2d76c939"
+    },
+    {
+      "legacyGoalId": "2cc41e62-ec79-5add-9d43-2499b4e147b2",
+      "canonicalGoalId": "ec782ce3-475e-5628-b3fe-947d72e74a74",
+      "matchType": "partial",
+      "reviewDecisionId": "2cc41e62-ec79-5add-9d43-2499b4e147b2"
+    },
+    {
+      "legacyGoalId": "2cc41e62-ec79-5add-9d43-2499b4e147b2",
+      "canonicalGoalId": "fc89ed54-1a78-55a9-8e54-751d6d46dad6",
+      "matchType": "partial",
+      "reviewDecisionId": "2cc41e62-ec79-5add-9d43-2499b4e147b2"
+    },
+    {
+      "legacyGoalId": "a161e6be-c302-513e-ba6b-ae217ed84a78",
+      "canonicalGoalId": "8e7c6b98-fb1a-5f08-8531-685a4ffba4ad",
+      "matchType": "partial",
+      "reviewDecisionId": "a161e6be-c302-513e-ba6b-ae217ed84a78"
+    },
+    {
+      "legacyGoalId": "7a28147c-b531-563c-845d-b397997c6639",
+      "canonicalGoalId": "9499943f-89b7-54e3-9fe2-e90404beaa4a",
+      "matchType": "partial",
+      "reviewDecisionId": "7a28147c-b531-563c-845d-b397997c6639"
+    },
+    {
+      "legacyGoalId": "ef3a58c6-09b3-5e91-80a0-fb3857268603",
+      "canonicalGoalId": "ffef97e3-12d6-5090-9816-46ab9e57fae2",
+      "matchType": "exact",
+      "reviewDecisionId": "ef3a58c6-09b3-5e91-80a0-fb3857268603"
+    },
+    {
+      "legacyGoalId": "61a685c4-b335-5c2b-a803-60c1c9e2cea6",
+      "canonicalGoalId": "523f7ef4-ed2b-5bda-8fc1-e4c4c94669a0",
+      "matchType": "partial",
+      "reviewDecisionId": "61a685c4-b335-5c2b-a803-60c1c9e2cea6"
+    },
+    {
+      "legacyGoalId": "8509c74f-0657-555e-92f5-b01c7f298eee",
+      "canonicalGoalId": "523f7ef4-ed2b-5bda-8fc1-e4c4c94669a0",
+      "matchType": "partial",
+      "reviewDecisionId": "8509c74f-0657-555e-92f5-b01c7f298eee"
+    },
+    {
+      "legacyGoalId": "550a30ba-48e0-5822-8733-38683473e37e",
+      "canonicalGoalId": "440854be-7f06-5678-91cb-ba8dcab56959",
+      "matchType": "exact",
+      "reviewDecisionId": "550a30ba-48e0-5822-8733-38683473e37e"
+    },
+    {
+      "legacyGoalId": "65529a29-8e40-5c29-ab13-43c5e9d91fe0",
+      "canonicalGoalId": "2706c28e-1c21-50de-8a63-c450f5fe8b07",
+      "matchType": "partial",
+      "reviewDecisionId": "65529a29-8e40-5c29-ab13-43c5e9d91fe0"
+    }
+  ],
+  "decisions": []
+}

--- a/docs/qa-ci/status/curriculum-quality-status.json
+++ b/docs/qa-ci/status/curriculum-quality-status.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "rulesVersion": "curriculum-quality-v1",
-  "generatedAt": "2026-05-12T10:30:49.339Z",
+  "generatedAt": "2026-05-12T11:46:05.495Z",
   "generatedBy": "app/scripts/generateCurriculumQualityStatus.ts",
   "sources": {
     "canonicalRoot": "curricula/DE/Gymnasium/canonical",
@@ -25,10 +25,10 @@
       "M5": 3
     },
     "ruleStatus": {
-      "pass": 100,
+      "pass": 101,
       "warn": 17,
       "fail": 19,
-      "not_configured": 71
+      "not_configured": 70
     }
   },
   "ruleCatalog": [
@@ -153,17 +153,17 @@
         "unsupportedAssignedAtomicGoals": 0,
         "surrogateBackedAtomicGoals": 0,
         "partialSourceLinkedAtomicGoals": 0,
-        "sourceAtomicGoals": 603,
-        "sourceMappedToViewAtomicGoals": 547,
-        "unmappedSourceAtomicGoals": 56,
-        "sourceExtractedGoals": 0,
+        "sourceAtomicGoals": 462,
+        "sourceMappedToViewAtomicGoals": 184,
+        "unmappedSourceAtomicGoals": 278,
+        "sourceExtractedGoals": 222,
         "sourceUnregisteredGoals": 0,
-        "sourceExtractedAtomicGoals": 0,
+        "sourceExtractedAtomicGoals": 222,
         "sourceUnregisteredAtomicGoals": 0,
-        "sourceOriginalGoals": 694,
-        "sourceFullyCoveredOriginalGoals": 620,
+        "sourceOriginalGoals": 515,
+        "sourceFullyCoveredOriginalGoals": 219,
         "sourcePartiallyCoveredOriginalGoals": 3,
-        "sourceUncoveredOriginalGoals": 71,
+        "sourceUncoveredOriginalGoals": 293,
         "jurisdictions": [
           {
             "jurisdiction": "DE-BW",
@@ -239,23 +239,23 @@
             "surrogateBackedAtomicGoals": 0,
             "unsupportedAssignedAtomicGoals": 0,
             "partialSourceLinkedAtomicGoals": 0,
-            "sourceAtomicGoals": 363,
-            "sourceMappedToViewAtomicGoals": 363,
-            "unmappedSourceAtomicGoals": 0,
-            "sourceExtractedGoals": 0,
+            "sourceAtomicGoals": 222,
+            "sourceMappedToViewAtomicGoals": 0,
+            "unmappedSourceAtomicGoals": 222,
+            "sourceExtractedGoals": 222,
             "sourceUnregisteredGoals": 0,
-            "sourceExtractedAtomicGoals": 0,
+            "sourceExtractedAtomicGoals": 222,
             "sourceUnregisteredAtomicGoals": 0,
-            "sourceOriginalGoals": 401,
-            "sourceFullyCoveredOriginalGoals": 401,
+            "sourceOriginalGoals": 222,
+            "sourceFullyCoveredOriginalGoals": 0,
             "sourcePartiallyCoveredOriginalGoals": 0,
-            "sourceUncoveredOriginalGoals": 0,
+            "sourceUncoveredOriginalGoals": 222,
             "errors": 0,
             "warnings": 0,
             "diagnosticPartialOnlyWarnings": 0,
             "atomicCoveragePercent": 100,
             "sourceBackedCoveragePercent": 100,
-            "sourceReverseCoveragePercent": 100,
+            "sourceReverseCoveragePercent": 0,
             "status": "error"
           },
           {
@@ -666,67 +666,157 @@
       "mappingPipeline": {
         "totalSources": 3,
         "completeSources": 0,
-        "incompleteSources": 0,
-        "blockedSources": 3,
-        "maxCompletedSteps": 0,
+        "incompleteSources": 1,
+        "blockedSources": 2,
+        "maxCompletedSteps": 2,
         "totalSteps": 3,
-        "currentStep": "MAPPING-1",
+        "currentStep": "MAPPING-3",
         "sources": [
           {
             "sourceLandscapeId": "357a7003-b636-570e-a0bd-6bb63518d2f6",
-            "title": "Biologie (Gymnasium)",
+            "title": "DE-BY - Biologie Gymnasium (Bayern, LehrplanPLUS Source-Extraction)",
             "jurisdiction": "DE-BY",
-            "path": "curricula/DE/Gymnasium/mapping/DE-BY/gymnasium/bavaria_biology_to_canonical_biology.json",
-            "sourceKind": "missing-extraction",
-            "currentStep": "MAPPING-1",
-            "completedSteps": 0,
+            "subject": "Biologie",
+            "stage": "SekI+SekII",
+            "path": "curricula/DE/Gymnasium/input/BY/gymnasium/source-extraction/DE_BY_BIOLOGIE_GYMNASIUM_LEHRPLANPLUS.source-extraction.json",
+            "sourceKind": "source-extraction",
+            "sourceDocuments": [
+              {
+                "key": "LEHRPLANPLUS_BIOLOGIE_GYMNASIUM",
+                "title": "LehrplanPLUS Gymnasium Bayern - Biologie",
+                "path": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json",
+                "official": true,
+                "available": true
+              }
+            ],
+            "currentStep": "MAPPING-3",
+            "completedSteps": 2,
             "totalSteps": 3,
-            "sourceGoals": 0,
-            "passages": 0,
+            "sourceGoals": 222,
+            "passages": 32,
+            "mappedSourceGoals": 62,
+            "unmappedSourceGoals": 160,
+            "extraMappedGoals": 0,
+            "exactMappings": 42,
+            "partialMappings": 20,
+            "otherMappings": 0,
+            "sourceGoalCountPeerBaselineReview": {
+              "accepted": true,
+              "details": "Identische Kompetenzformulierungen aus parallelen GA/EA-Profilen wurden auf 222 repraesentative Source-Ziele normalisiert; 32 Originalpassagen und 362 Fundstellen bleiben ueber sourceOccurrences erhalten."
+            },
+            "sourceGoalGranularity": {
+              "averageWords": 21.382882882882882,
+              "p90Words": 32,
+              "maxWords": 43,
+              "longGoals": 0,
+              "longGoalThreshold": 45,
+              "examples": []
+            },
             "steps": [
               {
                 "id": "MAPPING-1",
                 "label": "Original-Lehrplanpassagen extrahiert",
-                "status": "incomplete",
+                "status": "complete",
                 "dependsOn": [],
                 "checks": [
                   {
-                    "id": "source-extraction-file-present",
-                    "label": "Persistiertes Source-Extraction-Artefakt vorhanden",
-                    "passed": false,
-                    "details": "Für diese Source-Landschaft ist noch keine geprüfte source-extraction-Datei registriert."
+                    "id": "source-document-present",
+                    "label": "Strukturierte LehrplanPLUS-Biologie-Quelle liegt lokal vor",
+                    "passed": true,
+                    "details": "curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json"
+                  },
+                  {
+                    "id": "topic-passages-extracted",
+                    "label": "Alle zieltragenden LehrplanPLUS-Biologie-Lernbereiche sind als Passagen extrahiert",
+                    "passed": true,
+                    "details": "Erfasst: 32/32 Passagen."
+                  },
+                  {
+                    "id": "no-legacy-snapshot-counted",
+                    "label": "Kein alter Pilot-Quellsnapshot wird als Passage-Extraction gewertet",
+                    "passed": true,
+                    "details": "Verwendet wird curricula/DE/Gymnasium/input/BY/gymnasium/Biologie.json als strukturierte LehrplanPLUS-Quelle; alte Mappingdateien werden nur als M3-Seed verwendet."
                   }
                 ]
               },
               {
                 "id": "MAPPING-2",
                 "label": "Source-Ziele aus Lehrplanpassagen erstellt",
-                "status": "blocked",
+                "status": "complete",
                 "dependsOn": [
                   "MAPPING-1"
                 ],
                 "checks": [
                   {
-                    "id": "mapping-1-complete",
-                    "label": "MAPPING-1 abgeschlossen",
-                    "passed": false,
-                    "details": "Source-Ziele dürfen erst nach vollständig extrahierten Originalpassagen als abgeschlossen gelten."
+                    "id": "source-goals-created",
+                    "label": "Aus den LehrplanPLUS-Kompetenzerwartungen wurden Source-Ziele erzeugt",
+                    "passed": true,
+                    "details": "222/362 normalisierte Source-Ziele"
+                  },
+                  {
+                    "id": "source-goal-ids-unique",
+                    "label": "Source-Ziel-IDs sind eindeutig",
+                    "passed": true,
+                    "details": "Doppelte IDs: -"
+                  },
+                  {
+                    "id": "source-goals-reference-passages",
+                    "label": "Jedes Source-Ziel referenziert eine vorhandene Originalpassage",
+                    "passed": true,
+                    "details": "Ohne Passage: -"
+                  },
+                  {
+                    "id": "source-goal-text-present",
+                    "label": "Jedes Source-Ziel enthält den LehrplanPLUS-Originaltext",
+                    "passed": true,
+                    "details": "Ohne Text: -"
                   }
                 ]
               },
               {
                 "id": "MAPPING-3",
                 "label": "Source-Ziele auf SkillPilot-Ziele gemappt",
-                "status": "blocked",
+                "status": "incomplete",
                 "dependsOn": [
+                  "MAPPING-1",
                   "MAPPING-2"
                 ],
                 "checks": [
                   {
                     "id": "mapping-2-complete",
                     "label": "MAPPING-2 abgeschlossen",
+                    "passed": true,
+                    "details": "222 Source-Ziele liegen vor; MAPPING-3 kann gegen diese Source-Extraction-IDs laufen."
+                  },
+                  {
+                    "id": "m3-review-file-present",
+                    "label": "M3-Review-Datei ist vorhanden",
+                    "passed": true,
+                    "details": "Review-Datei mit sourceExtractionPath fuer diese Source-Extraction ist vorhanden."
+                  },
+                  {
+                    "id": "m3-review-decisions-reference-source-goals",
+                    "label": "M3-Review-Entscheidungen referenzieren gültige Source-Ziele",
+                    "passed": true,
+                    "details": "Review-Entscheidungen mit unbekannter Source-ID: 0."
+                  },
+                  {
+                    "id": "m3-review-targets-exist",
+                    "label": "M3-Review-Ziele referenzieren vorhandene Canonical-Ziele",
+                    "passed": true,
+                    "details": "Unbekannte Canonical-Ziele in Mappings: 0."
+                  },
+                  {
+                    "id": "m3-all-source-goals-reviewed",
+                    "label": "Alle Source-Ziele haben eine fachliche M3-Entscheidung",
                     "passed": false,
-                    "details": "Das Mapping auf SkillPilot-Ziele darf erst nach geprüften Source-Zielen als abgeschlossen gelten."
+                    "details": "0/222 Source-Ziele reviewed; offen: 222."
+                  },
+                  {
+                    "id": "m3-all-source-goals-covered-by-canonical",
+                    "label": "Alle Source-Ziele sind durch SkillPilot-Ziele abgedeckt",
+                    "passed": false,
+                    "details": "Fachlich abgedeckt: 0/222; Mappings: 62/222; verbleibend: 0 explizite Canonical-Gaps, 222 unreviewed."
                   }
                 ]
               }
@@ -876,21 +966,20 @@
         {
           "id": "CQR-000",
           "status": "fail",
-          "summary": "0/16 declared Bundesland source inventories are readable and fully registered.",
+          "summary": "1/16 declared Bundesland source inventories are readable and fully registered.",
           "metrics": {
             "totalJurisdictions": 16,
-            "completeSourceJurisdictions": 0,
+            "completeSourceJurisdictions": 1,
             "emptySourceJurisdictions": 14,
-            "missingReadableSourceInventoryJurisdictions": 2,
-            "sourceExtractedGoals": 0,
-            "sourceOriginalGoals": 694,
+            "missingReadableSourceInventoryJurisdictions": 1,
+            "sourceExtractedGoals": 222,
+            "sourceOriginalGoals": 515,
             "sourceUnregisteredGoals": 0,
-            "sourceExtractedAtomicGoals": 0,
+            "sourceExtractedAtomicGoals": 222,
             "sourceUnregisteredAtomicGoals": 0
           },
           "details": [
             "DE-HE: 293 source original goal(s) are registered, but no readable source inventory goals were extracted",
-            "DE-BY: 401 source original goal(s) are registered, but no readable source inventory goals were extracted",
             "DE-BW: no source inventory goals are registered or extracted",
             "DE-BB: no source inventory goals are registered or extracted",
             "DE-BE: no source inventory goals are registered or extracted",
@@ -920,15 +1009,15 @@
             "uncoveredJurisdictions": 14,
             "incompleteJurisdictions": 0,
             "unsupportedAssignmentJurisdictions": 0,
-            "sourceUnmappedJurisdictions": 1,
+            "sourceUnmappedJurisdictions": 2,
             "unsupportedAssignedAtomicGoals": 0,
-            "unmappedSourceAtomicGoals": 56,
-            "sourceAtomicGoals": 603,
-            "sourceMappedToViewAtomicGoals": 547,
-            "sourceOriginalGoals": 694,
-            "sourceFullyCoveredOriginalGoals": 620,
+            "unmappedSourceAtomicGoals": 278,
+            "sourceAtomicGoals": 462,
+            "sourceMappedToViewAtomicGoals": 184,
+            "sourceOriginalGoals": 515,
+            "sourceFullyCoveredOriginalGoals": 219,
             "sourcePartiallyCoveredOriginalGoals": 3,
-            "sourceUncoveredOriginalGoals": 71,
+            "sourceUncoveredOriginalGoals": 293,
             "surrogateBackedAtomicGoals": 0,
             "partialSourceLinkedAtomicGoals": 0,
             "warningedJurisdictions": 0,
@@ -942,6 +1031,7 @@
           },
           "details": [
             "DE-HE: 56 source Lehrplan atom(s) do not map into the Bundesland view",
+            "DE-BY: 222 source Lehrplan atom(s) do not map into the Bundesland view",
             "DE-BW: no source-backed atomic goals",
             "DE-BB: no source-backed atomic goals",
             "DE-BE: no source-backed atomic goals",
@@ -960,8 +1050,23 @@
         },
         {
           "id": "CQR-004",
-          "status": "not_configured",
-          "summary": "No persisted source-extraction mapping with GK/LK course-level metadata is configured for this curriculum."
+          "status": "pass",
+          "summary": "Course-level mapping is clean for 0 upper-secondary source-to-canonical mapping edge(s), including 0 reviewed course-level exception(s); unspecified upper-secondary source goals default to GK/LK unless explicitly reviewed.",
+          "metrics": {
+            "configuredMappingFiles": 1,
+            "sourceGoals": 0,
+            "sourceGoalsWithCourseLevel": 0,
+            "gkLkSourceGoals": 0,
+            "lkSourceGoals": 0,
+            "unspecifiedSourceGoals": 0,
+            "checkedMappingEdges": 0,
+            "defaultedUnspecifiedMappingEdges": 0,
+            "reviewedCourseLevelExceptions": 0,
+            "mismatches": 0,
+            "missingSourceGoals": 0,
+            "missingTargetGoals": 0,
+            "unmappedCourseLevelSourceGoals": 0
+          }
         },
         {
           "id": "CQR-301",

--- a/docs/qa-ci/status/curriculum-quality-status.md
+++ b/docs/qa-ci/status/curriculum-quality-status.md
@@ -1,6 +1,6 @@
 # Curriculum Quality Status
 
-Generated: 2026-05-12T10:30:49.339Z
+Generated: 2026-05-12T11:46:05.495Z
 Rules version: curriculum-quality-v1
 
 ## Summary
@@ -19,7 +19,7 @@ Rules version: curriculum-quality-v1
 
 | Curriculum | Maturity | Goals | Atomic | Passage extraction | Bundeslaender | QA scopes | Warn | Fail |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Biologie (Gymnasium, DE) | M0 | 216 | 182 | 0/3 | 0/16 | 0 | 0 | 2 |
+| Biologie (Gymnasium, DE) | M0 | 216 | 182 | 1/3 | 0/16 | 0 | 0 | 2 |
 | Chemie (Gymnasium, DE) | M5 | 467 | 399 | 32/32 | 16/16 | 1 | 0 | 0 |
 | Chinesisch (Gymnasium, DE) | M0 | 192 | 181 | 0/2 | 0/16 | 0 | 1 | 1 |
 | Deutsch (Gymnasium, DE) | M0 | 181 | 144 | 0/2 | 0/16 | 0 | 1 | 1 |
@@ -45,7 +45,7 @@ Rules version: curriculum-quality-v1
 
 | Curriculum | Source | Jurisdiction | Original sources | Complete | Current step | Passages | Source goals | Exact | Partial | Exact share | Evidence note |
 | --- | --- | --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | --- |
-| Biologie (Gymnasium, DE) | Biologie (Gymnasium) | DE-BY | No extraction | 0/3 | MAPPING-1 | 0 | 0 | 0 | 0 | 0% |  |
+| Biologie (Gymnasium, DE) | DE-BY - Biologie Gymnasium (Bayern, LehrplanPLUS Source-Extraction) | DE-BY | 1/1 original source(s) | 2/3 | MAPPING-3 | 32 | 222 | 42 | 20 | 68% |  |
 | Biologie (Gymnasium, DE) | Biologie Oberstufe (Hessen, KC 2024) | DE-HE | No extraction | 0/3 | MAPPING-1 | 0 | 0 | 0 | 0 | 0% |  |
 | Biologie (Gymnasium, DE) | Biologie Sekundarstufe I (Hessen, G9) | DE-HE | No extraction | 0/3 | MAPPING-1 | 0 | 0 | 0 | 0 | 0% |  |
 | Chemie (Gymnasium, DE) | DE-BB - Chemie Oberstufe (Brandenburg, RLP GOST 2022 Source-Extraction) | DE-BB | 1/1 original source(s) | 3/3 | - | 23 | 203 | 100 | 103 | 49% |  |
@@ -170,7 +170,7 @@ Rules version: curriculum-quality-v1
 
 | Curriculum | Complete | DE view atoms | Raw atoms | Source-backed states | Extracted source goals | Registered source originals | Fully covered originals | Unregistered source goals | Extracted source atoms | Unregistered source atoms | Unsupported assignments | Unmapped source atoms | Partial | Error | Max source-backed view coverage |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Biologie (Gymnasium, DE) | 0/16 | 160 | 182 | 2 | 0 | 694 | 620 | 0 | 0 | 0 | 0 | 56 | 0 | 2 | 160 (100%) |
+| Biologie (Gymnasium, DE) | 0/16 | 160 | 182 | 2 | 222 | 515 | 219 | 0 | 222 | 0 | 0 | 278 | 0 | 2 | 160 (100%) |
 | Chemie (Gymnasium, DE) | 16/16 | 336 | 399 | 16 | 5865 | 5865 | 5865 | 0 | 5865 | 0 | 0 | 0 | 0 | 0 | 334 (100%) |
 | Chinesisch (Gymnasium, DE) | 0/16 | 170 | 181 | 2 | 0 | 436 | 436 | 0 | 0 | 0 | 0 | 0 | 0 | 2 | 170 (100%) |
 | Deutsch (Gymnasium, DE) | 0/16 | 127 | 144 | 2 | 0 | 650 | 650 | 0 | 0 | 0 | 0 | 0 | 0 | 2 | 127 (100%) |


### PR DESCRIPTION
## Summary

Adds a source-extraction artifact for the Bavaria Gymnasium Biologie LehrplanPLUS source and registers a corresponding incomplete MAPPING-3 review scaffold against the canonical Biology curriculum.

## Impact

- Advances the Biologie mapping pipeline for DE-BY from MAPPING-1 to MAPPING-3.
- Records 32 extracted LehrplanPLUS passages and 222 deduplicated source goals, preserving 362 original occurrences through `sourceOccurrences`.
- Updates the curriculum quality status so the dashboard shows Biologie at 1/3 passage extraction and keeps MAPPING-3 / CQR-003 visibly open.

## Validation

- `npm --prefix app run quality:curriculum-status`
- `npm --prefix app run validate:graph`
- `npm --prefix app run validate:composition-views`
- `npm --prefix app run quality:source-coverage-audit`
- `npm --prefix app run lint`
- `./run_ci.sh`