### PR TITLE
[codex] Fix learner scope marker projection

### DIFF
--- a/app/scripts/validateLearnerGoalSelection.ts
+++ b/app/scripts/validateLearnerGoalSelection.ts
@@ -8,7 +8,11 @@ import {
 } from '../src/utils/compositionViewRuntime'
 import { normalizeLearnerProjectedEntries } from '../src/utils/learnerTreeProjection'
 import { buildDirectChildrenMap } from '../src/utils/treeProjectionRuntime'
-import { buildGoalContainsClosure, buildRenderedScopeDescendantCountMap } from '../src/utils/plannedScope'
+import {
+  buildGoalContainsClosure,
+  buildRenderedScopeDescendantCountMap,
+  buildRenderedScopeMarkerGoalIds,
+} from '../src/utils/plannedScope'
 import {
   ABI26_MATH_LANDSCAPE_ID,
   ABI26_ROOT_CURRICULUM_ID,
@@ -249,6 +253,11 @@ const bavariaScopeDescendantCounts = buildRenderedScopeDescendantCountMap(
   bavariaMathChildrenByParent,
   bavariaPlannedJ8ScopeGoalIds,
 )
+const bavariaScopeMarkerGoalIds = buildRenderedScopeMarkerGoalIds(
+  bavariaMathGoalById,
+  bavariaMathChildrenByParent,
+  bavariaPlannedJ8ScopeGoalIds,
+)
 
 assert.ok(
   bavariaPlannedJ8ScopeGoalIds.has(canonicalMathJ8AxisInterceptGoalId),
@@ -261,6 +270,15 @@ assert.ok(
 assert.ok(
   (bavariaScopeDescendantCounts.get(bavariaVisibleJ8StructureId) ?? 0) > 0,
   'A hidden canonical J8 planned scope must mark the visible Bavaria GK Jahrgangsstufe 8 structure.',
+)
+assert.deepStrictEqual(
+  Array.from(bavariaScopeMarkerGoalIds),
+  [bavariaVisibleJ8StructureId],
+  'A hidden canonical J8 planned scope must produce exactly one visible scope marker on Jahrgangsstufe 8.',
+)
+assert.ok(
+  !bavariaScopeMarkerGoalIds.has(canonicalMathJ8AxisInterceptGoalId),
+  'A hidden canonical J8 planned scope must not mark every scoped descendant as a separate planned goal.',
 )
 
 console.log('✅ Learner goal selection regression checks passed.')

--- a/app/src/components/CompetenceTree.tsx
+++ b/app/src/components/CompetenceTree.tsx
@@ -10,7 +10,11 @@ import { isWildcardFilter } from '../utils/goalFilters'
 import { isCourseProfileFilterId } from '../utils/personalCurriculumStageScope'
 import { formatFilterDisplayLabel, formatJurisdictionScopedTitle, type LabelLanguage } from '../utils/filterLabels'
 import { normalizeJurisdictionCode } from '../utils/jurisdictionMetadata'
-import { buildGoalContainsClosure, buildRenderedScopeDescendantCountMap } from '../utils/plannedScope'
+import {
+  buildGoalContainsClosure,
+  buildRenderedScopeDescendantCountMap,
+  buildRenderedScopeMarkerGoalIds,
+} from '../utils/plannedScope'
 import {
   buildVisibleChildrenMap,
   getAudienceGoalTitle,
@@ -108,6 +112,7 @@ interface TreeNodeProps {
   plannedGoals: Set<string>
   plannedScopeGoalIds: Set<string>
   plannedScopeDescendantCounts: Map<string, number>
+  plannedScopeMarkerGoalIds: Set<string>
   onTogglePlan: (id: string) => void
   readOnly?: boolean
   onSelect: (id: string) => void
@@ -154,6 +159,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   plannedGoals,
   plannedScopeGoalIds,
   plannedScopeDescendantCounts,
+  plannedScopeMarkerGoalIds,
   onTogglePlan,
   readOnly = false,
   onSelect,
@@ -238,7 +244,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   // still mark their visible descendants through plannedScopeGoalIds.
   const selfInSubtree = isInPlannedSubtree || isPlanned || isInPlannedScope
   const targetIconClassName =
-    hasActivePlan && selfInSubtree ? 'text-red-500 dark:text-red-400' : undefined
+    hasActivePlan && isPlanned ? 'text-red-500 dark:text-red-400' : undefined
 
   // Active Plan Strategy:
   const plannedCount = aggregatedPlannedGoals?.get(goal.id) ?? plannedScopeDescendantCounts.get(goal.id) ?? 0
@@ -246,7 +252,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   const isDimmed = hasActivePlan && !selfInSubtree && !hasPlannedGoalInRenderedSubtree
 
   const showDescendantPlanMarker =
-    !aggregatedPlannedGoals && !isPlanned && hasPlannedGoalInRenderedSubtree
+    !aggregatedPlannedGoals && !isPlanned && plannedScopeMarkerGoalIds.has(goal.id)
 
   const personalFilterId = (goal.landscapeId ? personalConfig?.[goal.landscapeId]?.filterId : undefined)
     ?? personalConfig?.[goal.id]?.filterId
@@ -427,6 +433,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                 plannedGoals={plannedGoals}
                 plannedScopeGoalIds={plannedScopeGoalIds}
                 plannedScopeDescendantCounts={plannedScopeDescendantCounts}
+                plannedScopeMarkerGoalIds={plannedScopeMarkerGoalIds}
                 onTogglePlan={onTogglePlan}
                 readOnly={readOnly}
                 onSelect={onSelect}
@@ -529,6 +536,10 @@ export const CompetenceTree: React.FC<CompetenceTreeProps> = ({
     () => buildRenderedScopeDescendantCountMap(props.allGoals, sortedChildrenByParent, plannedScopeGoalIds),
     [props.allGoals, plannedScopeGoalIds, sortedChildrenByParent],
   )
+  const plannedScopeMarkerGoalIds = React.useMemo(
+    () => buildRenderedScopeMarkerGoalIds(props.allGoals, sortedChildrenByParent, plannedScopeGoalIds),
+    [props.allGoals, plannedScopeGoalIds, sortedChildrenByParent],
+  )
 
   return (
     <div className="flex flex-col gap-1 overflow-y-auto max-h-full pr-2">
@@ -541,6 +552,7 @@ export const CompetenceTree: React.FC<CompetenceTreeProps> = ({
           masteryByGoalId={masteryByGoalId}
           plannedScopeGoalIds={plannedScopeGoalIds}
           plannedScopeDescendantCounts={plannedScopeDescendantCounts}
+          plannedScopeMarkerGoalIds={plannedScopeMarkerGoalIds}
           activeFilter={activeFilter}
           structureMode={structureMode}
           hideTechnicalStructureUi={hideTechnicalStructureUi}

--- a/app/src/utils/plannedScope.ts
+++ b/app/src/utils/plannedScope.ts
@@ -1,4 +1,5 @@
 import type { UiGoal } from '../goalTypes'
+import { isSyntheticProgramUnit } from './treeProjectionRuntime'
 
 export const buildGoalContainsClosure = (
   rootGoalIds: Iterable<string>,
@@ -53,4 +54,68 @@ export const buildRenderedScopeDescendantCountMap = (
   })
 
   return countsByGoalId
+}
+
+export const buildRenderedScopeMarkerGoalIds = (
+  allGoals: Map<string, UiGoal>,
+  renderedChildrenByParent: Map<string, string[]>,
+  scopedGoalIds: Set<string>,
+) => {
+  const statsByGoalId = new Map<string, { scopedConcrete: number; unscopedConcrete: number }>()
+  const parentIdsByChild = new Map<string, Set<string>>()
+  const visiting = new Set<string>()
+
+  renderedChildrenByParent.forEach((childIds, parentId) => {
+    childIds.forEach((childId) => {
+      const parentIds = parentIdsByChild.get(childId) ?? new Set<string>()
+      parentIds.add(parentId)
+      parentIdsByChild.set(childId, parentIds)
+    })
+  })
+
+  const compute = (goalId: string): { scopedConcrete: number; unscopedConcrete: number } => {
+    const cached = statsByGoalId.get(goalId)
+    if (cached) return cached
+    if (visiting.has(goalId)) return { scopedConcrete: 0, unscopedConcrete: 0 }
+
+    visiting.add(goalId)
+    const goal = allGoals.get(goalId)
+    const isSynthetic = !!goal && isSyntheticProgramUnit(goal)
+    const isScoped = scopedGoalIds.has(goalId)
+    const stats = {
+      scopedConcrete: goal && !isSynthetic && isScoped ? 1 : 0,
+      unscopedConcrete: goal && !isSynthetic && !isScoped ? 1 : 0,
+    }
+
+    renderedChildrenByParent.get(goalId)?.forEach((childId) => {
+      const childStats = compute(childId)
+      stats.scopedConcrete += childStats.scopedConcrete
+      stats.unscopedConcrete += childStats.unscopedConcrete
+    })
+
+    visiting.delete(goalId)
+    statsByGoalId.set(goalId, stats)
+    return stats
+  }
+
+  const isFullyCoveredScopeRepresentative = (goalId: string) => {
+    const stats = compute(goalId)
+    return stats.scopedConcrete > 0 && stats.unscopedConcrete === 0
+  }
+
+  const markerGoalIds = new Set<string>()
+  allGoals.forEach((_, goalId) => {
+    if (scopedGoalIds.has(goalId)) return
+    if (!isFullyCoveredScopeRepresentative(goalId)) return
+
+    const parentIds = parentIdsByChild.get(goalId) ?? new Set<string>()
+    const hasFullyCoveredParent = Array.from(parentIds).some((parentId) =>
+      isFullyCoveredScopeRepresentative(parentId),
+    )
+    if (!hasFullyCoveredParent) {
+      markerGoalIds.add(goalId)
+    }
+  })
+
+  return markerGoalIds
 }


### PR DESCRIPTION
## What changed

- Adds a rendered-scope marker projection that chooses the smallest visible fully covered scope node.
- Uses exact planned goal IDs for target-icon highlighting, so descendants no longer inherit red X markers.
- Adds a Bavaria math GK Jahrgangsstufe 8 regression assertion for the visible composition node.

## Why

When the GPT set the learner scope to Jahrgangsstufe 8, the cockpit marked every visible descendant with a red X. The scope itself is stored on a canonical hidden goal, so the UI needs to project that stored scope to one visible representative node instead of marking the whole rendered subtree.

## Validation

- npm --prefix app run validate:learner-goal-selection
- npm exec -- tsc -b (from app/)
- npm --prefix app run lint
- npm --prefix app run build
- git diff --check